### PR TITLE
feature/cache lock

### DIFF
--- a/src/cache/contracts/cache.contract.ts
+++ b/src/cache/contracts/cache.contract.ts
@@ -85,6 +85,17 @@ export type IReadableCache<TType = unknown> = {
 };
 
 /**
+ * IMPORT_PATH: `"@daiso-tech/core/cache/contracts"`
+ * @group Contracts
+ */
+export type GetOrAddSettings = CacheWriteSettings & {
+    /**
+     * @default false
+     */
+    enableLocking?: boolean;
+};
+
+/**
  * The `ICacheBase` contract defines a way for storing and reading as key-value pairs independent of data storage.
  *
  * IMPORT_PATH: `"@daiso-tech/core/cache/contracts"`
@@ -105,7 +116,7 @@ export type ICacheBase<TType = unknown> = IReadableCache<TType> & {
     getOrAdd(
         key: string,
         valueToAdd: AsyncLazyable<NoneFunc<TType>>,
-        settings?: CacheWriteSettings,
+        settings?: GetOrAddSettings,
     ): Promise<TType>;
 
     /**

--- a/src/cache/implementations/derivables/cache/cache.ts
+++ b/src/cache/implementations/derivables/cache/cache.ts
@@ -96,6 +96,8 @@ export type CacheSettingsBase<TType = unknown> = {
     defaultJitter?: number | null;
 
     /**
+     * You can pass the `waitUntil` function to handle background promises.
+     * This is required when working with environments like Cloudflare Workers or Vercel Functions to ensure tasks complete after the response is sent.
      * @default
      * ```ts
      * import { defaultWaitUntil } from "@daiso-tech/core/utilities"
@@ -114,6 +116,15 @@ export type CacheSettingsBase<TType = unknown> = {
      */
     executionContext?: IExecutionContext;
 
+    /**
+     * You can provide an `ILockFactoryBase` instance to handle locking when `GetOrAddSettings.enableLocking` is set to true during a `getOrAdd` call.
+     * @default
+     * ```ts
+     * lockFactory = new LockFactory({
+     *   adapter: new NoOpLockAdapter(),
+     * })
+     * ```
+     */
     lockFactory?: ILockFactoryBase;
 };
 

--- a/src/cache/implementations/derivables/cache/cache.ts
+++ b/src/cache/implementations/derivables/cache/cache.ts
@@ -15,6 +15,7 @@ import {
     KeyExistsCacheError,
     type CacheWriteSettings,
     type ICacheListenable,
+    type GetOrAddSettings,
 } from "@/cache/contracts/_module.js";
 import { type CacheAdapterVariants } from "@/cache/contracts/types.js";
 import { resolveCacheAdapter } from "@/cache/implementations/derivables/cache/resolve-cache-adapter.js";
@@ -24,6 +25,9 @@ import { EventBus } from "@/event-bus/implementations/derivables/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
+import { type ILockFactoryBase } from "@/lock/contracts/_module.js";
+import { NoOpLockAdapter } from "@/lock/implementations/adapters/_module.js";
+import { LockFactory } from "@/lock/implementations/derivables/_module-exports.js";
 import { type INamespace } from "@/namespace/contracts/_module.js";
 import { NoOpNamespace } from "@/namespace/implementations/_module.js";
 import { type ITimeSpan } from "@/time-span/contracts/_module.js";
