### PR TITLE
remove empty catch blocks

### DIFF
--- a/src/cache/implementations/test-utilities/cache.test-suite.ts
+++ b/src/cache/implementations/test-utilities/cache.test-suite.ts
@@ -655,8 +655,10 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const value2 = 2;
                     try {
                         await cache.addOrFail(key, value2);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyExistsCacheError)) {
+                            throw error;
+                        }
                     }
 
                     const result = await cache.get(key);
@@ -673,8 +675,10 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const value2 = 2;
                     try {
                         await cache.addOrFail(key, value2);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyExistsCacheError)) {
+                            throw error;
+                        }
                     }
 
                     const result = await cache.get(key);
@@ -885,8 +889,10 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const value = 1;
                     try {
                         await cache.updateOrFail(key, value);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundCacheError)) {
+                            throw error;
+                        }
                     }
 
                     const result = await cache.get(key);
@@ -918,8 +924,10 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const value2 = 2;
                     try {
                         await cache.updateOrFail(key, value2);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundCacheError)) {
+                            throw error;
+                        }
                     }
 
                     const result = await cache.get(key);
@@ -1081,8 +1089,10 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const value = 1;
                     try {
                         await cache.incrementOrFail(key, value);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundCacheError)) {
+                            throw error;
+                        }
                     }
 
                     const result = await cache.get(key);
@@ -1114,8 +1124,10 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const value2 = 2;
                     try {
                         await cache.incrementOrFail(key, value2);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundCacheError)) {
+                            throw error;
+                        }
                     }
 
                     const result = await cache.get(key);
@@ -1277,8 +1289,10 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const value = 1;
                     try {
                         await cache.decrementOrFail(key, value);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundCacheError)) {
+                            throw error;
+                        }
                     }
 
                     const result = await cache.get(key);
@@ -1310,8 +1324,10 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const value2 = 2;
                     try {
                         await cache.decrementOrFail(key, value2);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundCacheError)) {
+                            throw error;
+                        }
                     }
 
                     const result = await cache.get(key);
