### PR TITLE
simiplifying component settings

### DIFF
--- a/.changeset/updated-components-settings.md
+++ b/.changeset/updated-components-settings.md
@@ -1,0 +1,22 @@
+---
+"@daiso-tech/core": minor
+---
+
+Now you can passs both `IEventBus` or `IEventBusAdapter` to:
+- `CacheSettingsBase.eventBus`
+- `EventBusSettingsBase.eventBus`
+- `FileStorageSettingsBase.eventBus`
+- `CircuitBreakerFactorySettingsBase.eventBus`
+- `RateLimiterBreakerFactorySettingsBase.eventBus`
+- `LockFactorySettingsBase.eventBus`
+- `SemaphoreFactorySettingsBase.eventBus`
+- `SharedLockFactorySettingsBase.eventBus`
+
+Reduces boilerplate by eliminating the need to manually initialize an `EventBus` instance.
+
+Now you also can passs both `ILockFactoryBase`, `ILockAdapter` or `IDatabaseLockAdapter` to:
+
+- `CacheSettingsBase.lockFactory`
+- `FileStorageSettingsBase.lockFactory`
+
+Reduces boilerplate by eliminating the need to manually initialize an `LockFactory` instance.

--- a/src/cache/contracts/types.ts
+++ b/src/cache/contracts/types.ts
@@ -3,7 +3,6 @@
  */
 
 import { type ICacheAdapter } from "@/cache/contracts/cache-adapter.contract.js";
-import { type ICacheBase } from "@/cache/contracts/cache.contract.js";
 import { type IDatabaseCacheAdapter } from "@/cache/contracts/database-cache-adapter.contract.js";
 
 /**
@@ -13,11 +12,3 @@ import { type IDatabaseCacheAdapter } from "@/cache/contracts/database-cache-ada
 export type CacheAdapterVariants<TType = unknown> =
     | ICacheAdapter<TType>
     | IDatabaseCacheAdapter<TType>;
-
-/**
- * IMPORT_PATH: `"@daiso-tech/core/cache/contracts"`
- * @group Contracts
- */
-export type CacheVariants<TType = unknown> =
-    | ICacheBase<TType>
-    | CacheAdapterVariants<TType>;

--- a/src/cache/implementations/derivables/cache-resolver/cache-resolver.ts
+++ b/src/cache/implementations/derivables/cache-resolver/cache-resolver.ts
@@ -13,7 +13,7 @@ import {
     Cache,
     type CacheSettingsBase,
 } from "@/cache/implementations/derivables/cache/_module.js";
-import { type IEventBus } from "@/event-bus/contracts/_module.js";
+import { type EventBusInput } from "@/event-bus/contracts/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { type LockFactoryInput } from "@/lock/contracts/_module.js";
 import { type INamespace } from "@/namespace/contracts/_module.js";
@@ -104,7 +104,7 @@ export class CacheResolver<TAdapters extends string = string, TType = unknown>
         });
     }
 