@@ -109,6 +113,8 @@ export type CacheSettingsBase<TType = unknown> = {
      * ```
      */
     executionContext?: IExecutionContext;
+
+    lockFactory?: ILockFactoryBase;
 };
 
 /**
@@ -133,6 +139,7 @@ export class Cache<TType = unknown> implements ICache<TType> {
     private readonly defaultJitter: number | null;
     private readonly waitUntil: WaitUntil;
     private readonly executionContext: IExecutionContext;
+    private readonly lockFactory: ILockFactoryBase;
 
     /**
      *
@@ -178,8 +185,12 @@ export class Cache<TType = unknown> implements ICache<TType> {
             executionContext = new ExecutionContext(
                 new NoOpExecutionContextAdapter(),
             ),
+            lockFactory = new LockFactory({
+                adapter: new NoOpLockAdapter(),
+            }),
         } = settings;
 
+        this.lockFactory = lockFactory;
         this.executionContext = executionContext;
         this.waitUntil = waitUntil;
         this.shouldValidateOutput = shouldValidateOutput;
@@ -309,10 +320,10 @@ export class Cache<TType = unknown> implements ICache<TType> {
         return value;
     }
 
-    async getOrAdd(
+    private async _getOrAdd(
         key: string,
         valueToAdd: AsyncLazyable<NoneFunc<TType>>,
-        settings?: CacheWriteSettings,
+        settings?: GetOrAddSettings,
     ): Promise<TType> {
         const ttl = this.resolveCacheWriteSettings(settings);
         const keyObj = this.namespace.create(key);
@@ -354,6 +365,21 @@ export class Cache<TType = unknown> implements ICache<TType> {
         }
 
         return value;
+    }
+
+    async getOrAdd(
+        key: string,
+        valueToAdd: AsyncLazyable<NoneFunc<TType>>,
+        settings?: GetOrAddSettings,
+    ): Promise<TType> {
+        const enableLocking = settings?.enableLocking ?? false;
+
+        if (enableLocking) {
+            return await this.lockFactory.create(key).runOrFail(async () => {
+                return await this._getOrAdd(key, valueToAdd, settings);
+            });
+        }
+        return await this._getOrAdd(key, valueToAdd, settings);
     }
 
     private resolveCacheWriteSettings(

--- a/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker-factory.ts
+++ b/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker-factory.ts
@@ -121,6 +121,8 @@ export type CircuitBreakerFactorySettingsBase = {
     serdeTransformerName?: string;
 
     /**
+     * You can pass the `waitUntil` function to handle background promises.
+     * This is required when working with environments like Cloudflare Workers or Vercel Functions to ensure tasks complete after the response is sent.
      * @default
      * ```ts
      * import { defaultWaitUntil } from "@daiso-tech/core/utilities"

--- a/src/file-storage/implementations/derivables/file-storage/file-storage.ts
+++ b/src/file-storage/implementations/derivables/file-storage/file-storage.ts
@@ -164,6 +164,8 @@ export type FileStorageSettingsBase = {
     serdeTransformerName?: string;
 
     /**
+     * You can pass the `waitUntil` function to handle background promises.
+     * This is required when working with environments like Cloudflare Workers or Vercel Functions to ensure tasks complete after the response is sent.
      * @default
      * ```ts
      * import { defaultWaitUntil } from "@daiso-tech/core/utilities"

--- a/src/lock/implementations/derivables/lock-factory/lock-factory.ts
+++ b/src/lock/implementations/derivables/lock-factory/lock-factory.ts
@@ -119,6 +119,8 @@ export type LockFactorySettingsBase = {
     defaultRefreshTime?: ITimeSpan;
 
     /**
+     * You can pass the `waitUntil` function to handle background promises.
+     * This is required when working with environments like Cloudflare Workers or Vercel Functions to ensure tasks complete after the response is sent.
      * @default
      * ```ts
      * import { defaultWaitUntil } from "@daiso-tech/core/utilities"

--- a/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter-factory.ts
+++ b/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter-factory.ts
@@ -100,6 +100,8 @@ export type RateLimiterFactorySettingsBase = {
     serdeTransformerName?: string;
 
     /**
+     * You can pass the `waitUntil` function to handle background promises.
+     * This is required when working with environments like Cloudflare Workers or Vercel Functions to ensure tasks complete after the response is sent.
      * @default
      * ```ts
      * import { defaultWaitUntil } from "@daiso-tech/core/utilities"

--- a/src/semaphore/implementations/derivables/semaphore-factory/semaphore-factory.ts
+++ b/src/semaphore/implementations/derivables/semaphore-factory/semaphore-factory.ts
@@ -119,6 +119,8 @@ export type SemaphoreFactorySettingsBase = {
     defaultRefreshTime?: ITimeSpan;
 
     /**
+     * You can pass the `waitUntil` function to handle background promises.
+     * This is required when working with environments like Cloudflare Workers or Vercel Functions to ensure tasks complete after the response is sent.
      * @default
      * ```ts
      * import { defaultWaitUntil } from "@daiso-tech/core/utilities"

--- a/src/shared-lock/implementations/derivables/shared-lock-factory/shared-lock-factory.ts
+++ b/src/shared-lock/implementations/derivables/shared-lock-factory/shared-lock-factory.ts
@@ -116,6 +116,8 @@ export type SharedLockFactorySettingsBase = {
     defaultRefreshTime?: ITimeSpan;
 
     /**
+     * You can pass the `waitUntil` function to handle background promises.
+     * This is required when working with environments like Cloudflare Workers or Vercel Functions to ensure tasks complete after the response is sent.
      * @default
      * ```ts
      * import { defaultWaitUntil } from "@daiso-tech/core/utilities"


### PR DESCRIPTION
- **Add locking to cache getOrAdd method**
- **Improved documentation**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cache's `getOrAdd` method now supports optional distributed locking to control concurrent access.

* **Documentation**
  * Clarified `waitUntil` configuration options across multiple components for proper background task handling in serverless environments such as Cloudflare Workers and Vercel Functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->