@@ -1791,8 +1807,10 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
                     try {
                         await cache.getOrFail(key);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundCacheError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();
@@ -1963,8 +1981,10 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const value = 1;
                     try {
                         await cache.updateOrFail(key, value);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundCacheError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();
@@ -2164,8 +2184,10 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
                     try {
                         await cache.removeOrFail(key);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundCacheError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();
@@ -2531,8 +2553,10 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const value = 1;
                     try {
                         await cache.incrementOrFail(key, value);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundCacheError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();
@@ -2669,8 +2693,10 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const value = 1;
                     try {
                         await cache.decrementOrFail(key, value);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundCacheError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();

--- a/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker-factory.test.ts
+++ b/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker-factory.test.ts
@@ -44,37 +44,37 @@ describe("class: CircuitBreakerFactory", () => {
             _context: IReadableContext,
             _key: string,
         ): Promise<CircuitBreakerState> {
-            throw new Error("Function not implemented.");
+            throw new UnexpectedErrorA("Function not implemented.");
         },
         updateState: function (
             _context: IReadableContext,
             _key: string,
         ): Promise<CircuitBreakerStateTransition> {
-            throw new Error("Function not implemented.");
+            throw new UnexpectedErrorA("Function not implemented.");
         },
         isolate: function (
             _context: IReadableContext,
             _key: string,
         ): Promise<void> {
-            throw new Error("Function not implemented.");
+            throw new UnexpectedErrorA("Function not implemented.");
         },
         trackFailure: function (
             _context: IReadableContext,
             _key: string,
         ): Promise<void> {
-            throw new Error("Function not implemented.");
+            throw new UnexpectedErrorA("Function not implemented.");
         },
         trackSuccess: function (
             _context: IReadableContext,
             _key: string,
         ): Promise<void> {
-            throw new Error("Function not implemented.");
+            throw new UnexpectedErrorA("Function not implemented.");
         },
         reset: function (
             _context: IReadableContext,
             _key: string,
         ): Promise<void> {
-            throw new Error("Function not implemented.");
+            throw new UnexpectedErrorA("Function not implemented.");
         },
     };
     const KEY = "A";
@@ -102,6 +102,9 @@ describe("class: CircuitBreakerFactory", () => {
             .toMilliseconds(),
     };
 
+    class UnexpectedErrorA extends Error {}
+    class UnexpectedErrorB extends Error {}
+
     describe("API tests:", () => {
         describe("method: runOrFail", () => {
             describe("CIRCUIT_BREAKER_TRIGGER.BOTH:", () => {
@@ -122,11 +125,13 @@ describe("class: CircuitBreakerFactory", () => {
                     try {
                         await circuitBreaker.runOrFail(() => {
                             return Promise.reject(
-                                new Error("UNEXPECTED ERROR"),
+                                new UnexpectedErrorA("UNEXPECTED ERROR"),
                             );
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorA)) {
+                            throw error;
+                        }
                     }
 
                     expect(trackFailureSpy).toHaveBeenCalledOnce();
@@ -181,18 +186,18 @@ describe("class: CircuitBreakerFactory", () => {
                         .spyOn(adapter, "trackFailure")
                         .mockImplementation(() => Promise.resolve());
 
-                    class ErrorA extends Error {}
-                    class ErrorB extends Error {}
                     const circuitBreaker = circuitBreakerFactory.create(KEY, {
                         trigger: CIRCUIT_BREAKER_TRIGGER.BOTH,
-                        errorPolicy: ErrorA,
+                        errorPolicy: UnexpectedErrorA,
                     });
                     try {
                         await circuitBreaker.runOrFail(() => {
-                            return Promise.reject(new ErrorB());
+                            return Promise.reject(new UnexpectedErrorB());
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorB)) {
+                            throw error;
+                        }
                     }
 
                     expect(trackFailureSpy).not.toHaveBeenCalled();
@@ -212,7 +217,9 @@ describe("class: CircuitBreakerFactory", () => {
                         trigger: CIRCUIT_BREAKER_TRIGGER.BOTH,
                     });
                     const promise = circuitBreaker.runOrFail(() => {
-                        return Promise.reject(new Error("UNEXPECTED ERROR"));
+                        return Promise.reject(
+                            new UnexpectedErrorA("UNEXPECTED ERROR"),
+                        );
                     });
                     await expect(promise).rejects.toBeInstanceOf(
                         OpenCircuitBreakerError,
@@ -233,7 +240,9 @@ describe("class: CircuitBreakerFactory", () => {
                         trigger: CIRCUIT_BREAKER_TRIGGER.BOTH,
                     });
                     const promise = circuitBreaker.runOrFail(() => {
-                        return Promise.reject(new Error("UNEXPECTED ERROR"));
+                        return Promise.reject(
+                            new UnexpectedErrorA("UNEXPECTED ERROR"),
+                        );
                     });
                     await expect(promise).rejects.toBeInstanceOf(
                         IsolatedCircuitBreakerError,
@@ -258,11 +267,13 @@ describe("class: CircuitBreakerFactory", () => {
                     try {
                         await circuitBreaker.runOrFail(() => {
                             return Promise.reject(
-                                new Error("UNEXPECTED ERROR"),
+                                new UnexpectedErrorA("UNEXPECTED ERROR"),
                             );
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorA)) {
+                            throw error;
+                        }
                     }
 
                     expect(trackFailureSpy).toHaveBeenCalledOnce();
@@ -343,18 +354,18 @@ describe("class: CircuitBreakerFactory", () => {
                         .spyOn(adapter, "trackFailure")
                         .mockImplementation(() => Promise.resolve());
 
-                    class ErrorA extends Error {}
-                    class ErrorB extends Error {}
                     const circuitBreaker = circuitBreakerFactory.create(KEY, {
                         trigger: CIRCUIT_BREAKER_TRIGGER.ONLY_ERROR,
-                        errorPolicy: ErrorA,
+                        errorPolicy: UnexpectedErrorA,
                     });
                     try {
                         await circuitBreaker.runOrFail(() => {
-                            return Promise.reject(new ErrorB());
+                            return Promise.reject(new UnexpectedErrorB());
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorB)) {
+                            throw error;
+                        }
                     }
 
                     expect(trackFailureSpy).not.toHaveBeenCalled();
@@ -374,7 +385,9 @@ describe("class: CircuitBreakerFactory", () => {
                         trigger: CIRCUIT_BREAKER_TRIGGER.ONLY_ERROR,
                     });
                     const promise = circuitBreaker.runOrFail(() => {
-                        return Promise.reject(new Error("UNEXPECTED ERROR"));
+                        return Promise.reject(
+                            new UnexpectedErrorA("UNEXPECTED ERROR"),
+                        );
                     });
                     await expect(promise).rejects.toBeInstanceOf(
                         OpenCircuitBreakerError,
@@ -395,7 +408,9 @@ describe("class: CircuitBreakerFactory", () => {
                         trigger: CIRCUIT_BREAKER_TRIGGER.ONLY_ERROR,
                     });
                     const promise = circuitBreaker.runOrFail(() => {
-                        return Promise.reject(new Error("UNEXPECTED ERROR"));
+                        return Promise.reject(
+                            new UnexpectedErrorA("UNEXPECTED ERROR"),
+                        );
                     });
                     await expect(promise).rejects.toBeInstanceOf(
                         IsolatedCircuitBreakerError,
@@ -420,11 +435,13 @@ describe("class: CircuitBreakerFactory", () => {
                     try {
                         await circuitBreaker.runOrFail(() => {
                             return Promise.reject(
-                                new Error("UNEXPECTED ERROR"),
+                                new UnexpectedErrorA("UNEXPECTED ERROR"),
                             );
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorA)) {
+                            throw error;
+                        }
                     }
 
                     expect(trackFailureSpy).not.toHaveBeenCalled();
@@ -479,18 +496,18 @@ describe("class: CircuitBreakerFactory", () => {
                         .spyOn(adapter, "trackFailure")
                         .mockImplementation(() => Promise.resolve());
 
-                    class ErrorA extends Error {}
-                    class ErrorB extends Error {}
                     const circuitBreaker = circuitBreakerFactory.create(KEY, {
                         trigger: CIRCUIT_BREAKER_TRIGGER.ONLY_SLOW_CALL,
-                        errorPolicy: ErrorA,
+                        errorPolicy: UnexpectedErrorA,
                     });
                     try {
                         await circuitBreaker.runOrFail(() => {
-                            return Promise.reject(new ErrorB());
+                            return Promise.reject(new UnexpectedErrorB());
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorB)) {
+                            throw error;
+                        }
                     }
 
                     expect(trackFailureSpy).not.toHaveBeenCalled();
@@ -510,7 +527,9 @@ describe("class: CircuitBreakerFactory", () => {
                         trigger: CIRCUIT_BREAKER_TRIGGER.ONLY_SLOW_CALL,
                     });
                     const promise = circuitBreaker.runOrFail(() => {
-                        return Promise.reject(new Error("UNEXPECTED ERROR"));
+                        return Promise.reject(
+                            new UnexpectedErrorA("UNEXPECTED ERROR"),
+                        );
                     });
                     await expect(promise).rejects.toBeInstanceOf(
                         OpenCircuitBreakerError,
@@ -531,7 +550,9 @@ describe("class: CircuitBreakerFactory", () => {
                         trigger: CIRCUIT_BREAKER_TRIGGER.ONLY_SLOW_CALL,
                     });
                     const promise = circuitBreaker.runOrFail(() => {
-                        return Promise.reject(new Error("UNEXPECTED ERROR"));
+                        return Promise.reject(
+                            new UnexpectedErrorA("UNEXPECTED ERROR"),
+                        );
                     });
                     await expect(promise).rejects.toBeInstanceOf(
                         IsolatedCircuitBreakerError,
@@ -593,11 +614,13 @@ describe("class: CircuitBreakerFactory", () => {
                     try {
                         await circuitBreaker.runOrFail(() => {
                             return Promise.reject(
-                                new Error("UNEXPECTED ERROR"),
+                                new UnexpectedErrorA("UNEXPECTED ERROR"),
                             );
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorA)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();
@@ -639,13 +662,10 @@ describe("class: CircuitBreakerFactory", () => {
                     const circuitBreaker = circuitBreakerFactory.create(KEY, {
                         trigger: CIRCUIT_BREAKER_TRIGGER.BOTH,
                     });
-                    try {
-                        await circuitBreaker.runOrFail(async () => {
-                            await delay(slowCallTime.addMilliseconds(25));
-                        });
-                    } catch {
-                        /* EMPTY */
-                    }
+                    await circuitBreaker.runOrFail(async () => {
+                        await delay(slowCallTime.addMilliseconds(25));
+                    });
+
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();
                         expect(handlerFn).toHaveBeenCalledWith(
@@ -685,11 +705,8 @@ describe("class: CircuitBreakerFactory", () => {
                     const circuitBreaker = circuitBreakerFactory.create(KEY, {
                         trigger: CIRCUIT_BREAKER_TRIGGER.BOTH,
                     });
-                    try {
-                        await circuitBreaker.runOrFail(() => {});
-                    } catch {
-                        /* EMPTY */
-                    }
+                    await circuitBreaker.runOrFail(() => {});
+
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();
                         expect(handlerFn).toHaveBeenCalledWith(
@@ -726,18 +743,18 @@ describe("class: CircuitBreakerFactory", () => {
                         CIRCUIT_BREAKER_EVENTS.TRACKED_FAILURE,
                         handlerFn,
                     );
-                    class ErrorA extends Error {}
-                    class ErrorB extends Error {}
                     const circuitBreaker = circuitBreakerFactory.create(KEY, {
                         trigger: CIRCUIT_BREAKER_TRIGGER.BOTH,
-                        errorPolicy: ErrorA,
+                        errorPolicy: UnexpectedErrorA,
                     });
                     try {
                         await circuitBreaker.runOrFail(() => {
-                            throw new ErrorB();
+                            throw new UnexpectedErrorB();
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorB)) {
+                            throw error;
+                        }
                     }
 
                     await delay(eventDispatchWaitTime);
@@ -761,18 +778,18 @@ describe("class: CircuitBreakerFactory", () => {
                         CIRCUIT_BREAKER_EVENTS.UNTRACKED_FAILURE,
                         handlerFn,
                     );
-                    class ErrorA extends Error {}
-                    class ErrorB extends Error {}
                     const circuitBreaker = circuitBreakerFactory.create(KEY, {
                         trigger: CIRCUIT_BREAKER_TRIGGER.BOTH,
-                        errorPolicy: ErrorA,
+                        errorPolicy: UnexpectedErrorA,
                     });
                     try {
                         await circuitBreaker.runOrFail(() => {
-                            throw new ErrorB();
+                            throw new UnexpectedErrorB();
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorB)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalled();
@@ -804,11 +821,13 @@ describe("class: CircuitBreakerFactory", () => {
                     try {
                         await circuitBreaker.runOrFail(() => {
                             return Promise.reject(
-                                new Error("UNEXPECTED ERROR"),
+                                new UnexpectedErrorA("UNEXPECTED ERROR"),
                             );
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorA)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();
@@ -836,6 +855,9 @@ describe("class: CircuitBreakerFactory", () => {
                             to: CIRCUIT_BREAKER_STATE.CLOSED,
                         }),
                     );
+                    vi.spyOn(adapter, "trackSuccess").mockImplementation(() =>
+                        Promise.resolve(),
+                    );
                     vi.spyOn(adapter, "trackFailure").mockImplementation(() =>
                         Promise.resolve(),
                     );
@@ -850,13 +872,9 @@ describe("class: CircuitBreakerFactory", () => {
                     const circuitBreaker = circuitBreakerFactory.create(KEY, {
                         trigger: CIRCUIT_BREAKER_TRIGGER.ONLY_ERROR,
                     });
-                    try {
-                        await circuitBreaker.runOrFail(async () => {
-                            await delay(slowCallTime.addMilliseconds(25));
-                        });
-                    } catch {
-                        /* EMPTY */
-                    }
+                    await circuitBreaker.runOrFail(async () => {
+                        await delay(slowCallTime.addMilliseconds(25));
+                    });
 
                     await delay(eventDispatchWaitTime);
                     expect(handlerFn).not.toHaveBeenCalled();
@@ -882,11 +900,8 @@ describe("class: CircuitBreakerFactory", () => {
                     const circuitBreaker = circuitBreakerFactory.create(KEY, {
                         trigger: CIRCUIT_BREAKER_TRIGGER.ONLY_ERROR,
                     });
-                    try {
-                        await circuitBreaker.runOrFail(() => {});
-                    } catch {
-                        /* EMPTY */
-                    }
+                    await circuitBreaker.runOrFail(() => {});
+
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();
                         expect(handlerFn).toHaveBeenCalledWith(
@@ -926,13 +941,10 @@ describe("class: CircuitBreakerFactory", () => {
                     const circuitBreaker = circuitBreakerFactory.create(KEY, {
                         trigger: CIRCUIT_BREAKER_TRIGGER.ONLY_ERROR,
                     });
-                    try {
-                        await circuitBreaker.runOrFail(async () => {
-                            await delay(slowCallTime.addMilliseconds(25));
-                        });
-                    } catch {
-                        /* EMPTY */
-                    }
+                    await circuitBreaker.runOrFail(async () => {
+                        await delay(slowCallTime.addMilliseconds(25));
+                    });
+
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();
                         expect(handlerFn).toHaveBeenCalledWith(
@@ -969,18 +981,18 @@ describe("class: CircuitBreakerFactory", () => {
                         CIRCUIT_BREAKER_EVENTS.TRACKED_FAILURE,
                         handlerFn,
                     );
-                    class ErrorA extends Error {}
-                    class ErrorB extends Error {}
                     const circuitBreaker = circuitBreakerFactory.create(KEY, {
                         trigger: CIRCUIT_BREAKER_TRIGGER.ONLY_ERROR,
-                        errorPolicy: ErrorA,
+                        errorPolicy: UnexpectedErrorA,
                     });
                     try {
                         await circuitBreaker.runOrFail(() => {
-                            throw new ErrorB();
+                            throw new UnexpectedErrorB();
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorB)) {
+                            throw error;
+                        }
                     }
 
                     await delay(eventDispatchWaitTime);
@@ -1004,18 +1016,18 @@ describe("class: CircuitBreakerFactory", () => {
                         CIRCUIT_BREAKER_EVENTS.UNTRACKED_FAILURE,
                         handlerFn,
                     );
-                    class ErrorA extends Error {}
-                    class ErrorB extends Error {}
                     const circuitBreaker = circuitBreakerFactory.create(KEY, {
                         trigger: CIRCUIT_BREAKER_TRIGGER.ONLY_ERROR,
-                        errorPolicy: ErrorA,
+                        errorPolicy: UnexpectedErrorA,
                     });
                     try {
                         await circuitBreaker.runOrFail(() => {
-                            throw new ErrorB();
+                            throw new UnexpectedErrorB();
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorB)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalled();
@@ -1047,11 +1059,13 @@ describe("class: CircuitBreakerFactory", () => {
                     try {
                         await circuitBreaker.runOrFail(() => {
                             return Promise.reject(
-                                new Error("UNEXPECTED ERROR"),
+                                new UnexpectedErrorA("UNEXPECTED ERROR"),
                             );
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorA)) {
+                            throw error;
+                        }
                     }
 
                     await delay(eventDispatchWaitTime);
@@ -1150,8 +1164,6 @@ describe("class: CircuitBreakerFactory", () => {
                         Promise.resolve(),
                     );
 
-                    class ErrorA extends Error {}
-                    class ErrorB extends Error {}
                     const handlerFn = vi.fn(
                         (_event: TrackedFailureCircuitBreakerEvent) => {},
                     );
@@ -1161,14 +1173,16 @@ describe("class: CircuitBreakerFactory", () => {
                     );
                     const circuitBreaker = circuitBreakerFactory.create(KEY, {
                         trigger: CIRCUIT_BREAKER_TRIGGER.ONLY_SLOW_CALL,
-                        errorPolicy: ErrorA,
+                        errorPolicy: UnexpectedErrorA,
                     });
                     try {
                         await circuitBreaker.runOrFail(() => {
-                            return Promise.reject(new ErrorB());
+                            return Promise.reject(new UnexpectedErrorB());
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorB)) {
+                            throw error;
+                        }
                     }
 
                     await delay(eventDispatchWaitTime);
@@ -1185,8 +1199,6 @@ describe("class: CircuitBreakerFactory", () => {
                         Promise.resolve(),
                     );
 
-                    class ErrorA extends Error {}
-                    class ErrorB extends Error {}
                     const handlerFn = vi.fn(
                         (_event: TrackedSuccessCircuitBreakerEvent) => {},
                     );
@@ -1196,14 +1208,16 @@ describe("class: CircuitBreakerFactory", () => {
                     );
                     const circuitBreaker = circuitBreakerFactory.create(KEY, {
                         trigger: CIRCUIT_BREAKER_TRIGGER.ONLY_SLOW_CALL,
-                        errorPolicy: ErrorA,
+                        errorPolicy: UnexpectedErrorA,
                     });
                     try {
                         await circuitBreaker.runOrFail(() => {
-                            return Promise.reject(new ErrorB());
+                            return Promise.reject(new UnexpectedErrorB());
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorB)) {
+                            throw error;
+                        }
                     }
 
                     await delay(eventDispatchWaitTime);
@@ -1220,8 +1234,6 @@ describe("class: CircuitBreakerFactory", () => {
                         Promise.resolve(),
                     );
 
-                    class ErrorA extends Error {}
-                    class ErrorB extends Error {}
                     const handlerFn = vi.fn(
                         (_event: UntrackedFailureCircuitBreakerEvent) => {},
                     );
@@ -1231,14 +1243,16 @@ describe("class: CircuitBreakerFactory", () => {
                     );
                     const circuitBreaker = circuitBreakerFactory.create(KEY, {
                         trigger: CIRCUIT_BREAKER_TRIGGER.ONLY_SLOW_CALL,
-                        errorPolicy: ErrorA,
+                        errorPolicy: UnexpectedErrorA,
                     });
                     try {
                         await circuitBreaker.runOrFail(() => {
-                            return Promise.reject(new ErrorB());
+                            return Promise.reject(new UnexpectedErrorB());
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorB)) {
+                            throw error;
+                        }
                     }
 
                     await delay(eventDispatchWaitTime);
@@ -1269,9 +1283,12 @@ describe("class: CircuitBreakerFactory", () => {
                 const circuitBreaker = circuitBreakerFactory.create(KEY);
                 try {
                     await circuitBreaker.runOrFail(() => {});
-                } catch {
-                    /* EMPTY */
+                } catch (error: unknown) {
+                    if (!(error instanceof OpenCircuitBreakerError)) {
+                        throw error;
+                    }
                 }
+
                 await vi.waitFor(() => {
                     expect(handlerFn).toHaveBeenCalledOnce();
                     expect(handlerFn).toHaveBeenCalledWith(
@@ -1383,10 +1400,14 @@ describe("class: CircuitBreakerFactory", () => {
             const circuitBreaker1 = circuitBreakerFactory1.create(key);
             try {
                 await circuitBreaker1.runOrFail(() => {
-                    return Promise.reject(new Error("Unexpected error"));
+                    return Promise.reject(
+                        new UnexpectedErrorA("Unexpected error"),
+                    );
                 });
-            } catch {
-                /* EMPTY */
+            } catch (error: unknown) {
+                if (!(error instanceof UnexpectedErrorA)) {
+                    throw error;
+                }
             }
 
             const circuitBreakerFactory2 = new CircuitBreakerFactory({
@@ -1477,10 +1498,14 @@ describe("class: CircuitBreakerFactory", () => {
             const circuitBreaker1 = circuitBreakerFactory1.create(key);
             try {
                 await circuitBreaker1.runOrFail(() => {
-                    return Promise.reject(new Error("Unexpected error"));
+                    return Promise.reject(
+                        new UnexpectedErrorA("Unexpected error"),
+                    );
                 });
-            } catch {
-                /* EMPTY */
+            } catch (error: unknown) {
+                if (!(error instanceof UnexpectedErrorA)) {
+                    throw error;
+                }
             }
 
             const circuitBreakerFactory2 = new CircuitBreakerFactory({
@@ -1533,10 +1558,14 @@ describe("class: CircuitBreakerFactory", () => {
             const circuitBreaker1 = circuitBreakerFactory1.create(key);
             try {
                 await circuitBreaker1.runOrFail(() => {
-                    return Promise.reject(new Error("Unexpected error"));
+                    return Promise.reject(
+                        new UnexpectedErrorA("Unexpected error"),
+                    );
                 });
-            } catch {
-                /* EMPTY */
+            } catch (error: unknown) {
+                if (!(error instanceof UnexpectedErrorA)) {
+                    throw error;
+                }
             }
 
             const circuitBreakerFactory2 = new CircuitBreakerFactory({

--- a/src/collection/implementations/async-iterable-collection/async-iterable-collection.test.ts
+++ b/src/collection/implementations/async-iterable-collection/async-iterable-collection.test.ts
@@ -2415,8 +2415,10 @@ describe("class: AsyncIterableCollection", () => {
                     indexes.push(index);
                     return item === 6;
                 });
-            } catch {
-                /* Empty */
+            } catch (error: unknown) {
+                if (!(error instanceof ItemNotFoundCollectionError)) {
+                    throw error;
+                }
             }
             expect(indexes).toEqual([0, 1, 2, 3, 4]);
         });
@@ -2691,8 +2693,10 @@ describe("class: AsyncIterableCollection", () => {
                     indexes.push(index);
                     return item === 6;
                 });
-            } catch {
-                /* Empty */
+            } catch (error: unknown) {
+                if (!(error instanceof ItemNotFoundCollectionError)) {
+                    throw error;
+                }
             }
             expect(indexes).toEqual([0, 1, 2, 3, 4]);
         });
@@ -2890,8 +2894,10 @@ describe("class: AsyncIterableCollection", () => {
                     indexes.push(index);
                     return item === "c";
                 });
-            } catch {
-                /* Empty */
+            } catch (error: unknown) {
+                if (!(error instanceof ItemNotFoundCollectionError)) {
+                    throw error;
+                }
             }
             expect(indexes).toEqual([0, 1, 2]);
         });
@@ -3065,8 +3071,10 @@ describe("class: AsyncIterableCollection", () => {
                     indexes.push(index);
                     return item === "c";
                 });
-            } catch {
-                /* Empty */
+            } catch (error: unknown) {
+                if (!(error instanceof ItemNotFoundCollectionError)) {
+                    throw error;
+                }
             }
             expect(indexes).toEqual([0, 1, 2]);
         });

--- a/src/collection/implementations/iterable-collection/iterable-collection.test.ts
+++ b/src/collection/implementations/iterable-collection/iterable-collection.test.ts
@@ -1799,8 +1799,10 @@ describe("class: IterableCollection", () => {
                     indexes.push(index);
                     return item === 6;
                 });
-            } catch {
-                /* Empty */
+            } catch (error: unknown) {
+                if (!(error instanceof ItemNotFoundCollectionError)) {
+                    throw error;
+                }
             }
             expect(indexes).toEqual([0, 1, 2, 3, 4]);
         });
@@ -1983,8 +1985,10 @@ describe("class: IterableCollection", () => {
                     indexes.push(index);
                     return item === 6;
                 });
-            } catch {
-                /* Empty */
+            } catch (error: unknown) {
+                if (!(error instanceof ItemNotFoundCollectionError)) {
+                    throw error;
+                }
             }
             expect(indexes).toEqual([0, 1, 2, 3, 4]);
         });
@@ -2111,8 +2115,10 @@ describe("class: IterableCollection", () => {
                     indexes.push(index);
                     return item === "c";
                 });
-            } catch {
-                /* Empty */
+            } catch (error: unknown) {
+                if (!(error instanceof ItemNotFoundCollectionError)) {
+                    throw error;
+                }
             }
             expect(indexes).toEqual([0, 1, 2]);
         });
@@ -2239,8 +2245,10 @@ describe("class: IterableCollection", () => {
                     indexes.push(index);
                     return item === "c";
                 });
-            } catch {
-                /* Empty */
+            } catch (error: unknown) {
+                if (!(error instanceof ItemNotFoundCollectionError)) {
+                    throw error;
+                }
             }
             expect(indexes).toEqual([0, 1, 2]);
         });

--- a/src/collection/implementations/list-collection/list-collection.test.ts
+++ b/src/collection/implementations/list-collection/list-collection.test.ts
@@ -1740,8 +1740,10 @@ describe("class: ListCollection", () => {
                     indexes.push(index);
                     return item === 6;
                 });
-            } catch {
-                /* Empty */
+            } catch (error: unknown) {
+                if (!(error instanceof ItemNotFoundCollectionError)) {
+                    throw error;
+                }
             }
             expect(indexes).toEqual([0, 1, 2, 3, 4]);
         });
@@ -1927,8 +1929,10 @@ describe("class: ListCollection", () => {
                     indexes.push(index);
                     return item === 6;
                 });
-            } catch {
-                /* Empty */
+            } catch (error: unknown) {
+                if (!(error instanceof ItemNotFoundCollectionError)) {
+                    throw error;
+                }
             }
             expect(indexes).toEqual([0, 1, 2, 3, 4]);
         });
@@ -2055,8 +2059,10 @@ describe("class: ListCollection", () => {
                     indexes.push(index);
                     return item === "c";
                 });
-            } catch {
-                /* Empty */
+            } catch (error: unknown) {
+                if (!(error instanceof ItemNotFoundCollectionError)) {
+                    throw error;
+                }
             }
             expect(indexes).toEqual([0, 1, 2]);
         });
@@ -2183,8 +2189,10 @@ describe("class: ListCollection", () => {
                     indexes.push(index);
                     return item === "c";
                 });
-            } catch {
-                /* Empty */
+            } catch (error: unknown) {
+                if (!(error instanceof ItemNotFoundCollectionError)) {
+                    throw error;
+                }
             }
             expect(indexes).toEqual([0, 1, 2]);
         });

--- a/src/file-storage/implementations/derivables/file-storage/file-storage.test.ts
+++ b/src/file-storage/implementations/derivables/file-storage/file-storage.test.ts
@@ -310,8 +310,10 @@ describe("class: FileStorage", () => {
 
             try {
                 await fileStorage.create("a").getPublicUrlOrFail();
-            } catch {
-                /* EMPTY */
+            } catch (error: unknown) {
+                if (!(error instanceof KeyNotFoundFileError)) {
+                    throw error;
+                }
             }
             await delay(TTL);
 
@@ -326,8 +328,10 @@ describe("class: FileStorage", () => {
 
             try {
                 await fileStorage.create("a").getPublicUrlOrFail();
-            } catch {
-                /* EMPTY */
+            } catch (error: unknown) {
+                if (!(error instanceof KeyNotFoundFileError)) {
+                    throw error;
+                }
             }
             await delay(TTL);
 
@@ -355,8 +359,10 @@ describe("class: FileStorage", () => {
 
             try {
                 await fileStorage.create("a").getPublicUrlOrFail();
-            } catch {
-                /* EMPTY */
+            } catch (error: unknown) {
+                if (!(error instanceof KeyNotFoundFileError)) {
+                    throw error;
+                }
             }
             await delay(TTL);
 
@@ -534,8 +540,10 @@ describe("class: FileStorage", () => {
 
             try {
                 await fileStorage.create("a").getSignedDownloadUrlOrFail();
-            } catch {
-                /* EMPTY */
+            } catch (error: unknown) {
+                if (!(error instanceof KeyNotFoundFileError)) {
+                    throw error;
+                }
             }
 
             await delay(TTL);
@@ -553,8 +561,10 @@ describe("class: FileStorage", () => {
 
             try {
                 await fileStorage.create("a").getSignedDownloadUrlOrFail();
-            } catch {
-                /* EMPTY */
+            } catch (error: unknown) {
+                if (!(error instanceof KeyNotFoundFileError)) {
+                    throw error;
+                }
             }
             await delay(TTL);
 
@@ -582,8 +592,10 @@ describe("class: FileStorage", () => {
 
             try {
                 await fileStorage.create("a").getSignedDownloadUrlOrFail();
-            } catch {
-                /* EMPTY */
+            } catch (error: unknown) {
+                if (!(error instanceof KeyNotFoundFileError)) {
+                    throw error;
+                }
             }
             await delay(TTL);
 

--- a/src/file-storage/implementations/test-utilities/file-storage.test-suite.ts
+++ b/src/file-storage/implementations/test-utilities/file-storage.test-suite.ts
@@ -1010,8 +1010,10 @@ export function fileStorageTestSuite(
                     );
                     try {
                         await file.addOrFail({ data: newData });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyExistsFileError)) {
+                            throw error;
+                        }
                     }
 
                     const result = await file.getBytes();
@@ -1186,8 +1188,10 @@ export function fileStorageTestSuite(
                                 },
                             },
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyExistsFileError)) {
+                            throw error;
+                        }
                     }
 
                     const result = await file.getBytes();
@@ -1265,8 +1269,10 @@ export function fileStorageTestSuite(
                     const file = fileStorage.create(key);
                     try {
                         await file.updateOrFail({ data });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundFileError)) {
+                            throw error;
+                        }
                     }
 
                     const result = await file.getBytes();
@@ -1405,8 +1411,10 @@ export function fileStorageTestSuite(
                                 },
                             },
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundFileError)) {
+                            throw error;
+                        }
                     }
 
                     const result = await file.getBytes();
@@ -1823,8 +1831,10 @@ export function fileStorageTestSuite(
 
                     try {
                         await sourceFile.copyOrFail(destination);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyExistsFileError)) {
+                            throw error;
+                        }
                     }
 
                     const result = await destinationFile.getBytes();
@@ -2277,8 +2287,10 @@ export function fileStorageTestSuite(
 
                     try {
                         await sourceFile.moveOrFail(destination);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyExistsFileError)) {
+                            throw error;
+                        }
                     }
 
                     const result = await destinationFile.getBytes();
@@ -2796,8 +2808,10 @@ export function fileStorageTestSuite(
 
                     try {
                         await file.getTextOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -2950,8 +2964,10 @@ export function fileStorageTestSuite(
 
                     try {
                         await file.getBytesOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -3104,8 +3120,10 @@ export function fileStorageTestSuite(
 
                     try {
                         await file.getBufferOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -3258,8 +3276,10 @@ export function fileStorageTestSuite(
 
                     try {
                         await file.getArrayBufferOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -3412,8 +3432,10 @@ export function fileStorageTestSuite(
 
                     try {
                         await file.getReadableOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -3566,8 +3588,10 @@ export function fileStorageTestSuite(
 
                     try {
                         await file.getReadableStreamOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -3720,8 +3744,10 @@ export function fileStorageTestSuite(
 
                     try {
                         await file.getMetadataOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -4001,8 +4027,10 @@ export function fileStorageTestSuite(
                                 Buffer.from("NEW_CONTENT", "utf8"),
                             ),
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyExistsFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -4189,8 +4217,10 @@ export function fileStorageTestSuite(
                                 },
                             },
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyExistsFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -4404,8 +4434,10 @@ export function fileStorageTestSuite(
                                 Buffer.from("NEW_CONTENT", "utf8"),
                             ),
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -4598,8 +4630,10 @@ export function fileStorageTestSuite(
                                 },
                             },
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -4928,8 +4962,10 @@ export function fileStorageTestSuite(
 
                     try {
                         await file.removeOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -5099,8 +5135,10 @@ export function fileStorageTestSuite(
                     );
                     try {
                         await fileStorage.create("a").copyOrFail("b");
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -5142,8 +5180,10 @@ export function fileStorageTestSuite(
                     });
                     try {
                         await file.copyOrFail("b");
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyExistsFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -5372,8 +5412,10 @@ export function fileStorageTestSuite(
                     );
                     try {
                         await fileStorage.create("a").copyAndReplaceOrFail("b");
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -5641,8 +5683,10 @@ export function fileStorageTestSuite(
                     );
                     try {
                         await fileStorage.create("a").moveOrFail("b");
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -5684,8 +5728,10 @@ export function fileStorageTestSuite(
                     });
                     try {
                         await file.moveOrFail("b");
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyExistsFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -5914,8 +5960,10 @@ export function fileStorageTestSuite(
                     );
                     try {
                         await fileStorage.create("a").moveAndReplaceOrFail("b");
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof KeyNotFoundFileError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {

--- a/src/lock/implementations/test-utilities/lock-factory.test-suite.ts
+++ b/src/lock/implementations/test-utilities/lock-factory.test-suite.ts
@@ -241,12 +241,15 @@ export function lockFactoryTestSuite(
 
                     const releaseSpy = vi.spyOn(lock, "release");
 
+                    class UnexpectedError extends Error {}
                     try {
                         await lock.runOrFail(() => {
-                            return Promise.reject(new Error());
+                            return Promise.reject(new UnexpectedError());
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedError)) {
+                            throw error;
+                        }
                     }
 
                     expect(releaseSpy).toHaveBeenCalledTimes(1);
@@ -258,13 +261,15 @@ export function lockFactoryTestSuite(
                         ttl,
                     });
 
-                    class CustomError extends Error {}
+                    class UnexpectedErrorA extends Error {}
 
                     const error = lock.runOrFail(() => {
-                        return Promise.reject(new CustomError());
+                        return Promise.reject(new UnexpectedErrorA());
                     });
 
-                    await expect(error).rejects.toBeInstanceOf(CustomError);
+                    await expect(error).rejects.toBeInstanceOf(
+                        UnexpectedErrorA,
+                    );
                 });
                 test("Should call handler function when key doesnt exists", async () => {
                     const key = "a";
@@ -304,11 +309,7 @@ export function lockFactoryTestSuite(
                     const handlerFn = vi.fn(() => {
                         return Promise.resolve(RETURN_VALUE);
                     });
-                    try {
-                        await lock.runOrFail(handlerFn);
-                    } catch {
-                        /* EMPTY */
-                    }
+                    await lock.runOrFail(handlerFn);
 
                     expect(handlerFn).toHaveBeenCalledTimes(1);
                 });
@@ -323,11 +324,7 @@ export function lockFactoryTestSuite(
                     const handlerFn = vi.fn(() => {
                         return Promise.resolve(RETURN_VALUE);
                     });
-                    try {
-                        await lock.runOrFail(handlerFn);
-                    } catch {
-                        /* EMPTY */
-                    }
+                    await lock.runOrFail(handlerFn);
 
                     expect(handlerFn).toHaveBeenCalledTimes(1);
                 });
@@ -343,8 +340,10 @@ export function lockFactoryTestSuite(
                         await lockFactory
                             .create(key, { ttl })
                             .runOrFail(handlerFn);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedAcquireLockError)) {
+                            throw error;
+                        }
                     }
 
                     await delay(delayBuffer);
@@ -362,8 +361,10 @@ export function lockFactoryTestSuite(
                         await lockFactory
                             .create(key, { ttl })
                             .runOrFail(handlerFn);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedAcquireLockError)) {
+                            throw error;
+                        }
                     }
 
                     await delay(delayBuffer);
@@ -824,8 +825,10 @@ export function lockFactoryTestSuite(
                     const lock2 = lockFactory.create(key, { ttl });
                     try {
                         await lock2.releaseOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedReleaseLockError)) {
+                            throw error;
+                        }
                     }
                     const result = await lock2.acquire();
 
@@ -840,8 +843,10 @@ export function lockFactoryTestSuite(
                     const lock2 = lockFactory.create(key, { ttl });
                     try {
                         await lock2.releaseOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedReleaseLockError)) {
+                            throw error;
+                        }
                     }
                     const result = await lock2.acquire();
 
@@ -1169,8 +1174,10 @@ export function lockFactoryTestSuite(
                     const newTtl = TimeSpan.fromMilliseconds(50);
                     try {
                         await lock1.refreshOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedRefreshLockError)) {
+                            throw error;
+                        }
                     }
                     await delayWithBuffer(newTtl);
                     const lock2 = lockFactory.create(key, { ttl });
@@ -1734,8 +1741,10 @@ export function lockFactoryTestSuite(
                     );
                     try {
                         await lock.acquireOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedAcquireLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -1772,8 +1781,10 @@ export function lockFactoryTestSuite(
                     );
                     try {
                         await lock.acquireOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedAcquireLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -2160,8 +2171,10 @@ export function lockFactoryTestSuite(
                     );
                     try {
                         await lock.releaseOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedReleaseLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -2198,8 +2211,10 @@ export function lockFactoryTestSuite(
                     );
                     try {
                         await lock.releaseOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedReleaseLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -2236,8 +2251,10 @@ export function lockFactoryTestSuite(
                     );
                     try {
                         await lock.releaseOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedReleaseLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -2273,9 +2290,11 @@ export function lockFactoryTestSuite(
                         handlerFn,
                     );
                     try {
-                        await lock.release();
-                    } catch {
-                        /* EMPTY */
+                        await lock.releaseOrFail();
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedReleaseLockError)) {
+                            throw error;
+                        }
                     }
                     await delayWithBuffer(ttl);
 
@@ -2312,9 +2331,11 @@ export function lockFactoryTestSuite(
                     await delayWithBuffer(ttl);
 
                     try {
-                        await lock.release();
-                    } catch {
-                        /* EMPTY */
+                        await lock.releaseOrFail();
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedReleaseLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -2672,8 +2693,10 @@ export function lockFactoryTestSuite(
                     );
                     try {
                         await lock.refreshOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedRefreshLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -2712,8 +2735,10 @@ export function lockFactoryTestSuite(
                     );
                     try {
                         await lock2.refreshOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedRefreshLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -2752,8 +2777,10 @@ export function lockFactoryTestSuite(
                     );
                     try {
                         await lock2.refreshOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedRefreshLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -2793,8 +2820,10 @@ export function lockFactoryTestSuite(
                     );
                     try {
                         await lock2.refreshOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedRefreshLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -2835,8 +2864,10 @@ export function lockFactoryTestSuite(
                     );
                     try {
                         await lock.refreshOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedRefreshLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -2874,8 +2905,10 @@ export function lockFactoryTestSuite(
                     );
                     try {
                         await lock.refreshOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedRefreshLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);

--- a/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter-factory.test.ts
+++ b/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter-factory.test.ts
@@ -40,20 +40,20 @@ describe("class: RateLimiterFactory", () => {
             _context: IReadableContext,
             _key: string,
         ): Promise<IRateLimiterAdapterState | null> {
-            throw new Error("Function not implemented.");
+            throw new UnexpectedErrorA("Function not implemented.");
         },
         updateState: function (
             _context: IReadableContext,
             _key: string,
             _limit: number,
         ): Promise<IRateLimiterAdapterState> {
-            throw new Error("Function not implemented.");
+            throw new UnexpectedErrorA("Function not implemented.");
         },
         reset: function (
             _context: IReadableContext,
             _key: string,
         ): Promise<void> {
-            throw new Error("Function not implemented.");
+            throw new UnexpectedErrorA("Function not implemented.");
         },
     };
     const KEY = "a";
@@ -65,6 +65,8 @@ describe("class: RateLimiterFactory", () => {
             .multiply(3)
             .toMilliseconds(),
     };
+    class UnexpectedErrorA extends Error {}
+    class UnexpectedErrorB extends Error {}
 
     let rateLimiterFactory: IRateLimiterFactory;
     beforeEach(() => {
@@ -102,10 +104,12 @@ describe("class: RateLimiterFactory", () => {
                                 onlyError: true,
                             })
                             .runOrFail(() => {
-                                throw new Error("Unexpected error");
+                                throw new UnexpectedErrorA("Unexpected error");
                             });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorA)) {
+                            throw error;
+                        }
                     }
 
                     expect(updateStateSpy).toHaveBeenCalledOnce();
@@ -152,10 +156,12 @@ describe("class: RateLimiterFactory", () => {
                                 onlyError: true,
                             })
                             .runOrFail(() => {
-                                throw new Error("Unexpected error");
+                                throw new UnexpectedErrorA("Unexpected error");
                             });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorA)) {
+                            throw error;
+                        }
                     }
 
                     expect(getStateSpy).toHaveBeenCalledOnce();
@@ -200,7 +206,9 @@ describe("class: RateLimiterFactory", () => {
                         onlyError: true,
                     });
                     const promise = rateLimiter.runOrFail(() => {
-                        return Promise.reject(new Error("UNEXPECTED ERROR"));
+                        return Promise.reject(
+                            new UnexpectedErrorA("UNEXPECTED ERROR"),
+                        );
                     });
                     await expect(promise).rejects.toBeInstanceOf(
                         BlockedRateLimiterError,
@@ -228,10 +236,12 @@ describe("class: RateLimiterFactory", () => {
                                 onlyError: false,
                             })
                             .runOrFail(() => {
-                                throw new Error("Unexpected error");
+                                throw new UnexpectedErrorA("Unexpected error");
                             });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorA)) {
+                            throw error;
+                        }
                     }
 
                     expect(updateStateSpy).toHaveBeenCalledOnce();
@@ -278,10 +288,12 @@ describe("class: RateLimiterFactory", () => {
                                 onlyError: false,
                             })
                             .runOrFail(() => {
-                                throw new Error("Unexpected error");
+                                throw new UnexpectedErrorA("Unexpected error");
                             });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorA)) {
+                            throw error;
+                        }
                     }
 
                     expect(getStateSpy).not.toHaveBeenCalled();
@@ -323,7 +335,9 @@ describe("class: RateLimiterFactory", () => {
                         onlyError: false,
                     });
                     const promise = rateLimiter.runOrFail(() => {
-                        return Promise.reject(new Error("UNEXPECTED ERROR"));
+                        return Promise.reject(
+                            new UnexpectedErrorA("UNEXPECTED ERROR"),
+                        );
                     });
                     await expect(promise).rejects.toBeInstanceOf(
                         BlockedRateLimiterError,
@@ -454,17 +468,18 @@ describe("class: RateLimiterFactory", () => {
                     );
 
                     const limit = 5;
-                    class ErrorA extends Error {}
                     const rateLimiter = rateLimiterFactory.create(KEY, {
                         limit,
                         onlyError: true,
                     });
                     try {
                         await rateLimiter.runOrFail(() => {
-                            throw new ErrorA("Unexpected error");
+                            throw new UnexpectedErrorA("Unexpected error");
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorA)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();
@@ -477,7 +492,7 @@ describe("class: RateLimiterFactory", () => {
                                     key: rateLimiter.key,
                                     limit,
                                 } satisfies IRateLimiterStateMethods) as IRateLimiterStateMethods,
-                                error: expect.any(ErrorA),
+                                error: expect.any(UnexpectedErrorA),
                                 type: RATE_LIMITER_EVENTS.TRACKED_FAILURE,
                             } satisfies EventWithType<
                                 TrackedFailureRateLimiterEvent,
@@ -507,20 +522,20 @@ describe("class: RateLimiterFactory", () => {
                         handlerFn,
                     );
 
-                    class ErrorA extends Error {}
-                    class ErrorB extends Error {}
                     try {
                         await rateLimiterFactory
                             .create(KEY, {
                                 limit: 5,
                                 onlyError: true,
-                                errorPolicy: ErrorA,
+                                errorPolicy: UnexpectedErrorA,
                             })
                             .runOrFail(() => {
-                                throw new ErrorB("Unexpected error");
+                                throw new UnexpectedErrorB("Unexpected error");
                             });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorB)) {
+                            throw error;
+                        }
                     }
 
                     await delay(eventDispatchWaitTime);
@@ -547,20 +562,20 @@ describe("class: RateLimiterFactory", () => {
                         handlerFn,
                     );
 
-                    class ErrorA extends Error {}
-                    class ErrorB extends Error {}
                     const limit = 5;
                     const rateLimiter = rateLimiterFactory.create(KEY, {
                         limit,
                         onlyError: true,
-                        errorPolicy: ErrorA,
+                        errorPolicy: UnexpectedErrorA,
                     });
                     try {
                         await rateLimiter.runOrFail(() => {
-                            throw new ErrorB("Unexpected error");
+                            throw new UnexpectedErrorB("Unexpected error");
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorB)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();
@@ -573,7 +588,7 @@ describe("class: RateLimiterFactory", () => {
                                     key: rateLimiter.key,
                                     limit,
                                 } satisfies IRateLimiterStateMethods) as IRateLimiterStateMethods,
-                                error: expect.any(ErrorB),
+                                error: expect.any(UnexpectedErrorB),
                                 type: RATE_LIMITER_EVENTS.UNTRACKED_FAILURE,
                             } satisfies EventWithType<
                                 UntrackedFailureRateLimiterEvent,
@@ -604,17 +619,18 @@ describe("class: RateLimiterFactory", () => {
                         handlerFn,
                     );
 
-                    class ErrorA extends Error {}
                     const rateLimiter = rateLimiterFactory.create(KEY, {
                         limit,
                         onlyError: true,
                     });
                     try {
                         await rateLimiter.runOrFail(() => {
-                            throw new ErrorA("Unexpected error");
+                            throw new UnexpectedErrorA("Unexpected error");
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorA)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();
@@ -657,17 +673,18 @@ describe("class: RateLimiterFactory", () => {
                         handlerFn,
                     );
 
-                    class ErrorA extends Error {}
                     const rateLimiter = rateLimiterFactory.create(KEY, {
                         limit,
                         onlyError: true,
                     });
                     try {
                         await rateLimiter.runOrFail(() => {
-                            throw new ErrorA("Unexpected error");
+                            throw new UnexpectedErrorA("Unexpected error");
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorA)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();
@@ -758,17 +775,18 @@ describe("class: RateLimiterFactory", () => {
                         handlerFn,
                     );
 
-                    class ErrorA extends Error {}
                     const rateLimiter = rateLimiterFactory.create(KEY, {
                         limit,
                         onlyError: false,
                     });
                     try {
                         await rateLimiter.runOrFail(() => {
-                            throw new ErrorA("Unexpected error");
+                            throw new UnexpectedErrorA("Unexpected error");
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorA)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();
@@ -811,17 +829,18 @@ describe("class: RateLimiterFactory", () => {
                         handlerFn,
                     );
 
-                    class ErrorA extends Error {}
                     const rateLimiter = rateLimiterFactory.create(KEY, {
                         limit,
                         onlyError: false,
                     });
                     try {
                         await rateLimiter.runOrFail(() => {
-                            throw new ErrorA("Unexpected error");
+                            throw new UnexpectedErrorA("Unexpected error");
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorA)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();
@@ -914,11 +933,8 @@ describe("class: RateLimiterFactory", () => {
                         limit,
                         onlyError: false,
                     });
-                    try {
-                        await rateLimiter.runOrFail(() => {});
-                    } catch {
-                        /* EMPTY */
-                    }
+                    await rateLimiter.runOrFail(() => {});
+
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();
                         expect(handlerFn).toHaveBeenCalledWith(
@@ -1001,10 +1017,14 @@ describe("class: RateLimiterFactory", () => {
             });
             try {
                 await rateLimiter1.runOrFail(() => {
-                    return Promise.reject(new Error("Unexpected error"));
+                    return Promise.reject(
+                        new UnexpectedErrorA("Unexpected error"),
+                    );
                 });
-            } catch {
-                /* EMPTY */
+            } catch (error: unknown) {
+                if (!(error instanceof UnexpectedErrorA)) {
+                    throw error;
+                }
             }
 
             const rateLimiterFactory2 = new RateLimiterFactory({
@@ -1081,10 +1101,14 @@ describe("class: RateLimiterFactory", () => {
             });
             try {
                 await rateLimiter1.runOrFail(() => {
-                    return Promise.reject(new Error("Unexpected error"));
+                    return Promise.reject(
+                        new UnexpectedErrorA("Unexpected error"),
+                    );
                 });
-            } catch {
-                /* EMPTY */
+            } catch (error: unknown) {
+                if (!(error instanceof UnexpectedErrorA)) {
+                    throw error;
+                }
             }
 
             const rateLimiterFactory2 = new RateLimiterFactory({
@@ -1137,10 +1161,14 @@ describe("class: RateLimiterFactory", () => {
             });
             try {
                 await rateLimiter1.runOrFail(() => {
-                    return Promise.reject(new Error("Unexpected error"));
+                    return Promise.reject(
+                        new UnexpectedErrorA("Unexpected error"),
+                    );
                 });
-            } catch {
-                /* EMPTY */
+            } catch (error: unknown) {
+                if (!(error instanceof UnexpectedErrorA)) {
+                    throw error;
+                }
             }
 
             const rateLimiterFactory2 = new RateLimiterFactory({

--- a/src/semaphore/implementations/test-utilities/semaphore-factory.test-suite.ts
+++ b/src/semaphore/implementations/test-utilities/semaphore-factory.test-suite.ts
@@ -261,12 +261,15 @@ export function semaphoreFactoryTestSuite(
 
                     const releaseSpy = vi.spyOn(semaphore, "release");
 
+                    class UnexpectedError extends Error {}
                     try {
                         await semaphore.runOrFail(() => {
-                            return Promise.reject(new Error());
+                            return Promise.reject(new UnexpectedError());
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedError)) {
+                            throw error;
+                        }
                     }
 
                     expect(releaseSpy).toHaveBeenCalledTimes(1);
@@ -280,13 +283,15 @@ export function semaphoreFactoryTestSuite(
                         limit,
                     });
 
-                    class CustomError extends Error {}
+                    class UnexpectedErrorA extends Error {}
 
                     const error = semaphore.runOrFail(() => {
-                        return Promise.reject(new CustomError());
+                        return Promise.reject(new UnexpectedErrorA());
                     });
 
-                    await expect(error).rejects.toBeInstanceOf(CustomError);
+                    await expect(error).rejects.toBeInstanceOf(
+                        UnexpectedErrorA,
+                    );
                 });
                 test("Should call handler function when key doesnt exists", async () => {
                     const key = "a";
@@ -345,8 +350,10 @@ export function semaphoreFactoryTestSuite(
                     });
                     try {
                         await semaphore.runOrFail(handlerFn);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof LimitReachedSemaphoreError)) {
+                            throw error;
+                        }
                     }
 
                     await delay(delayBuffer);
@@ -367,8 +374,10 @@ export function semaphoreFactoryTestSuite(
                     });
                     try {
                         await semaphore.runOrFail(handlerFn);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof LimitReachedSemaphoreError)) {
+                            throw error;
+                        }
                     }
 
                     await delay(delayBuffer);
@@ -395,8 +404,10 @@ export function semaphoreFactoryTestSuite(
                                 limit,
                             })
                             .runOrFail(handlerFn);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof LimitReachedSemaphoreError)) {
+                            throw error;
+                        }
                     }
 
                     await delay(delayBuffer);
@@ -423,8 +434,10 @@ export function semaphoreFactoryTestSuite(
                                 limit,
                             })
                             .runOrFail(handlerFn);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof LimitReachedSemaphoreError)) {
+                            throw error;
+                        }
                     }
 
                     await delay(delayBuffer);
@@ -1764,8 +1777,10 @@ export function semaphoreFactoryTestSuite(
                     const newTtl = TimeSpan.fromMilliseconds(100);
                     try {
                         await semaphore2.refreshOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedRefreshSemaphoreError)) {
+                            throw error;
+                        }
                     }
                     await delayWithBuffer(newTtl);
 
@@ -2518,8 +2533,12 @@ export function semaphoreFactoryTestSuite(
                         });
                         try {
                             await semaphore3.acquireOrFail();
-                        } catch {
-                            /* EMPTY */
+                        } catch (error: unknown) {
+                            if (
+                                !(error instanceof LimitReachedSemaphoreError)
+                            ) {
+                                throw error;
+                            }
                         }
                         await vi.waitFor(() => {
                             expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -2957,8 +2976,12 @@ export function semaphoreFactoryTestSuite(
                         );
                         try {
                             await semaphore.releaseOrFail();
-                        } catch {
-                            /* EMPTY */
+                        } catch (error: unknown) {
+                            if (
+                                !(error instanceof FailedReleaseSemaphoreError)
+                            ) {
+                                throw error;
+                            }
                         }
                         await vi.waitFor(() => {
                             expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -3007,8 +3030,12 @@ export function semaphoreFactoryTestSuite(
                         );
                         try {
                             await semaphore.releaseOrFail();
-                        } catch {
-                            /* EMPTY */
+                        } catch (error: unknown) {
+                            if (
+                                !(error instanceof FailedReleaseSemaphoreError)
+                            ) {
+                                throw error;
+                            }
                         }
                         await vi.waitFor(() => {
                             expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -3055,8 +3082,12 @@ export function semaphoreFactoryTestSuite(
                         );
                         try {
                             await semaphore.releaseOrFail();
-                        } catch {
-                            /* EMPTY */
+                        } catch (error: unknown) {
+                            if (
+                                !(error instanceof FailedReleaseSemaphoreError)
+                            ) {
+                                throw error;
+                            }
                         }
                         await vi.waitFor(() => {
                             expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -3099,8 +3130,12 @@ export function semaphoreFactoryTestSuite(
                         );
                         try {
                             await semaphore.releaseOrFail();
-                        } catch {
-                            /* EMPTY */
+                        } catch (error: unknown) {
+                            if (
+                                !(error instanceof FailedReleaseSemaphoreError)
+                            ) {
+                                throw error;
+                            }
                         }
                         await vi.waitFor(() => {
                             expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -3595,8 +3630,12 @@ export function semaphoreFactoryTestSuite(
                         );
                         try {
                             await semaphore2.refreshOrFail(newTtl);
-                        } catch {
-                            /* EMPTY */
+                        } catch (error: unknown) {
+                            if (
+                                !(error instanceof FailedRefreshSemaphoreError)
+                            ) {
+                                throw error;
+                            }
                         }
                         await vi.waitFor(() => {
                             expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -3645,8 +3684,12 @@ export function semaphoreFactoryTestSuite(
                         );
                         try {
                             await semaphore2.refreshOrFail(newTtl);
-                        } catch {
-                            /* EMPTY */
+                        } catch (error: unknown) {
+                            if (
+                                !(error instanceof FailedRefreshSemaphoreError)
+                            ) {
+                                throw error;
+                            }
                         }
                         await vi.waitFor(() => {
                             expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -3689,8 +3732,12 @@ export function semaphoreFactoryTestSuite(
                         const newTtl = TimeSpan.fromMilliseconds(100);
                         try {
                             await semaphore.refreshOrFail(newTtl);
-                        } catch {
-                            /* EMPTY */
+                        } catch (error: unknown) {
+                            if (
+                                !(error instanceof FailedRefreshSemaphoreError)
+                            ) {
+                                throw error;
+                            }
                         }
                         await vi.waitFor(() => {
                             expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -3734,8 +3781,12 @@ export function semaphoreFactoryTestSuite(
                         const newTtl = TimeSpan.fromMilliseconds(100);
                         try {
                             await semaphore.refreshOrFail(newTtl);
-                        } catch {
-                            /* EMPTY */
+                        } catch (error: unknown) {
+                            if (
+                                !(error instanceof FailedRefreshSemaphoreError)
+                            ) {
+                                throw error;
+                            }
                         }
                         await vi.waitFor(() => {
                             expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -3778,8 +3829,12 @@ export function semaphoreFactoryTestSuite(
                         const newTtl = TimeSpan.fromMilliseconds(100);
                         try {
                             await semaphore.refreshOrFail(newTtl);
-                        } catch {
-                            /* EMPTY */
+                        } catch (error: unknown) {
+                            if (
+                                !(error instanceof FailedRefreshSemaphoreError)
+                            ) {
+                                throw error;
+                            }
                         }
                         await vi.waitFor(() => {
                             expect(handlerFn).toHaveBeenCalledTimes(1);

--- a/src/shared-lock/implementations/test-utilities/shared-lock-factory.test-suite.ts
+++ b/src/shared-lock/implementations/test-utilities/shared-lock-factory.test-suite.ts
@@ -168,6 +168,8 @@ export function sharedLockFactoryTestSuite(
         await delay(TimeSpan.fromTimeSpan(ttl).addTimeSpan(delayBuffer));
     }
 
+    class UnexpectedErrorA extends Error {}
+
     const waitForSettings = {
         interval: TimeSpan.fromTimeSpan(eventDispatchWaitTime).toMilliseconds(),
         timeout: TimeSpan.fromTimeSpan(eventDispatchWaitTime)
@@ -278,10 +280,12 @@ export function sharedLockFactoryTestSuite(
 
                     try {
                         await sharedLock.runWriterOrFail(() => {
-                            return Promise.reject(new Error());
+                            return Promise.reject(new UnexpectedErrorA());
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorA)) {
+                            throw error;
+                        }
                     }
 
                     expect(releaseSpy).toHaveBeenCalledTimes(1);
@@ -295,13 +299,13 @@ export function sharedLockFactoryTestSuite(
                         limit,
                     });
 
-                    class CustomError extends Error {}
-
                     const error = sharedLock.runWriterOrFail(() => {
-                        return Promise.reject(new CustomError());
+                        return Promise.reject(new UnexpectedErrorA());
                     });
 
-                    await expect(error).rejects.toBeInstanceOf(CustomError);
+                    await expect(error).rejects.toBeInstanceOf(
+                        UnexpectedErrorA,
+                    );
                 });
                 test("Should call handler function when key doesnt exists", async () => {
                     const key = "a";
@@ -358,11 +362,7 @@ export function sharedLockFactoryTestSuite(
                     const handlerFn = vi.fn(() => {
                         return Promise.resolve(RETURN_VALUE);
                     });
-                    try {
-                        await sharedLock.runWriterOrFail(handlerFn);
-                    } catch {
-                        /* EMPTY */
-                    }
+                    await sharedLock.runWriterOrFail(handlerFn);
 
                     expect(handlerFn).toHaveBeenCalledTimes(1);
                 });
@@ -379,11 +379,7 @@ export function sharedLockFactoryTestSuite(
                     const handlerFn = vi.fn(() => {
                         return Promise.resolve(RETURN_VALUE);
                     });
-                    try {
-                        await sharedLock.runWriterOrFail(handlerFn);
-                    } catch {
-                        /* EMPTY */
-                    }
+                    await sharedLock.runWriterOrFail(handlerFn);
 
                     expect(handlerFn).toHaveBeenCalledTimes(1);
                 });
@@ -408,8 +404,10 @@ export function sharedLockFactoryTestSuite(
                                 limit,
                             })
                             .runWriterOrFail(handlerFn);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedAcquireWriterLockError)) {
+                            throw error;
+                        }
                     }
 
                     await delay(delayBuffer);
@@ -436,8 +434,10 @@ export function sharedLockFactoryTestSuite(
                                 limit,
                             })
                             .runWriterOrFail(handlerFn);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedAcquireWriterLockError)) {
+                            throw error;
+                        }
                     }
 
                     await delay(delayBuffer);
@@ -828,8 +828,10 @@ export function sharedLockFactoryTestSuite(
 
                     try {
                         await sharedLock.acquireWriterOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedAcquireWriterLockError)) {
+                            throw error;
+                        }
                     }
 
                     const state = await sharedLock.getState();
@@ -1223,8 +1225,10 @@ export function sharedLockFactoryTestSuite(
                     });
                     try {
                         await sharedLock2.releaseWriterOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedReleaseWriterLockError)) {
+                            throw error;
+                        }
                     }
                     const result = await sharedLock2.acquireWriter();
 
@@ -1247,8 +1251,10 @@ export function sharedLockFactoryTestSuite(
                     });
                     try {
                         await sharedLock2.releaseWriterOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedReleaseWriterLockError)) {
+                            throw error;
+                        }
                     }
                     const result = await sharedLock2.acquireWriter();
 
@@ -1324,8 +1330,10 @@ export function sharedLockFactoryTestSuite(
 
                     try {
                         await sharedLock.releaseWriterOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedReleaseWriterLockError)) {
+                            throw error;
+                        }
                     }
 
                     const state = await sharedLock.getState();
@@ -1707,8 +1715,10 @@ export function sharedLockFactoryTestSuite(
                     const newTtl = TimeSpan.fromMilliseconds(50);
                     try {
                         await sharedLock1.refreshWriterOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedRefreshWriterLockError)) {
+                            throw error;
+                        }
                     }
                     await delayWithBuffer(newTtl);
 
@@ -1734,8 +1744,10 @@ export function sharedLockFactoryTestSuite(
                     const newTtl = TimeSpan.fromMilliseconds(100);
                     try {
                         await sharedLock1.refreshWriterOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedRefreshWriterLockError)) {
+                            throw error;
+                        }
                     }
                     await delay(newTtl.divide(2));
 
@@ -1782,8 +1794,10 @@ export function sharedLockFactoryTestSuite(
                     const newTtl = TimeSpan.fromSeconds(20);
                     try {
                         await sharedLock.refreshWriterOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedRefreshWriterLockError)) {
+                            throw error;
+                        }
                     }
 
                     const state = await sharedLock.getState();
@@ -2015,10 +2029,12 @@ export function sharedLockFactoryTestSuite(
 
                     try {
                         await sharedLock.runReaderOrFail(() => {
-                            return Promise.reject(new Error());
+                            return Promise.reject(new UnexpectedErrorA());
                         });
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof UnexpectedErrorA)) {
+                            throw error;
+                        }
                     }
 
                     expect(releaseSpy).toHaveBeenCalledTimes(1);
@@ -2032,13 +2048,13 @@ export function sharedLockFactoryTestSuite(
                         limit,
                     });
 
-                    class CustomError extends Error {}
-
                     const error = sharedLock.runReaderOrFail(() => {
-                        return Promise.reject(new CustomError());
+                        return Promise.reject(new UnexpectedErrorA());
                     });
 
-                    await expect(error).rejects.toBeInstanceOf(CustomError);
+                    await expect(error).rejects.toBeInstanceOf(
+                        UnexpectedErrorA,
+                    );
                 });
                 test("Should call handler function when key doesnt exists", async () => {
                     const key = "a";
@@ -2097,8 +2113,12 @@ export function sharedLockFactoryTestSuite(
                     });
                     try {
                         await sharedLock.runReaderOrFail(handlerFn);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(error instanceof LimitReachedReaderSemaphoreError)
+                        ) {
+                            throw error;
+                        }
                     }
 
                     await delay(delayBuffer);
@@ -2119,8 +2139,12 @@ export function sharedLockFactoryTestSuite(
                     });
                     try {
                         await sharedLock.runReaderOrFail(handlerFn);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(error instanceof LimitReachedReaderSemaphoreError)
+                        ) {
+                            throw error;
+                        }
                     }
 
                     await delay(delayBuffer);
@@ -2147,8 +2171,12 @@ export function sharedLockFactoryTestSuite(
                                 limit,
                             })
                             .runReaderOrFail(handlerFn);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(error instanceof LimitReachedReaderSemaphoreError)
+                        ) {
+                            throw error;
+                        }
                     }
 
                     await delay(delayBuffer);
@@ -2175,8 +2203,12 @@ export function sharedLockFactoryTestSuite(
                                 limit,
                             })
                             .runReaderOrFail(handlerFn);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(error instanceof LimitReachedReaderSemaphoreError)
+                        ) {
+                            throw error;
+                        }
                     }
 
                     await delay(delayBuffer);
@@ -2787,8 +2819,12 @@ export function sharedLockFactoryTestSuite(
 
                     try {
                         await sharedLock.acquireReaderOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(error instanceof LimitReachedReaderSemaphoreError)
+                        ) {
+                            throw error;
+                        }
                     }
 
                     const state = await sharedLock.getState();
@@ -3276,8 +3312,15 @@ export function sharedLockFactoryTestSuite(
 
                     try {
                         await sharedLock.releaseReaderOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(
+                                error instanceof
+                                FailedReleaseReaderSemaphoreError
+                            )
+                        ) {
+                            throw error;
+                        }
                     }
                     const state = await sharedLock.getState();
 
@@ -3628,8 +3671,15 @@ export function sharedLockFactoryTestSuite(
                     const newTtl = TimeSpan.fromMilliseconds(100);
                     try {
                         await sharedLock2.refreshReaderOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(
+                                error instanceof
+                                FailedRefreshReaderSemaphoreError
+                            )
+                        ) {
+                            throw error;
+                        }
                     }
                     await delayWithBuffer(newTtl);
 
@@ -3706,8 +3756,15 @@ export function sharedLockFactoryTestSuite(
                     const newTtl = TimeSpan.fromSeconds(20);
                     try {
                         await sharedLock.refreshReaderOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(
+                                error instanceof
+                                FailedRefreshReaderSemaphoreError
+                            )
+                        ) {
+                            throw error;
+                        }
                     }
 
                     const state = await sharedLock.getState();
@@ -4957,8 +5014,10 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock.acquireWriterOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedAcquireWriterLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -5001,8 +5060,10 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock.acquireWriterOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedAcquireWriterLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -5325,8 +5386,10 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock.releaseWriterOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedReleaseWriterLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -5370,8 +5433,10 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock.releaseWriterOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedReleaseWriterLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -5415,8 +5480,10 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock.releaseWriterOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedReleaseWriterLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -5461,8 +5528,10 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock.releaseWriterOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedReleaseWriterLockError)) {
+                            throw error;
+                        }
                     }
 
                     expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -5504,8 +5573,10 @@ export function sharedLockFactoryTestSuite(
 
                     try {
                         await sharedLock.releaseWriterOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedReleaseWriterLockError)) {
+                            throw error;
+                        }
                     }
 
                     await vi.waitFor(() => {
@@ -5921,8 +5992,10 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock.refreshWriterOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedRefreshWriterLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -5969,8 +6042,10 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock2.refreshWriterOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedRefreshWriterLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -6017,8 +6092,10 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock2.refreshWriterOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedRefreshWriterLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -6066,8 +6143,10 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock2.refreshWriterOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedRefreshWriterLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -6111,8 +6190,10 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock.refreshWriterOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedRefreshWriterLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -6155,8 +6236,10 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock.refreshWriterOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (!(error instanceof FailedRefreshWriterLockError)) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -6785,8 +6868,12 @@ export function sharedLockFactoryTestSuite(
                     });
                     try {
                         await sharedLock3.acquireReaderOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(error instanceof LimitReachedReaderSemaphoreError)
+                        ) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -7224,8 +7311,15 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock.releaseReaderOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(
+                                error instanceof
+                                FailedReleaseReaderSemaphoreError
+                            )
+                        ) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -7274,8 +7368,15 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock.releaseReaderOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(
+                                error instanceof
+                                FailedReleaseReaderSemaphoreError
+                            )
+                        ) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -7322,8 +7423,15 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock.releaseReaderOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(
+                                error instanceof
+                                FailedReleaseReaderSemaphoreError
+                            )
+                        ) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -7366,8 +7474,15 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock.releaseReaderOrFail();
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(
+                                error instanceof
+                                FailedReleaseReaderSemaphoreError
+                            )
+                        ) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -7755,8 +7870,15 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock2.refreshReaderOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(
+                                error instanceof
+                                FailedRefreshReaderSemaphoreError
+                            )
+                        ) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -7805,8 +7927,15 @@ export function sharedLockFactoryTestSuite(
                     );
                     try {
                         await sharedLock2.refreshReaderOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(
+                                error instanceof
+                                FailedRefreshReaderSemaphoreError
+                            )
+                        ) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -7849,8 +7978,15 @@ export function sharedLockFactoryTestSuite(
                     const newTtl = TimeSpan.fromMilliseconds(100);
                     try {
                         await sharedLock.refreshReaderOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(
+                                error instanceof
+                                FailedRefreshReaderSemaphoreError
+                            )
+                        ) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -7894,8 +8030,15 @@ export function sharedLockFactoryTestSuite(
                     const newTtl = TimeSpan.fromMilliseconds(100);
                     try {
                         await sharedLock.refreshReaderOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(
+                                error instanceof
+                                FailedRefreshReaderSemaphoreError
+                            )
+                        ) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);
@@ -7938,8 +8081,15 @@ export function sharedLockFactoryTestSuite(
                     const newTtl = TimeSpan.fromMilliseconds(100);
                     try {
                         await sharedLock.refreshReaderOrFail(newTtl);
-                    } catch {
-                        /* EMPTY */
+                    } catch (error: unknown) {
+                        if (
+                            !(
+                                error instanceof
+                                FailedRefreshReaderSemaphoreError
+                            )
+                        ) {
+                            throw error;
+                        }
                     }
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
- **Removed empty catch from shared-lock tests**
- **Removed empty catch from semaphore tests**
- **Removed empty catch from lock tests**
- **Removed empty catch from cache tests**
- **Removed empty catch from rate-limiter tests**
- **Removed empty catch from circuit-breaker tests**
- **Removed empty catch from collection tests**
- **Removed empty catch from file-storage tests**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved error handling across test suites in multiple modules (cache, circuit-breaker, collection, file-storage, lock, rate-limiter, semaphore, shared-lock) to catch unexpected failures while selectively suppressing only anticipated domain-specific errors, enhancing test reliability and failure detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->