-    setEventBus(eventBus: IEventBus): CacheResolver<TAdapters, TType> {
+    setEventBus(eventBus: EventBusInput): CacheResolver<TAdapters, TType> {
         return new CacheResolver({
             ...this.settings,
             eventBus,

--- a/src/cache/implementations/derivables/cache-resolver/cache-resolver.ts
+++ b/src/cache/implementations/derivables/cache-resolver/cache-resolver.ts
@@ -15,7 +15,7 @@ import {
 } from "@/cache/implementations/derivables/cache/_module.js";
 import { type IEventBus } from "@/event-bus/contracts/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
-import { type ILockFactoryBase } from "@/lock/contracts/_module.js";
+import { type LockFactoryInput } from "@/lock/contracts/_module.js";
 import { type INamespace } from "@/namespace/contracts/_module.js";
 import { type ITimeSpan } from "@/time-span/contracts/_module.js";
 import {
@@ -150,7 +150,7 @@ export class CacheResolver<TAdapters extends string = string, TType = unknown>
     }
 
     setLockFactory(
-        lockFactory: ILockFactoryBase,
+        lockFactory: LockFactoryInput,
     ): CacheResolver<TAdapters, TType> {
         return new CacheResolver({
             ...this.settings,

--- a/src/cache/implementations/derivables/cache/cache.ts
+++ b/src/cache/implementations/derivables/cache/cache.ts
@@ -25,9 +25,12 @@ import { EventBus } from "@/event-bus/implementations/derivables/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
-import { type ILockFactoryBase } from "@/lock/contracts/_module.js";
+import {
+    type ILockFactoryBase,
+    type LockFactoryInput,
+} from "@/lock/contracts/_module.js";
 import { NoOpLockAdapter } from "@/lock/implementations/adapters/_module.js";
-import { LockFactory } from "@/lock/implementations/derivables/_module-exports.js";
+import { resolveLockFactoryInput } from "@/lock/implementations/derivables/_module.js";
 import { type INamespace } from "@/namespace/contracts/_module.js";
 import { NoOpNamespace } from "@/namespace/implementations/_module.js";
 import { type ITimeSpan } from "@/time-span/contracts/_module.js";
@@ -121,15 +124,16 @@ export type CacheSettingsBase<TType = unknown> = {
     executionContext?: IExecutionContext;
 
     /**
-     * You can provide an `ILockFactoryBase` instance to handle locking when `GetOrAddSettings.enableLocking` is set to true during a `getOrAdd` call.
+     * You can provide an `ILockFactoryBase`, an `ILockAdapter` or an `IDatabaseLockAdapter` instance to handle locking when `GetOrAddSettings.enableLocking` is set to true during a `getOrAdd` call.
+     * If you provide an adapter, it will be automatically wrapped in an `LockFactory` instance.
      * @default
      * ```ts
-     * lockFactory = new LockFactory({
-     *   adapter: new NoOpLockAdapter(),
-     * })
+     * import { NoOpLockAdapter } from "@daiso-tech/core/lock/no-op-lock-adapter";
+     *
+     * new NoOpLockAdapter()
      * ```
      */
-    lockFactory?: ILockFactoryBase;
+    lockFactory?: LockFactoryInput;
 };
 
 /**
@@ -206,12 +210,10 @@ export class Cache<TType = unknown> implements ICache<TType> {
             executionContext = new ExecutionContext(
                 new NoOpExecutionContextAdapter(),
             ),
-            lockFactory = new LockFactory({
-                adapter: new NoOpLockAdapter(),
-            }),
+            lockFactory = new NoOpLockAdapter(),
         } = settings;
 
-        this.lockFactory = lockFactory;
+        this.lockFactory = resolveLockFactoryInput(namespace, lockFactory);
         this.executionContext = executionContext;
         this.waitUntil = waitUntil;
         this.shouldValidateOutput = shouldValidateOutput;

--- a/src/cache/implementations/derivables/cache/cache.ts
+++ b/src/cache/implementations/derivables/cache/cache.ts
@@ -26,7 +26,11 @@ import {
     type IEventBusAdapter,
 } from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
-import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
+import {
+    resolveEventBusInput,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type EventBus,
+} from "@/event-bus/implementations/derivables/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -89,8 +93,8 @@ export type CacheSettingsBase<TType = unknown> = {
     namespace?: INamespace;
 
     /**
-     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the components events.
-     * If you provide an adapter, it will be automatically wrapped in an {@link IEventBus | `IEventBus`} instance.
+     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the component's events.
+     * If you provide an adapter, it will be automatically wrapped in an {@link EventBus | `EventBus`} instance.
      *
      * @default
      * ```ts

--- a/src/cache/implementations/derivables/cache/cache.ts
+++ b/src/cache/implementations/derivables/cache/cache.ts
@@ -22,6 +22,8 @@ import { resolveCacheAdapter } from "@/cache/implementations/derivables/cache/re
 import {
     type EventBusInput,
     type IEventBus,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type IEventBusAdapter,
 } from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
 import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
@@ -31,9 +33,17 @@ import { ExecutionContext } from "@/execution-context/implementations/derivables
 import {
     type ILockFactoryBase,
     type LockFactoryInput,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type ILockAdapter,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type IDatabaseLockAdapter,
 } from "@/lock/contracts/_module.js";
 import { NoOpLockAdapter } from "@/lock/implementations/adapters/_module.js";
-import { resolveLockFactoryInput } from "@/lock/implementations/derivables/_module.js";
+import {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type LockFactory,
+    resolveLockFactoryInput,
+} from "@/lock/implementations/derivables/_module.js";
 import { type INamespace } from "@/namespace/contracts/_module.js";
 import { NoOpNamespace } from "@/namespace/implementations/_module.js";
 import { type ITimeSpan } from "@/time-span/contracts/_module.js";
@@ -79,8 +89,8 @@ export type CacheSettingsBase<TType = unknown> = {
     namespace?: INamespace;
 
     /**
-     * You can provide an `IEventBus` or an `IEventBusAdapter` instance to handle the components events.
-     * If you provide an adapter, it will be automatically wrapped in an `IEventBus` instance.
+     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the components events.
+     * If you provide an adapter, it will be automatically wrapped in an {@link IEventBus | `IEventBus`} instance.
      *
      * @default
      * ```ts
@@ -127,8 +137,8 @@ export type CacheSettingsBase<TType = unknown> = {
     executionContext?: IExecutionContext;
 
     /**
-     * You can provide an `ILockFactoryBase`, an `ILockAdapter` or an `IDatabaseLockAdapter` instance to handle locking when `GetOrAddSettings.enableLocking` is set to true during a `getOrAdd` call.
-     * If you provide an adapter, it will be automatically wrapped in an `LockFactory` instance.
+     * You can provide an {@link ILockFactoryBase | `ILockFactoryBase`}, an {@link ILockAdapter | `ILockAdapter`} or an {@link IDatabaseLockAdapter | `IDatabaseLockAdapter`} instance to handle locking when {@link GetOrAddSettings | `GetOrAddSettings.enableLocking`} is set to true during a `getOrAdd` call.
+     * If you provide an adapter, it will be automatically wrapped in an {@link LockFactory | `LockFactory`} instance.
      * @default
      * ```ts
      * import { NoOpLockAdapter } from "@daiso-tech/core/lock/no-op-lock-adapter";

--- a/src/cache/implementations/derivables/cache/cache.ts
+++ b/src/cache/implementations/derivables/cache/cache.ts
@@ -79,6 +79,9 @@ export type CacheSettingsBase<TType = unknown> = {
     namespace?: INamespace;
 
     /**
+     * You can provide an `IEventBus` or an `IEventBusAdapter` instance to handle the components events.
+     * If you provide an adapter, it will be automatically wrapped in an `IEventBus` instance.
+     *
      * @default
      * ```ts
      * import { NoOpEventBusAdapter } from "@daiso-tech/core/event-bus/no-op-event-bus-adapter";

--- a/src/cache/implementations/derivables/cache/cache.ts
+++ b/src/cache/implementations/derivables/cache/cache.ts
@@ -19,9 +19,12 @@ import {
 } from "@/cache/contracts/_module.js";
 import { type CacheAdapterVariants } from "@/cache/contracts/types.js";
 import { resolveCacheAdapter } from "@/cache/implementations/derivables/cache/resolve-cache-adapter.js";
-import { type IEventBus } from "@/event-bus/contracts/_module.js";
+import {
+    type EventBusInput,
+    type IEventBus,
+} from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
-import { EventBus } from "@/event-bus/implementations/derivables/_module.js";
+import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -78,15 +81,12 @@ export type CacheSettingsBase<TType = unknown> = {
     /**
      * @default
      * ```ts
-     * import { EventBus } from "@daiso-tech/core/event-bus";
      * import { NoOpEventBusAdapter } from "@daiso-tech/core/event-bus/no-op-event-bus-adapter";
      *
-     * new EventBus({
-     *   adapter: new NoOpEventBusAdapter()
-     * })
+     * new NoOpEventBusAdapter()
      * ```
      */
-    eventBus?: IEventBus;
+    eventBus?: EventBusInput;
 
     /**
      * You can decide the default ttl value. If null is passed then no ttl will be used by default.
@@ -201,9 +201,7 @@ export class Cache<TType = unknown> implements ICache<TType> {
             schema,
             namespace = new NoOpNamespace(),
             adapter,
-            eventBus = new EventBus<any>({
-                adapter: new NoOpEventBusAdapter(),
-            }),
+            eventBus = new NoOpEventBusAdapter(),
             defaultTtl = null,
             defaultJitter = 0.2,
             waitUntil = defaultWaitUntil,
@@ -221,7 +219,7 @@ export class Cache<TType = unknown> implements ICache<TType> {
         this.namespace = namespace;
         this.defaultTtl =
             defaultTtl === null ? null : TimeSpan.fromTimeSpan(defaultTtl);
-        this.eventBus = eventBus;
+        this.eventBus = resolveEventBusInput(namespace, eventBus);
         this.adapter = resolveCacheAdapter(adapter);
         this.defaultJitter = defaultJitter;
     }

--- a/src/circuit-breaker/implementations/derivables/circuit-breaker-factory-resolver/circuit-breaker-factory-resolver.ts
+++ b/src/circuit-breaker/implementations/derivables/circuit-breaker-factory-resolver/circuit-breaker-factory-resolver.ts
@@ -12,7 +12,7 @@ import {
     CircuitBreakerFactory,
     type CircuitBreakerFactorySettingsBase,
 } from "@/circuit-breaker/implementations/derivables/circuit-breaker-factory/_module.js";
-import { type IEventBus } from "@/event-bus/contracts/_module.js";
+import { type EventBusInput } from "@/event-bus/contracts/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { type INamespace } from "@/namespace/contracts/_module.js";
 import { type ITimeSpan } from "@/time-span/contracts/_module.js";
@@ -101,7 +101,9 @@ export class CircuitBreakerFactoryResolver<TAdapters extends string>
         });
     }
 
-    setEventBus(eventBus: IEventBus): CircuitBreakerFactoryResolver<TAdapters> {
+    setEventBus(
+        eventBus: EventBusInput,
+    ): CircuitBreakerFactoryResolver<TAdapters> {
         return new CircuitBreakerFactoryResolver({
             ...this.settings,
             eventBus,

--- a/src/circuit-breaker/implementations/derivables/circuit-breaker-factory-resolver/database-circuit-breaker-factory-resolver.ts
+++ b/src/circuit-breaker/implementations/derivables/circuit-breaker-factory-resolver/database-circuit-breaker-factory-resolver.ts
@@ -15,7 +15,7 @@ import {
     CircuitBreakerFactory,
     type CircuitBreakerFactorySettingsBase,
 } from "@/circuit-breaker/implementations/derivables/circuit-breaker-factory/_module.js";
-import { type IEventBus } from "@/event-bus/contracts/_module.js";
+import { type EventBusInput } from "@/event-bus/contracts/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { type INamespace } from "@/namespace/contracts/_module.js";
 import { type ITimeSpan } from "@/time-span/contracts/_module.js";
@@ -131,7 +131,7 @@ export class DatabaseCircuitBreakerFactoryResolver<TAdapters extends string>
     }
 
     setEventBus(
-        eventBus: IEventBus,
+        eventBus: EventBusInput,
     ): DatabaseCircuitBreakerFactoryResolver<TAdapters> {
         return new DatabaseCircuitBreakerFactoryResolver({
             ...this.settings,

--- a/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker-factory.ts
+++ b/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker-factory.ts
@@ -21,7 +21,11 @@ import {
     type IEventBusAdapter,
 } from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
-import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
+import {
+    resolveEventBusInput,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type EventBus,
+} from "@/event-bus/implementations/derivables/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -59,8 +63,8 @@ export type CircuitBreakerFactorySettingsBase = {
     namespace?: INamespace;
 
     /**
-     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the components events.
-     * If you provide an adapter, it will be automatically wrapped in an {@link IEventBus | `IEventBus`} instance.
+     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the component's events.
+     * If you provide an adapter, it will be automatically wrapped in an {@link EventBus | `EventBus`} instance.
      *
      * @default
      * ```ts

--- a/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker-factory.ts
+++ b/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker-factory.ts
@@ -17,6 +17,8 @@ import { CircuitBreaker } from "@/circuit-breaker/implementations/derivables/cir
 import {
     type EventBusInput,
     type IEventBus,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type IEventBusAdapter,
 } from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
 import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
@@ -57,8 +59,8 @@ export type CircuitBreakerFactorySettingsBase = {
     namespace?: INamespace;
 
     /**
-     * You can provide an `IEventBus` or an `IEventBusAdapter` instance to handle the components events.
-     * If you provide an adapter, it will be automatically wrapped in an `IEventBus` instance.
+     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the components events.
+     * If you provide an adapter, it will be automatically wrapped in an {@link IEventBus | `IEventBus`} instance.
      *
      * @default
      * ```ts

--- a/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker-factory.ts
+++ b/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker-factory.ts
@@ -14,9 +14,12 @@ import {
 } from "@/circuit-breaker/contracts/_module.js";
 import { CircuitBreakerSerdeTransformer } from "@/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker-serde-transformer.js";
 import { CircuitBreaker } from "@/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker.js";
-import { type IEventBus } from "@/event-bus/contracts/_module.js";
+import {
+    type EventBusInput,
+    type IEventBus,
+} from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
-import { EventBus } from "@/event-bus/implementations/derivables/_module.js";
+import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -56,15 +59,12 @@ export type CircuitBreakerFactorySettingsBase = {
     /**
      * @default
      * ```ts
-     * import { EventBus } from "@daiso-tech/core/event-bus";
      * import { NoOpEventBusAdapter } from "@daiso-tech/core/event-bus/no-op-event-bus-adapter";
      *
-     * new EventBus({
-     *   adapter: new NoOpEventBusAdapter()
-     * })
+     * new NoOpEventBusAdapter()
      * ```
      */
-    eventBus?: IEventBus;
+    eventBus?: EventBusInput;
 
     /**
      * You can set the default `ErrorPolicy`
@@ -220,9 +220,7 @@ export class CircuitBreakerFactory implements ICircuitBreakerFactory {
         const {
             enableAsyncTracking = true,
             namespace = new NoOpNamespace(),
-            eventBus = new EventBus({
-                adapter: new NoOpEventBusAdapter(),
-            }),
+            eventBus = new NoOpEventBusAdapter(),
             adapter,
             defaultSlowCallTime = TimeSpan.fromSeconds(10),
             defaultTrigger = CIRCUIT_BREAKER_TRIGGER.BOTH,
@@ -239,7 +237,7 @@ export class CircuitBreakerFactory implements ICircuitBreakerFactory {
         this.waitUntil = waitUntil;
         this.enableAsyncTracking = enableAsyncTracking;
         this.namespace = namespace;
-        this.eventBus = eventBus;
+        this.eventBus = resolveEventBusInput(namespace, eventBus);
         this.adapter = adapter;
         this.defaultSlowCallTime = TimeSpan.fromTimeSpan(defaultSlowCallTime);
         this.defaultTrigger = defaultTrigger;

--- a/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker-factory.ts
+++ b/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker-factory.ts
@@ -57,6 +57,9 @@ export type CircuitBreakerFactorySettingsBase = {
     namespace?: INamespace;
 
     /**
+     * You can provide an `IEventBus` or an `IEventBusAdapter` instance to handle the components events.
+     * If you provide an adapter, it will be automatically wrapped in an `IEventBus` instance.
+     *
      * @default
      * ```ts
      * import { NoOpEventBusAdapter } from "@daiso-tech/core/event-bus/no-op-event-bus-adapter";

--- a/src/event-bus/contracts/_module-exports.ts
+++ b/src/event-bus/contracts/_module-exports.ts
@@ -1,3 +1,4 @@
 export type * from "@/event-bus/contracts/event-bus-adapter.contract.js";
 export type * from "@/event-bus/contracts/event-bus-resolver.contract.js";
 export type * from "@/event-bus/contracts/event-bus.contract.js";
+export type * from "@/event-bus/contracts/types.js";

--- a/src/event-bus/contracts/_module.ts
+++ b/src/event-bus/contracts/_module.ts
@@ -1,3 +1,4 @@
 export type * from "@/event-bus/contracts/event-bus-adapter.contract.js";
 export type * from "@/event-bus/contracts/event-bus-resolver.contract.js";
 export type * from "@/event-bus/contracts/event-bus.contract.js";
+export type * from "@/event-bus/contracts/types.js";

--- a/src/event-bus/contracts/types.ts
+++ b/src/event-bus/contracts/types.ts
@@ -1,0 +1,17 @@
+/**
+ * @module EventBus
+ */
+
+import { type IEventBusAdapter } from "@/event-bus/contracts/event-bus-adapter.contract.js";
+import {
+    type BaseEventMap,
+    type IEventBus,
+} from "@/event-bus/contracts/event-bus.contract.js";
+
+/**
+ * IMPORT_PATH: `"@daiso-tech/core/lock/contracts"`
+ * @group Contracts
+ */
+export type EventBusInput<TEventMap extends BaseEventMap = BaseEventMap> =
+    | IEventBusAdapter
+    | IEventBus<TEventMap>;

--- a/src/event-bus/implementations/derivables/event-bus/_module.ts
+++ b/src/event-bus/implementations/derivables/event-bus/_module.ts
@@ -1,1 +1,2 @@
 export * from "@/event-bus/implementations/derivables/event-bus/event-bus.js";
+export * from "@/event-bus/implementations/derivables/event-bus/resolve-event-bus-input.js";

--- a/src/event-bus/implementations/derivables/event-bus/is-event-bus.test.ts
+++ b/src/event-bus/implementations/derivables/event-bus/is-event-bus.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "vitest";
+
+import {
+    type BaseEvent,
+    type EventListener,
+    type EventListenerFn,
+    type EventWithType,
+    type IEventBus,
+    type IEventBusAdapter,
+    type Unsubscribe,
+} from "@/event-bus/contracts/_module.js";
+import { isEventBus } from "@/event-bus/implementations/derivables/event-bus/is-event-bus.js";
+import { type IReadableContext } from "@/execution-context/contracts/execution-context.contract.js";
+import { type OneOrArray } from "@/utilities/_module.js";
+
+describe("function: isEventBus", () => {
+    test("Should return true when given IEventBus", () => {
+        const eventBus: IEventBus = {
+            addListener<TEventName extends string>(
+                _eventNames: OneOrArray<TEventName>,
+                _listener: EventListener<EventWithType<BaseEvent, string>>,
+            ): Promise<void> {
+                throw new Error("Method not implemented.");
+            },
+
+            removeListener<TEventName extends string>(
+                _eventNames: OneOrArray<TEventName>,
+                _listener: EventListener<EventWithType<BaseEvent, string>>,
+            ): Promise<void> {
+                throw new Error("Method not implemented.");
+            },
+
+            listenOnce<TEventName extends string>(
+                _eventName: TEventName,
+                _listener: EventListener<EventWithType<BaseEvent, string>>,
+            ): Promise<void> {
+                throw new Error("Method not implemented.");
+            },
+
+            asPromise<TEventName extends string>(
+                _eventName: TEventName,
+            ): Promise<EventWithType<BaseEvent, string>> {
+                throw new Error("Method not implemented.");
+            },
+
+            subscribeOnce<TEventName extends string>(
+                _eventName: TEventName,
+                _listener: EventListener<EventWithType<BaseEvent, string>>,
+            ): Promise<Unsubscribe> {
+                throw new Error("Method not implemented.");
+            },
+
+            subscribe<TEventName extends string>(
+                _eventNames: OneOrArray<TEventName>,
+                _listener: EventListener<EventWithType<BaseEvent, string>>,
+            ): Promise<Unsubscribe> {
+                throw new Error("Method not implemented.");
+            },
+
+            dispatch<TEventName extends string>(
+                _eventName: TEventName,
+                _event: BaseEvent,
+            ): Promise<void> {
+                throw new Error("Method not implemented.");
+            },
+        };
+
+        expect(isEventBus(eventBus)).toBe(true);
+    });
+    test("Should return false when given IEventBusAdapter", () => {
+        const eventBusAdapter: IEventBusAdapter = {
+            dispatch(
+                _context: IReadableContext,
+                _eventName: string,
+                _eventData: BaseEvent,
+            ): Promise<void> {
+                throw new Error("Method not implemented.");
+            },
+
+            addListener(
+                _context: IReadableContext,
+                _eventName: string,
+                _listener: EventListenerFn<BaseEvent>,
+            ): Promise<void> {
+                throw new Error("Method not implemented.");
+            },
+
+            removeListener(
+                _context: IReadableContext,
+                _eventName: string,
+                _listener: EventListenerFn<BaseEvent>,
+            ): Promise<void> {
+                throw new Error("Method not implemented.");
+            },
+        };
+
+        expect(isEventBus(eventBusAdapter)).toBe(false);
+    });
+});

--- a/src/event-bus/implementations/derivables/event-bus/is-event-bus.ts
+++ b/src/event-bus/implementations/derivables/event-bus/is-event-bus.ts
@@ -1,0 +1,22 @@
+/**
+ * @module EventBus
+ */
+
+import {
+    type BaseEventMap,
+    type EventBusInput,
+    type IEventBus,
+} from "@/event-bus/contracts/_module.js";
+
+/**
+ * @internal
+ */
+export function isEventBus<TEventMap extends BaseEventMap = BaseEventMap>(
+    eventBusInput: EventBusInput<TEventMap>,
+): eventBusInput is IEventBus<TEventMap> {
+    return (
+        typeof eventBusInput === "object" &&
+        "subscribe" in eventBusInput &&
+        typeof eventBusInput.subscribe === "function"
+    );
+}

--- a/src/event-bus/implementations/derivables/event-bus/resolve-event-bus-input.ts
+++ b/src/event-bus/implementations/derivables/event-bus/resolve-event-bus-input.ts
@@ -1,0 +1,27 @@
+/**
+ * @module EventBus
+ */
+
+import {
+    type EventBusInput,
+    type IEventBus,
+} from "@/event-bus/contracts/_module.js";
+import { EventBus } from "@/event-bus/implementations/derivables/event-bus/event-bus.js";
+import { isEventBus } from "@/event-bus/implementations/derivables/event-bus/is-event-bus.js";
+import { type INamespace } from "@/namespace/contracts/_module.js";
+
+/**
+ * @internal
+ */
+export function resolveEventBusInput(
+    namespace: INamespace,
+    eventBusInput: EventBusInput,
+): IEventBus {
+    if (isEventBus(eventBusInput)) {
+        return eventBusInput;
+    }
+    return new EventBus({
+        namespace,
+        adapter: eventBusInput,
+    });
+}

--- a/src/file-storage/implementations/derivables/file-storage-resolver/file-storage-resolver.ts
+++ b/src/file-storage/implementations/derivables/file-storage-resolver/file-storage-resolver.ts
@@ -15,7 +15,7 @@ import {
     type FileKeyValidator,
     type FileStorageSettingsBase,
 } from "@/file-storage/implementations/derivables/file-storage/_module.js";
-import { type ILockFactoryBase } from "@/lock/contracts/_module.js";
+import { type LockFactoryInput } from "@/lock/contracts/_module.js";
 import { type INamespace } from "@/namespace/contracts/_module.js";
 import {
     DefaultAdapterNotDefinedError,
@@ -181,7 +181,7 @@ export class FileStorageResolver<TAdapters extends string = string>
     }
 
     setLockFactory(
-        lockFactory: ILockFactoryBase,
+        lockFactory: LockFactoryInput,
     ): FileStorageResolver<TAdapters> {
         return new FileStorageResolver({
             ...this.settings,

--- a/src/file-storage/implementations/derivables/file-storage-resolver/file-storage-resolver.ts
+++ b/src/file-storage/implementations/derivables/file-storage-resolver/file-storage-resolver.ts
@@ -2,7 +2,7 @@
  * @module FileStorage
  */
 
-import { type IEventBus } from "@/event-bus/contracts/_module.js";
+import { type EventBusInput } from "@/event-bus/contracts/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import {
     type IFileStorage,
@@ -89,7 +89,7 @@ export class FileStorageResolver<TAdapters extends string = string>
         });
     }
 
-    setEventBus(eventBus: IEventBus): FileStorageResolver<TAdapters> {
+    setEventBus(eventBus: EventBusInput): FileStorageResolver<TAdapters> {
         return new FileStorageResolver({
             ...this.settings,
             eventBus,

--- a/src/file-storage/implementations/derivables/file-storage/file-storage.ts
+++ b/src/file-storage/implementations/derivables/file-storage/file-storage.ts
@@ -24,9 +24,12 @@ import {
 import { FileSerdeTransformer } from "@/file-storage/implementations/derivables/file-storage/file-serde-transformer.js";
 import { File } from "@/file-storage/implementations/derivables/file-storage/file.js";
 import { resolveFileStorageAdapter } from "@/file-storage/implementations/derivables/file-storage/resolve-file-storage-adapter.js";
-import { type ILockFactoryBase } from "@/lock/contracts/_module.js";
+import {
+    type ILockFactoryBase,
+    type LockFactoryInput,
+} from "@/lock/contracts/_module.js";
 import { NoOpLockAdapter } from "@/lock/implementations/adapters/_module.js";
-import { LockFactory } from "@/lock/implementations/derivables/_module-exports.js";
+import { resolveLockFactoryInput } from "@/lock/implementations/derivables/_module.js";
 import {
     useFactory,
     type MiddlewareFn,
@@ -200,15 +203,16 @@ export type FileStorageSettingsBase = {
     executionContext?: IExecutionContext;
 
     /**
-     * You can provide an `ILockFactoryBase` instance to handle locking when write methods are called.
+     * You can provide an `ILockFactoryBase`, an `ILockAdapter` or an `IDatabaseLockAdapter` instance to handle locking when write methods are called.
+     * If you provide an adapter, it will be automatically wrapped in an `LockFactory` instance.
      * @default
      * ```ts
-     * lockFactory = new LockFactory({
-     *   adapter: new NoOpLockAdapter(),
-     * })
+     * import { NoOpLockAdapter } from "@daiso-tech/core/lock/no-op-lock-adapter";
+     *
+     * new NoOpLockAdapter()
      * ```
      */
-    lockFactory?: ILockFactoryBase;
+    lockFactory?: LockFactoryInput;
 };
 
 /**
@@ -288,12 +292,10 @@ export class FileStorage implements IFileStorage {
             executionContext = new ExecutionContext(
                 new NoOpExecutionContextAdapter(),
             ),
-            lockFactory = new LockFactory({
-                adapter: new NoOpLockAdapter(),
-            }),
+            lockFactory = new NoOpLockAdapter(),
         } = settings;
 
-        this.lockFactory = lockFactory;
+        this.lockFactory = resolveLockFactoryInput(namespace, lockFactory);
         this.use = useFactory({ executionContext });
         this.executionContext = executionContext;
         this.waitUntil = waitUntil;

--- a/src/file-storage/implementations/derivables/file-storage/file-storage.ts
+++ b/src/file-storage/implementations/derivables/file-storage/file-storage.ts
@@ -153,6 +153,9 @@ export type FileStorageSettingsBase = {
     urlAdapter?: Partial<IFileUrlAdapter>;
 
     /**
+     * You can provide an `IEventBus` or an `IEventBusAdapter` instance to handle the components events.
+     * If you provide an adapter, it will be automatically wrapped in an `IEventBus` instance.
+     *
      * @default
      * ```ts
      * import { NoOpEventBusAdapter } from "@daiso-tech/core/event-bus/no-op-event-bus-adapter";

--- a/src/file-storage/implementations/derivables/file-storage/file-storage.ts
+++ b/src/file-storage/implementations/derivables/file-storage/file-storage.ts
@@ -8,7 +8,11 @@ import {
     type IEventBusAdapter,
 } from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
-import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
+import {
+    resolveEventBusInput,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type EventBus,
+} from "@/event-bus/implementations/derivables/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -164,8 +168,8 @@ export type FileStorageSettingsBase = {
     urlAdapter?: Partial<IFileUrlAdapter>;
 
     /**
-     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the components events.
-     * If you provide an adapter, it will be automatically wrapped in an {@link IEventBus | `IEventBus`} instance.
+     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the component's events.
+     * If you provide an adapter, it will be automatically wrapped in an {@link EventBus | `EventBus`} instance.
      *
      * @default
      * ```ts

--- a/src/file-storage/implementations/derivables/file-storage/file-storage.ts
+++ b/src/file-storage/implementations/derivables/file-storage/file-storage.ts
@@ -1,9 +1,12 @@
 /**
  * @module FileStorage
  */
-import { type IEventBus } from "@/event-bus/contracts/_module.js";
+import {
+    type EventBusInput,
+    type IEventBus,
+} from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
-import { EventBus } from "@/event-bus/implementations/derivables/_module.js";
+import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -152,15 +155,12 @@ export type FileStorageSettingsBase = {
     /**
      * @default
      * ```ts
-     * import { EventBus } from "@daiso-tech/core/event-bus";
      * import { NoOpEventBusAdapter } from "@daiso-tech/core/event-bus/no-op-event-bus-adapter";
      *
-     * new EventBus({
-     *   adapter: new NoOpEventBusAdapter()
-     * })
+     * new NoOpEventBusAdapter()
      * ```
      */
-    eventBus?: IEventBus;
+    eventBus?: EventBusInput;
 
     /**
      * You can pass an {@link ISerderRegister | `ISerderRegister`} instance to the {@link FileStorage | `FileStorage`} to register the file's serialization and deserialization logic for the provided adapter.
@@ -275,9 +275,7 @@ export class FileStorage implements IFileStorage {
         const {
             adapter,
             namespace = new NoOpNamespace(),
-            eventBus = new EventBus({
-                adapter: new NoOpEventBusAdapter(),
-            }),
+            eventBus = new NoOpEventBusAdapter(),
             onlyLowercase = false,
             keyValidator = defaultKeyValidator,
             serde = new Serde(new NoOpSerdeAdapter()),
@@ -309,7 +307,7 @@ export class FileStorage implements IFileStorage {
         this.defaultContentLanguage = defaultContentLanguage;
         this.adapter = resolveFileStorageAdapter(adapter, urlAdapter);
         this.namespace = namespace;
-        this.eventBus = eventBus;
+        this.eventBus = resolveEventBusInput(namespace, eventBus);
         this.serde = serde;
         this.serdeTransformerName = serdeTransformerName;
         this.registerToSerde();

--- a/src/file-storage/implementations/derivables/file-storage/file-storage.ts
+++ b/src/file-storage/implementations/derivables/file-storage/file-storage.ts
@@ -4,6 +4,8 @@
 import {
     type EventBusInput,
     type IEventBus,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type IEventBusAdapter,
 } from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
 import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
@@ -30,9 +32,18 @@ import { resolveFileStorageAdapter } from "@/file-storage/implementations/deriva
 import {
     type ILockFactoryBase,
     type LockFactoryInput,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type IDatabaseLockAdapter,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type ILockAdapter,
 } from "@/lock/contracts/_module.js";
+// eslint-disable-next-line import/order
 import { NoOpLockAdapter } from "@/lock/implementations/adapters/_module.js";
-import { resolveLockFactoryInput } from "@/lock/implementations/derivables/_module.js";
+import {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type LockFactory,
+    resolveLockFactoryInput,
+} from "@/lock/implementations/derivables/_module.js";
 import {
     useFactory,
     type MiddlewareFn,
@@ -153,8 +164,8 @@ export type FileStorageSettingsBase = {
     urlAdapter?: Partial<IFileUrlAdapter>;
 
     /**
-     * You can provide an `IEventBus` or an `IEventBusAdapter` instance to handle the components events.
-     * If you provide an adapter, it will be automatically wrapped in an `IEventBus` instance.
+     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the components events.
+     * If you provide an adapter, it will be automatically wrapped in an {@link IEventBus | `IEventBus`} instance.
      *
      * @default
      * ```ts
@@ -206,8 +217,8 @@ export type FileStorageSettingsBase = {
     executionContext?: IExecutionContext;
 
     /**
-     * You can provide an `ILockFactoryBase`, an `ILockAdapter` or an `IDatabaseLockAdapter` instance to handle locking when write methods are called.
-     * If you provide an adapter, it will be automatically wrapped in an `LockFactory` instance.
+     * You can provide an {@link ILockFactoryBase | `ILockFactoryBase`}, an {@link ILockAdapter | `ILockAdapter`} or an {@link IDatabaseLockAdapter | `IDatabaseLockAdapter`} instance to handle locking when write methods are called.
+     * If you provide an adapter, it will be automatically wrapped in an {@link LockFactory | `LockFactory`} instance.
      * @default
      * ```ts
      * import { NoOpLockAdapter } from "@daiso-tech/core/lock/no-op-lock-adapter";

--- a/src/lock/contracts/types.ts
+++ b/src/lock/contracts/types.ts
@@ -4,9 +4,16 @@
 
 import { type IDatabaseLockAdapter } from "@/lock/contracts/database-lock-adapter.contract.js";
 import { type ILockAdapter } from "@/lock/contracts/lock-adapter.contract.js";
+import { type ILockFactoryBase } from "@/lock/contracts/lock-factory.contract.js";
 
 /**
  * IMPORT_PATH: `"@daiso-tech/core/lock/contracts"`
  * @group Contracts
  */
 export type LockAdapterVariants = ILockAdapter | IDatabaseLockAdapter;
+
+/**
+ * IMPORT_PATH: `"@daiso-tech/core/lock/contracts"`
+ * @group Contracts
+ */
+export type LockFactoryInput = LockAdapterVariants | ILockFactoryBase;

--- a/src/lock/implementations/derivables/lock-factory-resolver/lock-factory-resolver.ts
+++ b/src/lock/implementations/derivables/lock-factory-resolver/lock-factory-resolver.ts
@@ -1,7 +1,7 @@
 /**
  * @module Lock
  */
-import { type IEventBus } from "@/event-bus/contracts/_module.js";
+import { type EventBusInput } from "@/event-bus/contracts/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import {
     type ILockFactoryResolver,
@@ -99,7 +99,7 @@ export class LockFactoryResolver<TAdapters extends string>
         });
     }
 
-    setEventBus(eventBus: IEventBus): LockFactoryResolver<TAdapters> {
+    setEventBus(eventBus: EventBusInput): LockFactoryResolver<TAdapters> {
         return new LockFactoryResolver({
             ...this.settings,
             eventBus,

--- a/src/lock/implementations/derivables/lock-factory/_module.ts
+++ b/src/lock/implementations/derivables/lock-factory/_module.ts
@@ -1,2 +1,3 @@
 export * from "@/lock/implementations/derivables/lock-factory/lock-factory.js";
 export * from "@/lock/implementations/derivables/lock-factory/resolve-lock-adapter.js";
+export * from "@/lock/implementations/derivables/lock-factory/resolve-lock-factory-input.js";

--- a/src/lock/implementations/derivables/lock-factory/is-lock-factory.test.ts
+++ b/src/lock/implementations/derivables/lock-factory/is-lock-factory.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect } from "vitest";
+
+import { type IReadableContext } from "@/execution-context/contracts/execution-context.contract.js";
+import {
+    type ILockAdapter,
+    type ILockAdapterState,
+    type ILockFactoryBase,
+    type LockFactoryCreateSettings,
+    type ILock,
+    type IDatabaseLockAdapter,
+    type IDatabaseLockTransaction,
+    type ILockData,
+    type ILockExpirationData,
+} from "@/lock/contracts/_module.js";
+import { isLockFactory } from "@/lock/implementations/derivables/lock-factory/is-lock-factory.js";
+import { type TimeSpan } from "@/time-span/implementations/time-span.js";
+import { type InvokableFn } from "@/utilities/_module.js";
+
+describe("function: isLockFactory", () => {
+    test("Should return true when given ILockFactoryBase", () => {
+        const lockFactory: ILockFactoryBase = {
+            create: function (
+                _key: string,
+                _settings?: LockFactoryCreateSettings,
+            ): ILock {
+                throw new Error("Function not implemented.");
+            },
+        };
+
+        expect(isLockFactory(lockFactory)).toBe(true);
+    });
+    test("Should return false when given ILockAdapter", () => {
+        const lockAdapter: ILockAdapter = {
+            acquire: function (
+                _context: IReadableContext,
+                _key: string,
+                _lockId: string,
+                _ttl: TimeSpan | null,
+            ): Promise<boolean> {
+                throw new Error("Function not implemented.");
+            },
+            release: function (
+                _context: IReadableContext,
+                _key: string,
+                _lockId: string,
+            ): Promise<boolean> {
+                throw new Error("Function not implemented.");
+            },
+            forceRelease: function (
+                _context: IReadableContext,
+                _key: string,
+            ): Promise<boolean> {
+                throw new Error("Function not implemented.");
+            },
+            refresh: function (
+                _context: IReadableContext,
+                _key: string,
+                _lockId: string,
+                _ttl: TimeSpan,
+            ): Promise<boolean> {
+                throw new Error("Function not implemented.");
+            },
+            getState: function (
+                _context: IReadableContext,
+                _key: string,
+            ): Promise<ILockAdapterState | null> {
+                throw new Error("Function not implemented.");
+            },
+        };
+
+        expect(isLockFactory(lockAdapter)).toBe(false);
+    });
+    test("Should return false when given IDatabaseLockAdapter", () => {
+        const databaseLockAdapter: IDatabaseLockAdapter = {
+            transaction: function <TReturn>(
+                _context: IReadableContext,
+                _fn: InvokableFn<
+                    [transaction: IDatabaseLockTransaction],
+                    Promise<TReturn>
+                >,
+            ): Promise<TReturn> {
+                throw new Error("Function not implemented.");
+            },
+            remove: function (
+                _context: IReadableContext,
+                _key: string,
+            ): Promise<ILockExpirationData | null> {
+                throw new Error("Function not implemented.");
+            },
+            removeIfOwner: function (
+                _context: IReadableContext,
+                _key: string,
+                _lockId: string,
+            ): Promise<ILockData | null> {
+                throw new Error("Function not implemented.");
+            },
+            updateExpiration: function (
+                _context: IReadableContext,
+                _key: string,
+                _lockId: string,
+                _expiration: Date,
+            ): Promise<number> {
+                throw new Error("Function not implemented.");
+            },
+            find: function (
+                _context: IReadableContext,
+                _key: string,
+            ): Promise<ILockData | null> {
+                throw new Error("Function not implemented.");
+            },
+        };
+
+        expect(isLockFactory(databaseLockAdapter)).toBe(false);
+    });
+});

--- a/src/lock/implementations/derivables/lock-factory/is-lock-factory.ts
+++ b/src/lock/implementations/derivables/lock-factory/is-lock-factory.ts
@@ -1,0 +1,21 @@
+/**
+ * @module Lock
+ */
+
+import {
+    type ILockFactoryBase,
+    type LockFactoryInput,
+} from "@/lock/contracts/_module.js";
+
+/**
+ * @internal
+ */
+export function isLockFactory(
+    lockFactoryInput: LockFactoryInput,
+): lockFactoryInput is ILockFactoryBase {
+    return (
+        typeof lockFactoryInput === "object" &&
+        "create" in lockFactoryInput &&
+        typeof lockFactoryInput.create === "function"
+    );
+}

--- a/src/lock/implementations/derivables/lock-factory/lock-factory.ts
+++ b/src/lock/implementations/derivables/lock-factory/lock-factory.ts
@@ -4,9 +4,12 @@
 
 import { v4 } from "uuid";
 
-import { type IEventBus } from "@/event-bus/contracts/_module.js";
+import {
+    type EventBusInput,
+    type IEventBus,
+} from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
-import { EventBus } from "@/event-bus/implementations/derivables/_module.js";
+import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -91,15 +94,12 @@ export type LockFactorySettingsBase = {
     /**
      * @default
      * ```ts
-     * import { EventBus } from "@daiso-tech/core/event-bus";
      * import { NoOpEventBusAdapter } from "@daiso-tech/core/event-bus/no-op-event-bus-adapter";
      *
-     * new EventBus({
-     *   adapter: new NoOpEventBusAdapter()
-     * })
+     * new NoOpEventBusAdapter()
      * ```
      */
-    eventBus?: IEventBus;
+    eventBus?: EventBusInput;
 
     /**
      * You can decide the default ttl value for {@link ILock | `ILock`} expiration. If null is passed then no ttl will be used by default.
@@ -218,9 +218,7 @@ export class LockFactory implements ILockFactory {
             serde = new Serde(new NoOpSerdeAdapter()),
             namespace = new NoOpNamespace(),
             adapter,
-            eventBus = new EventBus<any>({
-                adapter: new NoOpEventBusAdapter(),
-            }),
+            eventBus = new NoOpEventBusAdapter(),
             serdeTransformerName = "",
             waitUntil = defaultWaitUntil,
             executionContext = new ExecutionContext(
@@ -237,7 +235,7 @@ export class LockFactory implements ILockFactory {
         this.namespace = namespace;
         this.defaultTtl =
             defaultTtl === null ? null : TimeSpan.fromTimeSpan(defaultTtl);
-        this.eventBus = eventBus;
+        this.eventBus = resolveEventBusInput(namespace, eventBus);
         this.serdeTransformerName = serdeTransformerName;
 
         this.originalAdapter = adapter;

--- a/src/lock/implementations/derivables/lock-factory/lock-factory.ts
+++ b/src/lock/implementations/derivables/lock-factory/lock-factory.ts
@@ -11,7 +11,11 @@ import {
     type IEventBusAdapter,
 } from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
-import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
+import {
+    resolveEventBusInput,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type EventBus,
+} from "@/event-bus/implementations/derivables/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -94,8 +98,8 @@ export type LockFactorySettingsBase = {
     createLockId?: Invokable<[], string>;
 
     /**
-     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the components events.
-     * If you provide an adapter, it will be automatically wrapped in an {@link IEventBus | `IEventBus`} instance.
+     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the component's events.
+     * If you provide an adapter, it will be automatically wrapped in an {@link EventBus | `EventBus`} instance.
      *
      * @default
      * ```ts

--- a/src/lock/implementations/derivables/lock-factory/lock-factory.ts
+++ b/src/lock/implementations/derivables/lock-factory/lock-factory.ts
@@ -92,6 +92,9 @@ export type LockFactorySettingsBase = {
     createLockId?: Invokable<[], string>;
 
     /**
+     * You can provide an `IEventBus` or an `IEventBusAdapter` instance to handle the components events.
+     * If you provide an adapter, it will be automatically wrapped in an `IEventBus` instance.
+     *
      * @default
      * ```ts
      * import { NoOpEventBusAdapter } from "@daiso-tech/core/event-bus/no-op-event-bus-adapter";

--- a/src/lock/implementations/derivables/lock-factory/lock-factory.ts
+++ b/src/lock/implementations/derivables/lock-factory/lock-factory.ts
@@ -7,6 +7,8 @@ import { v4 } from "uuid";
 import {
     type EventBusInput,
     type IEventBus,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type IEventBusAdapter,
 } from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
 import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
@@ -92,8 +94,8 @@ export type LockFactorySettingsBase = {
     createLockId?: Invokable<[], string>;
 
     /**
-     * You can provide an `IEventBus` or an `IEventBusAdapter` instance to handle the components events.
-     * If you provide an adapter, it will be automatically wrapped in an `IEventBus` instance.
+     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the components events.
+     * If you provide an adapter, it will be automatically wrapped in an {@link IEventBus | `IEventBus`} instance.
      *
      * @default
      * ```ts

--- a/src/lock/implementations/derivables/lock-factory/resolve-lock-factory-input.ts
+++ b/src/lock/implementations/derivables/lock-factory/resolve-lock-factory-input.ts
@@ -1,0 +1,27 @@
+/**
+ * @module Lock
+ */
+
+import {
+    type ILockFactoryBase,
+    type LockFactoryInput,
+} from "@/lock/contracts/_module.js";
+import { isLockFactory } from "@/lock/implementations/derivables/lock-factory/is-lock-factory.js";
+import { LockFactory } from "@/lock/implementations/derivables/lock-factory/lock-factory.js";
+import { type INamespace } from "@/namespace/contracts/_module.js";
+
+/**
+ * @internal
+ */
+export function resolveLockFactoryInput(
+    namespace: INamespace,
+    lockFactoryInput: LockFactoryInput,
+): ILockFactoryBase {
+    if (isLockFactory(lockFactoryInput)) {
+        return lockFactoryInput;
+    }
+    return new LockFactory({
+        namespace,
+        adapter: lockFactoryInput,
+    });
+}

--- a/src/middleware/use-factory.ts
+++ b/src/middleware/use-factory.ts
@@ -6,7 +6,11 @@ import { type IExecutionContext } from "@/execution-context/contracts/_module.js
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/no-op-execution-context-adapter.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
 import { applyMiddlewares } from "@/middleware/helpers.js";
-import { type Middleware } from "@/middleware/types.js";
+import {
+    type Middleware,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type MiddlewareArgs,
+} from "@/middleware/types.js";
 import {
     type Invokable,
     type InvokableFn,
@@ -140,7 +144,6 @@ export type UseFactorySettings = {
  * @see {@link Use | `Use`}
  * @see {@link UseFactorySettings | `UseFactorySettings`}
  * @see {@link Middleware | `Middleware`}
- * @see {@link applyMiddlewares | `applyMiddlewares`}
  *
  * IMPORT_PATH: `@daiso-tech/core/middleware`
  */

--- a/src/rate-limiter/implementations/derivables/rate-limiter-factory-resolver/database-rate-limiter-factory-resolver.ts
+++ b/src/rate-limiter/implementations/derivables/rate-limiter-factory-resolver/database-rate-limiter-factory-resolver.ts
@@ -3,7 +3,7 @@
  */
 
 import { type BackoffPolicy } from "@/backoff-policies/_module.js";
-import { type IEventBus } from "@/event-bus/contracts/_module.js";
+import { type EventBusInput } from "@/event-bus/contracts/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { type INamespace } from "@/namespace/contracts/_module.js";
 import {
@@ -129,7 +129,7 @@ export class DatabaseRateLimiterFactoryResolver<TAdapters extends string>
     }
 
     setEventBus(
-        eventBus: IEventBus,
+        eventBus: EventBusInput,
     ): DatabaseRateLimiterFactoryResolver<TAdapters> {
         return new DatabaseRateLimiterFactoryResolver({
             ...this.settings,

--- a/src/rate-limiter/implementations/derivables/rate-limiter-factory-resolver/rate-limiter-factory-resolver.ts
+++ b/src/rate-limiter/implementations/derivables/rate-limiter-factory-resolver/rate-limiter-factory-resolver.ts
@@ -2,7 +2,7 @@
  * @module RateLimiter
  */
 
-import { type IEventBus } from "@/event-bus/contracts/_module.js";
+import { type EventBusInput } from "@/event-bus/contracts/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { type INamespace } from "@/namespace/contracts/_module.js";
 import {
@@ -97,7 +97,9 @@ export class RateLimiterFactoryResolver<TAdapters extends string>
         });
     }
 
-    setEventBus(eventBus: IEventBus): RateLimiterFactoryResolver<TAdapters> {
+    setEventBus(
+        eventBus: EventBusInput,
+    ): RateLimiterFactoryResolver<TAdapters> {
         return new RateLimiterFactoryResolver({
             ...this.settings,
             eventBus,

--- a/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter-factory.test.ts
+++ b/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter-factory.test.ts
@@ -682,7 +682,7 @@ describe("class: RateLimiterFactory", () => {
                             throw new UnexpectedErrorA("Unexpected error");
                         });
                     } catch (error: unknown) {
-                        if (!(error instanceof UnexpectedErrorA)) {
+                        if (!(error instanceof BlockedRateLimiterError)) {
                             throw error;
                         }
                     }
@@ -838,7 +838,7 @@ describe("class: RateLimiterFactory", () => {
                             throw new UnexpectedErrorA("Unexpected error");
                         });
                     } catch (error: unknown) {
-                        if (!(error instanceof UnexpectedErrorA)) {
+                        if (!(error instanceof BlockedRateLimiterError)) {
                             throw error;
                         }
                     }
@@ -933,7 +933,13 @@ describe("class: RateLimiterFactory", () => {
                         limit,
                         onlyError: false,
                     });
-                    await rateLimiter.runOrFail(() => {});
+                    try {
+                        await rateLimiter.runOrFail(() => {});
+                    } catch (error: unknown) {
+                        if (!(error instanceof BlockedRateLimiterError)) {
+                            throw error;
+                        }
+                    }
 
                     await vi.waitFor(() => {
                         expect(handlerFn).toHaveBeenCalledOnce();

--- a/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter-factory.ts
+++ b/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter-factory.ts
@@ -9,7 +9,11 @@ import {
     type IEventBusAdapter,
 } from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
-import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
+import {
+    resolveEventBusInput,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type EventBus,
+} from "@/event-bus/implementations/derivables/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -55,8 +59,8 @@ export type RateLimiterFactorySettingsBase = {
     namespace?: INamespace;
 
     /**
-     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the components events.
-     * If you provide an adapter, it will be automatically wrapped in an {@link IEventBus | `IEventBus`} instance.
+     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the component's events.
+     * If you provide an adapter, it will be automatically wrapped in an {@link EventBus | `EventBus`} instance.
      *
      * @default
      * ```ts

--- a/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter-factory.ts
+++ b/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter-factory.ts
@@ -5,6 +5,8 @@
 import {
     type EventBusInput,
     type IEventBus,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type IEventBusAdapter,
 } from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
 import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
@@ -53,8 +55,8 @@ export type RateLimiterFactorySettingsBase = {
     namespace?: INamespace;
 
     /**
-     * You can provide an `IEventBus` or an `IEventBusAdapter` instance to handle the components events.
-     * If you provide an adapter, it will be automatically wrapped in an `IEventBus` instance.
+     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the components events.
+     * If you provide an adapter, it will be automatically wrapped in an {@link IEventBus | `IEventBus`} instance.
      *
      * @default
      * ```ts

--- a/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter-factory.ts
+++ b/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter-factory.ts
@@ -2,9 +2,12 @@
  * @module RateLimiter
  */
 
-import { type IEventBus } from "@/event-bus/contracts/_module.js";
+import {
+    type EventBusInput,
+    type IEventBus,
+} from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
-import { EventBus } from "@/event-bus/implementations/derivables/_module.js";
+import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -52,15 +55,12 @@ export type RateLimiterFactorySettingsBase = {
     /**
      * @default
      * ```ts
-     * import { EventBus } from "@daiso-tech/core/event-bus";
      * import { NoOpEventBusAdapter } from "@daiso-tech/core/event-bus/no-op-event-bus-adapter";
      *
-     * new EventBus({
-     *   adapter: new NoOpEventBusAdapter()
-     * })
+     *  new NoOpEventBusAdapter()
      * ```
      */
-    eventBus?: IEventBus;
+    eventBus?: EventBusInput;
 
     /**
      * You can set the default `ErrorPolicy`
@@ -193,9 +193,7 @@ export class RateLimiterFactory implements IRateLimiterFactory {
         const {
             enableAsyncTracking = true,
             namespace = new NoOpNamespace(),
-            eventBus = new EventBus({
-                adapter: new NoOpEventBusAdapter(),
-            }),
+            eventBus = new NoOpEventBusAdapter(),
             adapter,
             onlyError = false,
             defaultErrorPolicy = () => true,
@@ -212,7 +210,7 @@ export class RateLimiterFactory implements IRateLimiterFactory {
         this.serdeTransformerName = serdeTransformerName;
         this.enableAsyncTracking = enableAsyncTracking;
         this.namespace = namespace;
-        this.eventBus = eventBus;
+        this.eventBus = resolveEventBusInput(namespace, eventBus);
         this.adapter = adapter;
         this.onlyError = onlyError;
         this.defaultErrorPolicy = defaultErrorPolicy;

--- a/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter-factory.ts
+++ b/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter-factory.ts
@@ -53,11 +53,14 @@ export type RateLimiterFactorySettingsBase = {
     namespace?: INamespace;
 
     /**
+     * You can provide an `IEventBus` or an `IEventBusAdapter` instance to handle the components events.
+     * If you provide an adapter, it will be automatically wrapped in an `IEventBus` instance.
+     *
      * @default
      * ```ts
      * import { NoOpEventBusAdapter } from "@daiso-tech/core/event-bus/no-op-event-bus-adapter";
      *
-     *  new NoOpEventBusAdapter()
+     * new NoOpEventBusAdapter()
      * ```
      */
     eventBus?: EventBusInput;

--- a/src/semaphore/implementations/derivables/semaphore-factory-resolver/semaphore-factory-resolver.ts
+++ b/src/semaphore/implementations/derivables/semaphore-factory-resolver/semaphore-factory-resolver.ts
@@ -1,7 +1,7 @@
 /**
  * @module Semaphore
  */
-import { type IEventBus } from "@/event-bus/contracts/_module.js";
+import { type EventBusInput } from "@/event-bus/contracts/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { type INamespace } from "@/namespace/contracts/_module.js";
 import {
@@ -89,7 +89,7 @@ export class SemaphoreFactoryResolver<TAdapters extends string>
         });
     }
 
-    setEventBus(eventBus: IEventBus): SemaphoreFactoryResolver<TAdapters> {
+    setEventBus(eventBus: EventBusInput): SemaphoreFactoryResolver<TAdapters> {
         return new SemaphoreFactoryResolver({
             ...this.settings,
             eventBus,

--- a/src/semaphore/implementations/derivables/semaphore-factory/semaphore-factory.ts
+++ b/src/semaphore/implementations/derivables/semaphore-factory/semaphore-factory.ts
@@ -11,7 +11,11 @@ import {
     type IEventBusAdapter,
 } from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
-import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
+import {
+    resolveEventBusInput,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type EventBus,
+} from "@/event-bus/implementations/derivables/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -94,8 +98,8 @@ export type SemaphoreFactorySettingsBase = {
     createSlotId?: Invokable<[], string>;
 
     /**
-     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the components events.
-     * If you provide an adapter, it will be automatically wrapped in an {@link IEventBus | `IEventBus`} instance.
+     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the component's events.
+     * If you provide an adapter, it will be automatically wrapped in an {@link EventBus | `EventBus`} instance.
      *
      * @default
      * ```ts

--- a/src/semaphore/implementations/derivables/semaphore-factory/semaphore-factory.ts
+++ b/src/semaphore/implementations/derivables/semaphore-factory/semaphore-factory.ts
@@ -4,9 +4,12 @@
 
 import { v4 } from "uuid";
 
-import { type IEventBus } from "@/event-bus/contracts/_module.js";
+import {
+    type EventBusInput,
+    type IEventBus,
+} from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
-import { EventBus } from "@/event-bus/implementations/derivables/_module.js";
+import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -91,15 +94,12 @@ export type SemaphoreFactorySettingsBase = {
     /**
      * @default
      * ```ts
-     * import { EventBus } from "@daiso-tech/core/event-bus";
      * import { NoOpEventBusAdapter } from "@daiso-tech/core/event-bus/no-op-event-bus-adapter";
      *
-     * new EventBus({
-     *   adapter: new NoOpEventBusAdapter()
-     * })
+     * new NoOpEventBusAdapter()
      * ```
      */
-    eventBus?: IEventBus;
+    eventBus?: EventBusInput;
 
     /**
      * You can decide the default ttl value for {@link ISemaphore | `ISemaphore`} expiration. If null is passed then no ttl will be used by default.
@@ -218,9 +218,7 @@ export class SemaphoreFactory implements ISemaphoreFactory {
             serde = new Serde(new NoOpSerdeAdapter()),
             namespace = new NoOpNamespace(),
             adapter,
-            eventBus = new EventBus<any>({
-                adapter: new NoOpEventBusAdapter(),
-            }),
+            eventBus = new NoOpEventBusAdapter(),
             serdeTransformerName = "",
             waitUntil = defaultWaitUntil,
             executionContext = new ExecutionContext(
@@ -237,7 +235,7 @@ export class SemaphoreFactory implements ISemaphoreFactory {
         this.namespace = namespace;
         this.defaultTtl =
             defaultTtl === null ? null : TimeSpan.fromTimeSpan(defaultTtl);
-        this.eventBus = eventBus;
+        this.eventBus = resolveEventBusInput(namespace, eventBus);
         this.serdeTransformerName = serdeTransformerName;
 
         this.originalAdapter = adapter;

--- a/src/semaphore/implementations/derivables/semaphore-factory/semaphore-factory.ts
+++ b/src/semaphore/implementations/derivables/semaphore-factory/semaphore-factory.ts
@@ -92,6 +92,9 @@ export type SemaphoreFactorySettingsBase = {
     createSlotId?: Invokable<[], string>;
 
     /**
+     * You can provide an `IEventBus` or an `IEventBusAdapter` instance to handle the components events.
+     * If you provide an adapter, it will be automatically wrapped in an `IEventBus` instance.
+     *
      * @default
      * ```ts
      * import { NoOpEventBusAdapter } from "@daiso-tech/core/event-bus/no-op-event-bus-adapter";

--- a/src/semaphore/implementations/derivables/semaphore-factory/semaphore-factory.ts
+++ b/src/semaphore/implementations/derivables/semaphore-factory/semaphore-factory.ts
@@ -7,6 +7,8 @@ import { v4 } from "uuid";
 import {
     type EventBusInput,
     type IEventBus,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type IEventBusAdapter,
 } from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
 import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
@@ -92,8 +94,8 @@ export type SemaphoreFactorySettingsBase = {
     createSlotId?: Invokable<[], string>;
 
     /**
-     * You can provide an `IEventBus` or an `IEventBusAdapter` instance to handle the components events.
-     * If you provide an adapter, it will be automatically wrapped in an `IEventBus` instance.
+     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the components events.
+     * If you provide an adapter, it will be automatically wrapped in an {@link IEventBus | `IEventBus`} instance.
      *
      * @default
      * ```ts

--- a/src/shared-lock/implementations/derivables/shared-lock-factory-resolver/shared-lock-factory-resolver.ts
+++ b/src/shared-lock/implementations/derivables/shared-lock-factory-resolver/shared-lock-factory-resolver.ts
@@ -1,7 +1,7 @@
 /**
  * @module SharedLock
  */
-import { type IEventBus } from "@/event-bus/contracts/_module.js";
+import { type EventBusInput } from "@/event-bus/contracts/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { type INamespace } from "@/namespace/contracts/_module.js";
 import {
@@ -99,7 +99,7 @@ export class SharedLockFactoryResolver<TAdapters extends string>
         });
     }
 
-    setEventBus(eventBus: IEventBus): SharedLockFactoryResolver<TAdapters> {
+    setEventBus(eventBus: EventBusInput): SharedLockFactoryResolver<TAdapters> {
         return new SharedLockFactoryResolver({
             ...this.settings,
             eventBus,

--- a/src/shared-lock/implementations/derivables/shared-lock-factory/shared-lock-factory.ts
+++ b/src/shared-lock/implementations/derivables/shared-lock-factory/shared-lock-factory.ts
@@ -89,6 +89,9 @@ export type SharedLockFactorySettingsBase = {
     createLockId?: Invokable<[], string>;
 
     /**
+     * You can provide an `IEventBus` or an `IEventBusAdapter` instance to handle the components events.
+     * If you provide an adapter, it will be automatically wrapped in an `IEventBus` instance.
+     *
      * @default
      * ```ts
      * import { NoOpEventBusAdapter } from "@daiso-tech/core/event-bus/no-op-event-bus-adapter";

--- a/src/shared-lock/implementations/derivables/shared-lock-factory/shared-lock-factory.ts
+++ b/src/shared-lock/implementations/derivables/shared-lock-factory/shared-lock-factory.ts
@@ -4,9 +4,12 @@
 
 import { v4 } from "uuid";
 
-import { type IEventBus } from "@/event-bus/contracts/_module.js";
+import {
+    type EventBusInput,
+    type IEventBus,
+} from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
-import { EventBus } from "@/event-bus/implementations/derivables/_module.js";
+import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -88,15 +91,12 @@ export type SharedLockFactorySettingsBase = {
     /**
      * @default
      * ```ts
-     * import { EventBus } from "@daiso-tech/core/event-bus";
      * import { NoOpEventBusAdapter } from "@daiso-tech/core/event-bus/no-op-event-bus-adapter";
      *
-     * new EventBus({
-     *   adapter: new NoOpEventBusAdapter()
-     * })
+     * new NoOpEventBusAdapter()
      * ```
      */
-    eventBus?: IEventBus;
+    eventBus?: EventBusInput;
 
     /**
      * You can decide the default ttl value for {@link ISharedLock | `ISharedLock`} expiration. If null is passed then no ttl will be used by default.
@@ -215,9 +215,7 @@ export class SharedLockFactory implements ISharedLockFactory {
             serde = new Serde(new NoOpSerdeAdapter()),
             namespace = new NoOpNamespace(),
             adapter,
-            eventBus = new EventBus<any>({
-                adapter: new NoOpEventBusAdapter(),
-            }),
+            eventBus = new NoOpEventBusAdapter(),
             serdeTransformerName = "",
             waitUntil = defaultWaitUntil,
             executionContext = new ExecutionContext(
@@ -234,7 +232,7 @@ export class SharedLockFactory implements ISharedLockFactory {
         this.namespace = namespace;
         this.defaultTtl =
             defaultTtl === null ? null : TimeSpan.fromTimeSpan(defaultTtl);
-        this.eventBus = eventBus;
+        this.eventBus = resolveEventBusInput(namespace, eventBus);
         this.serdeTransformerName = serdeTransformerName;
 
         this.originalAdapter = adapter;

--- a/src/shared-lock/implementations/derivables/shared-lock-factory/shared-lock-factory.ts
+++ b/src/shared-lock/implementations/derivables/shared-lock-factory/shared-lock-factory.ts
@@ -11,7 +11,11 @@ import {
     type IEventBusAdapter,
 } from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
-import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
+import {
+    resolveEventBusInput,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type EventBus,
+} from "@/event-bus/implementations/derivables/_module.js";
 import { type IExecutionContext } from "@/execution-context/contracts/_module.js";
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -91,8 +95,8 @@ export type SharedLockFactorySettingsBase = {
     createLockId?: Invokable<[], string>;
 
     /**
-     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the components events.
-     * If you provide an adapter, it will be automatically wrapped in an {@link IEventBus | `IEventBus`} instance.
+     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the component's events.
+     * If you provide an adapter, it will be automatically wrapped in an {@link EventBus | `EventBus`} instance.
      *
      * @default
      * ```ts

--- a/src/shared-lock/implementations/derivables/shared-lock-factory/shared-lock-factory.ts
+++ b/src/shared-lock/implementations/derivables/shared-lock-factory/shared-lock-factory.ts
@@ -7,6 +7,8 @@ import { v4 } from "uuid";
 import {
     type EventBusInput,
     type IEventBus,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type IEventBusAdapter,
 } from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
 import { resolveEventBusInput } from "@/event-bus/implementations/derivables/_module.js";
@@ -89,8 +91,8 @@ export type SharedLockFactorySettingsBase = {
     createLockId?: Invokable<[], string>;
 
     /**
-     * You can provide an `IEventBus` or an `IEventBusAdapter` instance to handle the components events.
-     * If you provide an adapter, it will be automatically wrapped in an `IEventBus` instance.
+     * You can provide an {@link IEventBus | `IEventBus`} or an {@link IEventBusAdapter | `IEventBusAdapter`} instance to handle the components events.
+     * If you provide an adapter, it will be automatically wrapped in an {@link IEventBus | `IEventBus`} instance.
      *
      * @default
      * ```ts

--- a/website/docs/components/cache/cache_usage.md
+++ b/website/docs/components/cache/cache_usage.md
@@ -313,15 +313,12 @@ To use locking, pass a `lockFactory` to the `Cache` constructor:
 ```ts
 import { Cache } from "@daiso-tech/core/cache";
 import { MemoryCacheAdapter } from "@daiso-tech/core/cache/memory-cache-adapter";
-import { LockFactory } from "@daiso-tech/core/lock";
 import { RedisLockAdapter } from "@daiso-tech/core/lock/redis-lock-adapter";
 import Redis from "ioredis";
 
 const cache = new Cache({
     adapter: new MemoryCacheAdapter(),
-    lockFactory: new LockFactory({
-        adapter: new RedisLockAdapter(new Redis("YOUR_REDIS_CONNECTION_STRING")),
-    }),
+    lockFactory: new RedisLockAdapter(new Redis("YOUR_REDIS_CONNECTION_STRING")),
 });
 ```
 
@@ -339,11 +336,12 @@ const value = await cache.getOrAdd(
 ```
 
 :::info
-For further information about `LockFactory` and its adapters refer to the [`@daiso-tech/core/lock`](../lock/lock_usage.md) documentation.
+You can pass `ILockFactoryBase`, `ILockAdapter`, and `IDatabaseLockAdapter` to `lockFactory` setting.
+For further information about `LockFactory` refer to the [`@daiso-tech/core/lock`](../lock/lock_usage.md) documentation.
 :::
 
 :::warning
-The `lockFactory` defaults to a no-op implementation, so `enableLocking: true` has no effect unless you provide a real lock adapter.
+The `lockFactory` defaults to a `NoOpLockAdapter` implementation, so `enableLocking: true` has no effect unless you provide a real lock adapter.
 :::
 
 ### Namespacing

--- a/website/docs/components/cache/cache_usage.md
+++ b/website/docs/components/cache/cache_usage.md
@@ -398,7 +398,7 @@ console.log(await cacheA.get("key"));
 ### Cache events
 
 You can listen to different [cache events](https://daiso-tech.github.io/daiso-core/modules/Cache.html) that are triggered by the `Cache` instance.
-Refer to the [`@daiso-tech/core/event-bus`](../event_bus/event_bus_usage.md) documentation to learn how to use events. Since no events are dispatched by default, you need to pass an object that implements IEventBus contract.
+Refer to the [`@daiso-tech/core/event-bus`](../event_bus/event_bus_usage.md) documentation to learn how to use events. Since no events are dispatched by default, you need to pass an object that implements `IEventBus` or `IEventBusAdapter` contract.
 
 
 ```ts
@@ -419,7 +419,6 @@ If multiple cache adapters (e.g., `RedisCacheAdapter` and `MemoryCacheAdapter`) 
 import { RedisCacheAdapter } from "@daiso-tech/core/cache/redis-cache-adapter";
 import { MemoryCacheAdapter } from "@daiso-tech/core/cache/memory-cache-adapter";
 import { Cache } from "@daiso-tech/core/cache";
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { Namespace } from "@daiso-tech/core/namespace";
 import { RedisPubSubEventBusAdapter } from "@daiso-tech/core/event-bus/redis-pub-sub-event-bus-adapter";
 import { Serde } from "@daiso-tech/core/serde";
@@ -436,11 +435,9 @@ const redisPubSubEventBusAdapter = new RedisPubSubEventBusAdapter({
 const memoryCacheAdapter = new MemoryCacheAdapter();
 const memoryCache = new Cache({
     adapter: memoryCacheAdapter,
-    eventBus: new EventBus({
-        // We assign distinct namespaces to MemoryCacheAdapter and RedisCacheAdapter to isolate their events.
-        namespace: new Namespace(["memory", "event-bus"]),
-        adapter: redisPubSubEventBusAdapter,
-    }),
+    // We assign distinct namespaces to MemoryCacheAdapter and RedisCacheAdapter to isolate their events.
+    namespace: new Namespace(["memory", "event-bus"]),
+    eventBus: redisPubSubEventBusAdapter
 });
 
 const redisCacheAdapter = new RedisCacheAdapter({
@@ -449,11 +446,9 @@ const redisCacheAdapter = new RedisCacheAdapter({
 });
 const redisCache = new Cache({
     adapter: redisCacheAdapter,
-    eventBus: new EventBus({
-        // We assign distinct namespaces to MemoryCacheAdapter and RedisCacheAdapter to isolate their events.
-        namespace: new Namespace(["redis", "event-bus"]),
-        adapter: redisPubSubEventBusAdapter,
-    }),
+    // We assign distinct namespaces to MemoryCacheAdapter and RedisCacheAdapter to isolate their events.
+    namespace: new Namespace(["redis", "event-bus"]),
+    eventBus: redisPubSubEventBusAdapter
 });
 ```
 
@@ -481,7 +476,6 @@ import type {
 } from "@daiso-tech/core/cache/contracts";
 import { Cache } from "@daiso-tech/core/cache";
 import { MemoryCacheAdapter } from "@daiso-tech/core/cache/adapter/memory-cache-adapter";
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { MemoryEventBus } from "@daiso-tech/core/event-bus/memory-event-bus";
 
 async function readingFunc(cache: IReadableCache): Promise<void> {
@@ -509,9 +503,7 @@ async function listenerFunc(cacheListenable: ICacheListenable): Promise<void> {
 
 const cache = new Cache({
     adapter: new MemoryCacheAdapter(),
-    eventBus: new EventBus({
-        adapter: new MemoryEventBus()
-    })
+    eventBus: new MemoryEventBus()
 })
 await listenerFunc(cache.events);
 await manipulatingFunc(cache);

--- a/website/docs/components/circuit_breaker/circuit_breaker_usage.md
+++ b/website/docs/components/circuit_breaker/circuit_breaker_usage.md
@@ -314,22 +314,19 @@ await eventBus.addListener("sending-circuit-breaker-over-network", ({ circuitBre
 ### Circuit-breaker events
 
 You can listen to different [circuit-breaker events](https://daiso-tech.github.io/daiso-core/modules/CircuitBreaker.html) that are triggered by the `CircuitBreaker` instance.
-Refer to the [`EventBus`](../event_bus/event_bus_usage.md) documentation to learn how to use events. Since no events are dispatched by default, you need to pass an object that implements `IEventBus` contract.
+Refer to the [`EventBus`](../event_bus/event_bus_usage.md) documentation to learn how to use events. Since no events are dispatched by default, you need to pass an object that implements `IEventBus` or `IEventBusAdapter` contract.
 
 ```ts
 import { MemoryCircuitBreakerStorageAdapter } from "@daiso-tech/core/circuit-breaker/memory-circuit-breaker-storage-adapter";
 import { DatabaseCircuitBreakerAdapter } from "@daiso-tech/core/circuit-breaker/database-circuit-breaker-adapter";
 import { CircuitBreakerFactory, CIRCUIT_BREAKER_EVENTS } from "@daiso-tech/core/circuit-breaker";
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { MemoryEventBusAdapter } from "@daiso-tech/core/event-bus/memory-event-bus-adapter";
 
 const circuitBreakerFactory = new CircuitBreakerFactory({
     adapter: new DatabaseCircuitBreakerAdapter({ 
         adapter: new MemoryCircuitBreakerStorageAdapter()
     }),
-    eventBus: new EventBus({
-        adapter: new MemoryEventBusAdapter(),
-    }),
+    eventBus: new MemoryEventBusAdapter()
 });
 
 await circuitBreakerFactory.events.addListener(CIRCUIT_BREAKER_EVENTS.STATE_TRANSITIONED, (event) => {
@@ -346,7 +343,6 @@ If multiple circuit-breaker adapters (e.g., `RedisCircuitBreakerAdapter` and `Da
 import { RedisCircuitBreakerAdapter } from "@daiso-tech/core/circuit-breaker/redis-circuit-breaker-adapter";
 import { MemoryCircuitBreakerStorageAdapter } from "@daiso-tech/core/circuit-breaker/memory-circuit-breaker-storage-adapter";
 import { DatabaseCircuitBreakerAdapter } from "@daiso-tech/core/circuit-breaker/database-circuit-breaker-adapter";
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { RedisPubSubEventBusAdapter } from "@daiso-tech/core/event-bus/redis-pub-sub-event-bus-adapter";
 import { Serde } from "@daiso-tech/core/serde";
 import { SuperJsonSerdeAdapter } from "@daiso-tech/core/serde/super-json-serde-adapter";
@@ -364,11 +360,9 @@ const memoryCircuitBreakerFactory = new CircuitBreakerFactory({
     adapter: new DatabaseCircuitBreakerAdapter({ 
         adapter: new MemoryCircuitBreakerStorageAdapter()
     }),
-    eventBus: new EventBus({
-        // We assign distinct namespaces to DatabaseCircuitBreakerAdapter and RedisCircuitBreakerAdapter to isolate their events.
-        namespace: new Namespace(["memory", "event-bus"]),
-        adapter: redisPubSubEventBusAdapter,
-    }),
+    // We assign distinct namespaces to DatabaseCircuitBreakerAdapter and RedisCircuitBreakerAdapter to isolate their events.
+    namespace: new Namespace(["memory", "event-bus"]),
+    eventBus: redisPubSubEventBusAdapter
 });
 
 const redisCircuitBreakerAdapter = new RedisCircuitBreakerAdapter({
@@ -377,11 +371,9 @@ const redisCircuitBreakerAdapter = new RedisCircuitBreakerAdapter({
 });
 const redisCircuitBreakerFactory = new CircuitBreakerFactory({
     adapter: redisCircuitBreakerAdapter,
-    eventBus: new EventBus({
-        // We assign distinct namespaces to DatabaseCircuitBreakerAdapter and RedisCircuitBreakerAdapter to isolate their events.
-        namespace: new Namespace(["redis", "event-bus"]),
-        adapter: redisPubSubEventBusAdapter,
-    }),
+    // We assign distinct namespaces to DatabaseCircuitBreakerAdapter and RedisCircuitBreakerAdapter to isolate their events.
+    namespace: new Namespace(["redis", "event-bus"]),
+    eventBus: redisPubSubEventBusAdapter
 });
 ```
 
@@ -400,7 +392,6 @@ The library includes 3 additional contracts:
 This seperation makes it easy to visually distinguish the 3 contracts, making it immediately obvious that they serve different purposes.
 
 ```ts
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { MemoryEventBusAdapter } from "@daiso-tech/core/event-bus/memory-event-bus-adapter";
 import { CircuitBreakerFactory } from "@daiso-tech/core/circuit-breaker";
 import { MemoryCircuitBreakerStorageAdapter } from "@daiso-tech/core/circuit-breaker/memory-circuit-breaker-storage-adapter";
@@ -441,9 +432,7 @@ const circuitBreakerFactory = new CircuitBreakerFactory({
     adapter: new DatabaseCircuitBreakerAdapter({
         adapter: new MemoryCircuitBreakerStorageAdapter(),
     }),
-    eventBus: new EventBus({
-        adapter: new MemoryEventBusAdapter()
-    })
+    eventBus: new MemoryEventBusAdapter()
 })
 await circuitBreakerListenableFunc(circuitBreakerFactory.events);
 await circuitBreakerFactoryFunc(circuitBreakerFactory);

--- a/website/docs/components/file_storage/file_storage_usage.md
+++ b/website/docs/components/file_storage/file_storage_usage.md
@@ -649,21 +649,16 @@ const fsFileStorage = new FileStorage({
 
 ### File locking on write operations
 
-By default, no locking is applied to write operations. You can provide an [`ILockFactoryBase`](https://daiso-tech.github.io/daiso-core/types/Lock.ILockFactoryBase.html) instance via the `lockFactory` setting to enable distributed locking, ensuring that concurrent write operations on the same file are serialized and safe.
+The `FileStorage` instance methods supports distributed locking via the `lockFactory` settings passed into `FileStorage` constructor. Data races will occur when multiple clients simultaneously perform write operation to same file and file will be corrupted.
 
 ```ts
 import { MemoryFileStorageAdapter } from "@daiso-tech/core/file-storage/memory-file-storage-adapter";
 import { FileStorage } from "@daiso-tech/core/file-storage";
-import { LockFactory } from "@daiso-tech/core/lock";
 import { MemoryLockAdapter } from "@daiso-tech/core/lock/memory-lock-adapter";
-
-const lockFactory = new LockFactory({
-    adapter: new MemoryLockAdapter(),
-});
 
 const fileStorage = new FileStorage({
     adapter: new MemoryFileStorageAdapter(),
-    lockFactory,
+    lockFactory: new MemoryLockAdapter(),
 });
 
 // Write operations on the same file key will now be protected by a lock
@@ -671,7 +666,8 @@ await fileStorage.create("file.txt").add({ data: "CONTENT" });
 ```
 
 :::info
-This is especially useful in distributed or concurrent environments where multiple processes or servers may write to the same file simultaneously. Use a distributed lock adapter (e.g., Redis-based) for cross-process locking.
+You can pass `ILockFactoryBase`, `ILockAdapter`, and `IDatabaseLockAdapter` to `lockFactory` setting.
+For further information about `LockFactory` refer to the [`@daiso-tech/core/lock`](../lock/lock_usage.md) documentation.
 :::
 
 ### Separating creating, listening to and manipulating files

--- a/website/docs/components/file_storage/file_storage_usage.md
+++ b/website/docs/components/file_storage/file_storage_usage.md
@@ -641,7 +641,7 @@ const fsFileStorage = new FileStorage({
 
 ### File locking on write operations
 
-The `FileStorage` instance methods supports distributed locking via the `lockFactory` settings passed into `FileStorage` constructor. Data races will occur when multiple clients simultaneously perform write operation to same file and file will be corrupted.
+The `FileStorage` instance method supports distributed locking via the `lockFactory` settings passed into `FileStorage` constructor. Data races will occur when multiple clients simultaneously perform write operation to same file and file will be corrupted.
 
 ```ts
 import { MemoryFileStorageAdapter } from "@daiso-tech/core/file-storage/memory-file-storage-adapter";

--- a/website/docs/components/file_storage/file_storage_usage.md
+++ b/website/docs/components/file_storage/file_storage_usage.md
@@ -583,19 +583,16 @@ await eventBus.addListener("sending-file-over-network", ({ file }) => {
 
 You can listen to different [file events](https://daiso-tech.github.io/daiso-core/modules/File.html) that are triggered by the `File` instance.
 
-Refer to the [`EventBus`](../event_bus/event_bus_usage.md) documentation to learn how to use events. Since no events are dispatched by default, you need to pass an object that implements `IEventBus` contract.
+Refer to the [`EventBus`](../event_bus/event_bus_usage.md) documentation to learn how to use events. Since no events are dispatched by default, you need to pass an object that implements `IEventBus` or `IEventBusAdapter` contract.
 
 ```ts
 import { MemoryFileStorageAdapter } from "@daiso-tech/core/file-storage/memory-file-storage-adapter";
 import { FileStorage, FILE_EVENTS } from "@daiso-tech/core/file-storage";
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { MemoryEventBusAdapter } from "@daiso-tech/core/event-bus/memory-event-bus-adapter";
 
 const fileStorage = new FileStorage({
     adapter: new MemoryFileStorageAdapter(),
-    eventBus: new EventBus({
-        adapter: new MemoryEventBusAdapter(),
-    }),
+    eventBus: new MemoryEventBusAdapter(),
 });
 
 await fileStorage.events.addListener(FILE_EVENTS.ADDED, () => {
@@ -611,7 +608,6 @@ If multiple file-storage adapters (e.g., `FsFileStorageAdapter` and `MemoryFileS
 ```ts
 import { FsFileStorageAdapter } from "@daiso-tech/core/file-storage/fs-file-storage-adapter";
 import { MemoryFileStorageAdapter } from "@daiso-tech/core/file-storage/memory-file-storage-adapter";
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { RedisPubSubEventBusAdapter } from "@daiso-tech/core/event-bus/redis-pub-sub-event-bus-adapter";
 import { Serde } from "@daiso-tech/core/serde";
 import { SuperJsonSerdeAdapter } from "@daiso-tech/core/serde/super-json-serde-adapter";
@@ -627,21 +623,17 @@ const redisPubSubEventBusAdapter = new RedisPubSubEventBusAdapter({
 const memoryFileStorageAdapter = new MemoryFileStorageAdapter();
 const memoryFileStorage = new FileStorage({
     adapter: memoryFileStorageAdapter,
-    eventBus: new EventBus({
-        // We assign distinct namespaces to MemoryFileStorageAdapter and FsFileStorageAdapter to isolate their events.
-        namespace: new Namespace(["memory", "event-bus"]),
-        adapter: redisPubSubEventBusAdapter,
-    }),
+    // We assign distinct namespaces to MemoryFileStorageAdapter and FsFileStorageAdapter to isolate their events.
+    namespace: new Namespace(["memory", "event-bus"]),
+    eventBus: redisPubSubEventBusAdapter
 });
 
 const fsFileStorageAdapter = new FsFileStorageAdapter();
 const fsFileStorage = new FileStorage({
     adapter: fsFileStorageAdapter,
-    eventBus: new EventBus({
-        // We assign distinct namespaces to MemoryFileStorageAdapter and FsFileStorageAdapter to isolate their events.
-        namespace: new Namespace(["fs", "event-bus"]),
-        adapter: redisPubSubEventBusAdapter,
-    }),
+    // We assign distinct namespaces to MemoryFileStorageAdapter and FsFileStorageAdapter to isolate their events.
+    namespace: new Namespace(["fs", "event-bus"]),
+    eventBus: redisPubSubEventBusAdapter
 });
 ```
 

--- a/website/docs/components/lock/lock_usage.md
+++ b/website/docs/components/lock/lock_usage.md
@@ -564,19 +564,16 @@ await eventBus.addListener("sending-lock-over-network", ({ lock }) => {
 ### Lock events
 
 You can listen to different [lock events](https://daiso-tech.github.io/daiso-core/modules/Lock.html) that are triggered by the `Lock` instance.
-Refer to the [`EventBus`](../event_bus/event_bus_usage.md) documentation to learn how to use events. Since no events are dispatched by default, you need to pass an object that implements `IEventBus` contract.
+Refer to the [`EventBus`](../event_bus/event_bus_usage.md) documentation to learn how to use events. Since no events are dispatched by default, you need to pass an object that implements `IEventBus` or `IEventBusAdapter` contract.
 
 ```ts
 import { MemoryLockAdapter } from "@daiso-tech/core/lock/memory-lock-adapter";
 import { LockFactory, LOCK_EVENTS } from "@daiso-tech/core/lock";
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { MemoryEventBusAdapter } from "@daiso-tech/core/event-bus/memory-event-bus-adapter";
 
 const lockFactory = new LockFactory({
     adapter: new MemoryLockAdapter(),
-    eventBus: new EventBus({
-        adapter: new MemoryEventBusAdapter(),
-    }),
+    eventBus: new MemoryEventBusAdapter(),
 });
 
 await lockFactory.events.addListener(LOCK_EVENTS.ACQUIRED, () => {
@@ -592,7 +589,6 @@ If multiple lock adapters (e.g., `RedisLockAdapter` and `MemoryLockAdapter`) are
 ```ts
 import { RedisLockAdapter } from "@daiso-tech/core/lock/redis-lock-adapter";
 import { MemoryLockAdapter } from "@daiso-tech/core/lock/memory-lock-adapter";
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { RedisPubSubEventBusAdapter } from "@daiso-tech/core/event-bus/redis-pub-sub-event-bus-adapter";
 import { Serde } from "@daiso-tech/core/serde";
 import { SuperJsonSerdeAdapter } from "@daiso-tech/core/serde/super-json-serde-adapter";
@@ -609,11 +605,9 @@ const redisPubSubEventBusAdapter = new RedisPubSubEventBusAdapter({
 const memoryLockAdapter = new MemoryLockAdapter();
 const memoryLockFactory = new LockFactory({
     adapter: memoryLockAdapter,
-    eventBus: new EventBus({
-        // We assign distinct namespaces to MemoryLockAdapter and RedisLockAdapter to isolate their events.
-        namespace: new Namespace(["memory", "event-bus"]),
-        adapter: redisPubSubEventBusAdapter,
-    }),
+    // We assign distinct namespaces to MemoryLockAdapter and RedisLockAdapter to isolate their events.
+    namespace: new Namespace(["memory", "event-bus"]),
+    eventBus: redisPubSubEventBusAdapter
 });
 
 const redisLockAdapter = new RedisLockAdapter({
@@ -622,11 +616,9 @@ const redisLockAdapter = new RedisLockAdapter({
 });
 const redisLockFactory = new LockFactory({
     adapter: redisLockAdapter,
-    eventBus: new EventBus({
-        // We assign distinct namespaces to MemoryLockAdapter and RedisLockAdapter to isolate their events.
-        namespace: new Namespace(["redis", "event-bus"]),
-        adapter: redisPubSubEventBusAdapter,
-    }),
+    // We assign distinct namespaces to MemoryLockAdapter and RedisLockAdapter to isolate their events.
+    namespace: new Namespace(["redis", "event-bus"]),
+    eventBus: redisPubSubEventBusAdapter
 });
 ```
 
@@ -645,7 +637,6 @@ The library includes 3 additional contracts:
 This seperation makes it easy to visually distinguish the 3 contracts, making it immediately obvious that they serve different purposes.
 
 ```ts
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { MemoryEventBusAdapter } from "@daiso-tech/core/event-bus/memory-event-bus-adapter";
 import { LockFactory } from "@daiso-tech/core/lock";
 import { MemoryLockAdapter } from "@daiso-tech/core/lock/memory-lock-adapter";
@@ -686,9 +677,7 @@ async function lockListenableFunc(
 
 const lockFactory = new LockFactory({
     adapter: new MemoryLockAdapter(),
-    eventBus: new EventBus({
-        adapter: new MemoryEventBusAdapter(),
-    }),
+    eventBus: new MemoryEventBusAdapter(),
 });
 await lockListenableFunc(lockFactory.events);
 await lockFactoryFunc(lockFactory);

--- a/website/docs/components/rate-limiter/rate_limiter_usage.md
+++ b/website/docs/components/rate-limiter/rate_limiter_usage.md
@@ -263,22 +263,19 @@ await eventBus.addListener("sending-rate-limiter-over-network", ({ rateLimiter }
 ### Rate-limiter events
 
 You can listen to different [rate-limiter events](https://daiso-tech.github.io/daiso-core/modules/RateLimiter.html) that are triggered by the `RateLimiter` instance.
-Refer to the [`EventBus`](../event_bus/event_bus_usage.md) documentation to learn how to use events. Since no events are dispatched by default, you need to pass an object that implements `IEventBus` contract.
+Refer to the [`EventBus`](../event_bus/event_bus_usage.md) documentation to learn how to use events. Since no events are dispatched by default, you need to pass an object that implements `IEventBus` or `IEventBusAdapter` contract.
 
 ```ts
 import { MemoryRateLimiterStorageAdapter } from "@daiso-tech/core/rate-limiter/memory-rate-limiter-storage-adapter";
 import { DatabaseRateLimiterAdapter } from "@daiso-tech/core/rate-limiter/database-rate-limiter-adapter";
 import { RateLimiterFactory, RATE_LIMITER_EVENTS } from "@daiso-tech/core/rate-limiter";
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { MemoryEventBusAdapter } from "@daiso-tech/core/event-bus/memory-event-bus-adapter";
 
 const rateLimiterFactory = new RateLimiterFactory({
     adapter: new DatabaseRateLimiterAdapter({ 
         adapter: new MemoryRateLimiterStorageAdapter()
     }),
-    eventBus: new EventBus({
-        adapter: new MemoryEventBusAdapter(),
-    }),
+    eventBus: new MemoryEventBusAdapter(),
 });
 
 await rateLimiterFactory.events.addListener(RATE_LIMITER_EVENTS.BLOCKED, (_event) => {
@@ -295,7 +292,6 @@ If multiple rate-limiter adapters (e.g., `RedisRateLimiterAdapter` and `Database
 import { RedisRateLimiterAdapter } from "@daiso-tech/core/rate-limiter/redis-rate-limiter-adapter";
 import { MemoryRateLimiterStorageAdapter } from "@daiso-tech/core/rate-limiter/memory-rate-limiter-storage-adapter";
 import { DatabaseRateLimiterAdapter } from "@daiso-tech/core/rate-limiter/database-rate-limiter-adapter";
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { RedisPubSubEventBusAdapter } from "@daiso-tech/core/event-bus/redis-pub-sub-event-bus-adapter";
 import { Serde } from "@daiso-tech/core/serde";
 import { SuperJsonSerdeAdapter } from "@daiso-tech/core/serde/super-json-serde-adapter";
@@ -313,11 +309,9 @@ const memoryRateLimiterFactory = new RateLimiterFactory({
     adapter: new DatabaseRateLimiterAdapter({ 
         adapter: new MemoryRateLimiterStorageAdapter()
     }),
-    eventBus: new EventBus({
-        // We assign distinct namespaces to DatabaseRateLimiterAdapter and RedisRateLimiterAdapter to isolate their events.
-        namespace: new Namespace(["memory", "event-bus"]),
-        adapter: redisPubSubEventBusAdapter,
-    }),
+    // We assign distinct namespaces to DatabaseRateLimiterAdapter and RedisRateLimiterAdapter to isolate their events.
+    namespace: new Namespace(["memory", "event-bus"]),
+    eventBus: redisPubSubEventBusAdapter
 });
 
 const redisRateLimiterAdapter = new RedisRateLimiterAdapter({
@@ -326,11 +320,9 @@ const redisRateLimiterAdapter = new RedisRateLimiterAdapter({
 });
 const redisRateLimiterFactory = new RateLimiterFactory({
     adapter: redisRateLimiterAdapter,
-    eventBus: new EventBus({
-        // We assign distinct namespaces to DatabaseRateLimiterAdapter and RedisRateLimiterAdapter to isolate their events.
-        namespace: new Namespace(["redis", "event-bus"]),
-        adapter: redisPubSubEventBusAdapter,
-    }),
+    // We assign distinct namespaces to DatabaseRateLimiterAdapter and RedisRateLimiterAdapter to isolate their events.
+    namespace: new Namespace(["redis", "event-bus"]),
+    eventBus: redisPubSubEventBusAdapter
 });
 ```
 
@@ -349,7 +341,6 @@ The library includes 3 additional contracts:
 This seperation makes it easy to visually distinguish the 3 contracts, making it immediately obvious that they serve different purposes.
 
 ```ts
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { MemoryEventBusAdapter } from "@daiso-tech/core/event-bus/memory-event-bus-adapter";
 import { RateLimiterFactory } from "@daiso-tech/core/rate-limiter";
 import { MemoryRateLimiterStorageAdapter } from "@daiso-tech/core/rate-limiter/memory-rate-limiter-storage-adapter";
@@ -390,9 +381,7 @@ const rateLimiterFactory = new RateLimiterFactory({
     adapter: new DatabaseRateLimiterAdapter({
         adapter: new MemoryRateLimiterStorageAdapter(),
     }),
-    eventBus: new EventBus({
-        adapter: new MemoryEventBusAdapter()
-    })
+    eventBus: new MemoryEventBusAdapter()
 })
 await rateLimiterListenableFunc(rateLimiterFactory.events);
 await rateLimiterFactoryFunc(rateLimiterFactory);

--- a/website/docs/components/semaphore/semaphore_usage.md
+++ b/website/docs/components/semaphore/semaphore_usage.md
@@ -646,19 +646,16 @@ await eventBus.addListener(
 ### Semaphore events
 
 You can listen to different [semaphore events](https://daiso-tech.github.io/daiso-core/modules/Semaphore.html) that are triggered by the `Semaphore` instance.
-Refer to the [`EventBus`](../event_bus/event_bus_usage.md) documentation to learn how to use events. Since no events are dispatched by default, you need to pass an object that implements `IEventBus` contract.
+Refer to the [`EventBus`](../event_bus/event_bus_usage.md) documentation to learn how to use events. Since no events are dispatched by default, you need to pass an object that implements `IEventBus` or `IEventBusAdapter` contract.
 
 ```ts
 import { MemorySemaphoreAdapter } from "@daiso-tech/core/semaphore/memory-semaphore-adapter";
 import { SemaphoreFactory, SEMAPHORE_EVENTS } from "@daiso-tech/core/semaphore";
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { MemoryEventBusAdapter } from "@daiso-tech/core/event-bus/memory-event-bus-adapter";
 
 const semaphoreFactory = new SemaphoreFactory({
     adapter: new MemorySemaphoreAdapter(),
-    eventBus: new EventBus({
-        adapter: new MemoryEventBusAdapter(),
-    }),
+    eventBus: new MemoryEventBusAdapter(),
 });
 
 await semaphoreFactory.events.addListener(SEMAPHORE_EVENTS.ACQUIRED, () => {
@@ -674,7 +671,6 @@ If multiple semaphore adapters (e.g., `RedisSemaphoreAdapter` and `MemorySemapho
 ```ts
 import { RedisSemaphoreAdapter } from "@daiso-tech/core/semaphore/redis-semaphore-adapter";
 import { MemorySemaphoreAdapter } from "@daiso-tech/core/semaphore/memory-semaphore-adapter";
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { RedisPubSubEventBusAdapter } from "@daiso-tech/core/event-bus/redis-pub-sub-event-bus-adapter";
 import { Serde } from "@daiso-tech/core/serde";
 import { SuperJsonSerdeAdapter } from "@daiso-tech/core/serde/super-json-serde-adapter";
@@ -691,11 +687,9 @@ const redisPubSubEventBusAdapter = new RedisPubSubEventBusAdapter({
 const memorySemaphoreAdapter = new MemorySemaphoreAdapter();
 const memorySemaphoreFactory = new SemaphoreFactory({
     adapter: memorySemaphoreAdapter,
-    eventBus: new EventBus({
-        // We assign distinct namespaces to MemorySemaphoreAdapter and RedisSemaphoreAdapter to isolate their events.
-        namespace: new Namespace(["memory", "event-bus"]),
-        adapter: redisPubSubEventBusAdapter,
-    }),
+    // We assign distinct namespaces to MemorySemaphoreAdapter and RedisSemaphoreAdapter to isolate their events.
+    namespace: new Namespace(["memory", "event-bus"]),
+    eventBus: redisPubSubEventBusAdapter
 });
 
 const redisSemaphoreAdapter = new RedisSemaphoreAdapter({
@@ -704,11 +698,9 @@ const redisSemaphoreAdapter = new RedisSemaphoreAdapter({
 });
 const redisSemaphoreFactory = new SemaphoreFactory({
     adapter: redisSemaphoreAdapter,
-    eventBus: new EventBus({
-        // We assign distinct namespaces to MemorySemaphoreAdapter and RedisSemaphoreAdapter to isolate their events.
-        namespace: new Namespace(["redis", "event-bus"]),
-        adapter: redisPubSubEventBusAdapter,
-    }),
+    // We assign distinct namespaces to MemorySemaphoreAdapter and RedisSemaphoreAdapter to isolate their events.
+    namespace: new Namespace(["redis", "event-bus"]),
+    eventBus: redisPubSubEventBusAdapter
 });
 ```
 
@@ -727,7 +719,6 @@ The library includes 3 additional contracts:
 This seperation makes it easy to visually distinguish the 3 contracts, making it immediately obvious that they serve different purposes.
 
 ```ts
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { MemoryEventBusAdapter } from "@daiso-tech/core/event-bus/memory-event-bus-adapter";
 import { SemaphoreFactory } from "@daiso-tech/core/semaphore";
 import { MemorySemaphoreAdapter } from "@daiso-tech/core/semaphore/memory-semaphore-adapter";
@@ -778,9 +769,7 @@ async function semaphoreListenableFunc(
 
 const semaphoreFactory = new SemaphoreFactory({
     adapter: new MemorySemaphoreAdapter(),
-    eventBus: new EventBus({
-        adapter: new MemoryEventBusAdapter(),
-    }),
+    eventBus: new MemoryEventBusAdapter(),
 });
 await semaphoreListenableFunc(semaphoreFactory.events);
 await semaphoreFactoryFunc(semaphoreFactory);

--- a/website/docs/components/shared_lock/shared_lock_usage.md
+++ b/website/docs/components/shared_lock/shared_lock_usage.md
@@ -971,7 +971,7 @@ await eventBus.addListener(
 ### Shared-lock events
 
 You can listen to different [shared-lock events](https://daiso-tech.github.io/daiso-core/modules/SharedLock.html) that are triggered by the `Shared-lock` instance.
-Refer to the [`EventBus`](../event_bus/event_bus_usage.md) documentation to learn how to use events. Since no events are dispatched by default, you need to pass an object that implements `IEventBus` contract.
+Refer to the [`EventBus`](../event_bus/event_bus_usage.md) documentation to learn how to use events. Since no events are dispatched by default, you need to pass an object that implements `IEventBus` or `IEventBusAdapter` contract.
 
 ```ts
 import { MemorySharedLockAdapter } from "@daiso-tech/core/shared-lock/memory-shared-lock-adapter";
@@ -980,15 +980,12 @@ import {
     SHARED_LOCK_EVENTS,
 } from "@daiso-tech/core/shared-lock";
 import { MemoryEventBusAdapter } from "@daiso-tech/core/event-bus/memory-event-bus-adapter";
-import { EventBus } from "@daiso-tech/core/event-bus";
 
 const redisPubSubEventBusAdapter = new MemoryEventBusAdapter();
 
 const sharedLock = new SharedLockFactory({
     adapter: new MemorySharedLockAdapter(),
-    eventBus: new EventBus({
-        adapter: redisPubSubEventBusAdapter,
-    }),
+    eventBus: redisPubSubEventBusAdapter
 });
 
 await sharedLockFactory.events.addListener(
@@ -1007,7 +1004,6 @@ If multiple shared-lock adapters (e.g., `RedisSharedLockAdapter` and `MemoryShar
 ```ts
 import { RedisSharedLockAdapter } from "@daiso-tech/core/shared-lock/redis-shared-lock-adapter";
 import { MemorySharedLockAdapter } from "@daiso-tech/core/shared-lock/memory-shared-lock-adapter";
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { RedisPubSubEventBusAdapter } from "@daiso-tech/core/event-bus/redis-pub-sub-event-bus-adapter";
 import { Serde } from "@daiso-tech/core/serde";
 import { SuperJsonSerdeAdapter } from "@daiso-tech/core/serde/super-json-serde-adapter";
@@ -1024,11 +1020,9 @@ const redisPubSubEventBusAdapter = new RedisPubSubEventBusAdapter({
 const memorySharedLockAdapter = new MemorySharedLockAdapter();
 const memorySharedLockFactory = new SharedLockFactory({
     adapter: memorySharedLockAdapter,
-    eventBus: new EventBus({
-        // We assign distinct namespaces to MemorySharedLockAdapter and RedisSharedLockAdapter to isolate their events.
-        namespace: new Namespace(["memory", "event-bus"]),
-        adapter: redisPubSubEventBusAdapter,
-    }),
+    // We assign distinct namespaces to MemorySharedLockAdapter and RedisSharedLockAdapter to isolate their events.
+    namespace: new Namespace(["memory", "event-bus"]),
+    eventBus: redisPubSubEventBusAdapter
 });
 
 const redisSharedLockAdapter = new RedisSharedLockAdapter({
@@ -1037,11 +1031,9 @@ const redisSharedLockAdapter = new RedisSharedLockAdapter({
 });
 const redisSharedLockFactory = new SharedLockFactory({
     adapter: redisSharedLockAdapter,
-    eventBus: new EventBus({
-        // We assign distinct namespaces to MemorySharedLockAdapter and RedisSharedLockAdapter to isolate their events.
-        namespace: new Namespace(["redis", "event-bus"]),
-        adapter: redisPubSubEventBusAdapter,
-    }),
+    // We assign distinct namespaces to MemorySharedLockAdapter and RedisSharedLockAdapter to isolate their events.
+    namespace: new Namespace(["redis", "event-bus"]),
+    eventBus: redisPubSubEventBusAdapter
 });
 ```
 
@@ -1064,7 +1056,6 @@ The library includes 3 additional contracts:
 This seperation makes it easy to visually distinguish the 3 contracts, making it immediately obvious that they serve different purposes.
 
 ```ts
-import { EventBus } from "@daiso-tech/core/event-bus";
 import { MemoryEventBusAdapter } from "@daiso-tech/core/event-bus/memory-event-bus-adapter";
 import { SharedLockFactory } from "@daiso-tech/core/shared-lock";
 import { MemorySharedLockAdapter } from "@daiso-tech/core/shared-lock/memory-shared-lock-adapter";
@@ -1152,9 +1143,7 @@ async function sharedLockListenableFunc(
 
 const sharedLockFactory = new SharedLockFactory({
     adapter: new MemorySharedLockAdapter(),
-    eventBus: new EventBus({
-        adapter: new MemoryEventBusAdapter(),
-    }),
+    eventBus: new MemoryEventBusAdapter(),
 });
 await sharedLockListenableFunc(sharedLockFactory.events);
 await sharedLockFactoryFunc(sharedLockFactory);


### PR DESCRIPTION
- **Updated lockFactory setting to take ILockFactory, ILockAdapter, IDatabaseLockAdapter**
- **Updated eventBus setting to take IEventBus and IEventBusAdapter**
- **Added src code docs**
- **Updated website docs**
- **Updated src code docs**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated usage examples across Cache, CircuitBreaker, FileStorage, Lock, RateLimiter, Semaphore, and SharedLock to show passing event-bus and lock-factory adapters directly.

* **Refactor**
  * Public APIs now accept adapter-or-instance inputs for event-bus and lock-factory settings, reducing wrapper boilerplate.

* **New Features**
  * Added runtime type guards and normalization helpers so adapters or instances are accepted transparently.

* **Tests**
  * Added tests validating the new type-guard behavior.

* **Chore**
  * Removed a legacy broad cache union type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->