### PR TITLE
enhancement/more cache plugins

### DIFF
--- a/.changeset/cache-plugins.md
+++ b/.changeset/cache-plugins.md
@@ -1,0 +1,132 @@
+---
+"@daiso-tech/core": minor
+---
+
+## Architectural Shift: Composable Cache Plugins
+
+The cache module has undergone a significant architectural refactoring. Behaviours that were previously hard-coded into the `Cache` and `CacheResolver` implementations — schema validation, TTL jitter, and write-lock serialisation — have been extracted into standalone, composable plugins. The core `Cache` class is now a thin passthrough that delegates operations directly to the underlying `ICacheAdapter`, while optional capabilities are layered on via the middleware plugin system (`PluginFn`/`withPlugin`).
+
+### Motivation
+
+The previous architecture baked cross-cutting concerns like schema validation, TTL jittering, and distributed write locking directly into the `Cache` and `CacheResolver` classes. This had several drawbacks:
+
+- **Tight coupling**: Users who wanted only one feature (e.g., schema validation) still paid the overhead of the other features.
+- **Difficult to extend**: Adding new cross-cutting behaviours required modifying the core `Cache` class, increasing complexity and risk.
+- **No composability**: Behaviours could not be mixed, matched, or reordered independently.
+- **Testing complexity**: Core cache tests had to account for all combined behaviours.
+
+The new plugin-based architecture solves these problems by keeping the `Cache` class focused on a single responsibility — delegating to an `ICacheAdapter` — and providing each cross-cutting behaviour as an independent `PluginFn<ICacheAdapter>` that can be composed via `withPlugin(adapter, ...plugins)`.
+
+### New Plugin-Based Capabilities
+
+The following behaviours are no longer built into `Cache` or `CacheResolver`. They are available as opt-in plugins that operate at the `ICacheAdapter` level:
+
+**`withCacheJitter`** — Adds random jitter to TTL values on `add` and `put` operations to help prevent cache stampedes (thundering-herd problems).
+
+- Configurable via `defaultJitter` (default ±20 %).
+- Applied as a middleware that intercepts TTL parameters before they reach the adapter.
+- `WITHOUT` this plugin, TTLs are stored as-is — no jitter is applied.
+- Import path: `@daiso-tech/core/cache/plugins`
+
+**`withCacheSchema`** — Validates cache values against a `StandardSchemaV1`-compliant schema before storing (`add`, `put`, `update`) and optionally on retrieval (`get`, `getAndRemove`).
+
+- Controlled via `shouldValidateOutput` (default `true`).
+- `WITHOUT` this plugin, no schema validation occurs — any value type is accepted.
+- Import path: `@daiso-tech/core/cache/plugins`
+
+**`withCacheWriteLock`** — Acquires a distributed lock via `ILockFactory` before executing mutating cache operations (`add`, `put`, `update`, `increment`, `getAndRemove`, `removeMany`), ensuring concurrent writes to the same cache entry are serialised.
+
+- The set of protected methods is configurable via `onlyMethods`.
+- `WITHOUT` this plugin, concurrent writes proceed without locking — the adapter's own concurrency guarantees apply.
+- Import path: `@daiso-tech/core/cache/plugins`
+
+### How the New Architecture Works
+
+The `Cache` class (`src/cache/implementations/derivables/cache/cache.ts`) has been simplified to a thin wrapper that:
+
+1. Accepts an `ICacheAdapter` (optionally enhanced by plugins) via `CacheSettings.adapter`.
+2. Delegates every operation ( `get`, `add`, `put`, `update`, `increment`, `remove`, `clear`, etc.) directly to the adapter.
+3. No longer performs schema validation, TTL jittering, or write-lock acquisition internally.
+
+The `CacheResolver` class (`src/cache/implementations/derivables/cache-resolver/cache-resolver.ts`) has been similarly streamlined:
+
+- Its `use()` method creates a plain `Cache` instance with no built-in plugins.
+- `CacheResolverSettings` extends `CacheSettingsBase`, which now only contains `defaultTtl` and `context`.
+- To use plugins with `CacheResolver`, users must apply plugins to the adapter _before_ registering it, or wrap the adapter at registration time.
+
+The `ICache` contract (`src/cache/contracts/cache.contract.ts`) now uses inline `ttl?: ITimeSpan | null` parameters instead of the removed `CacheWriteSettings` object for `add`, `put`, `getOrAdd`, and related methods. This simplifies the API surface and aligns with the plugin philosophy — TTL manipulation is handled at the plugin/adapter level.
+
+### Plugin Composition Pattern
+
+Plugins are applied to an `ICacheAdapter` before passing it to `Cache`:
+
+```ts
+import { withPlugin } from "@daiso-tech/core/middleware";
+import { MemoryCacheAdapter } from "@daiso-tech/core/cache/memory-cache-adapter";
+import { Cache } from "@daiso-tech/core/cache";
+import { withCacheSchema } from "@daiso-tech/core/cache/plugins";
+import { withCacheJitter } from "@daiso-tech/core/cache/plugins";
+import { withCacheWriteLock } from "@daiso-tech/core/cache/plugins";
+import { z } from "zod";
+
+// Compose multiple plugins on the adapter
+const adapter = withPlugin(
+    new MemoryCacheAdapter(),
+    withCacheSchema({ schema: z.string() }),
+    withCacheJitter({ defaultJitter: 0.1 }),
+    withCacheWriteLock({ lockFactory }),
+);
+
+// Pass the enhanced adapter to the thin Cache class
+const cache = new Cache({ adapter });
+```
+
+Plugins are applied in order and wrap the adapter's methods using the `Enhance` utility. `withPluginFactory(enhanceFactory(useFactory()))` is the standard way to create a `withPlugin` function that supports method interception.
+
+### Migration Path
+
+Users who relied on the previous built-in schema validation, TTL jitter, or write-lock behaviour must now explicitly compose the corresponding plugins.
+
+| Previous behaviour                      | New requirement                                               |
+| --------------------------------------- | ------------------------------------------------------------- |
+| Schema validation on cache reads/writes | Apply `withCacheSchema({ schema })` to the adapter            |
+| TTL jitter to prevent stampedes         | Apply `withCacheJitter({ defaultJitter })` to the adapter     |
+| Distributed write locking               | Apply `withCacheWriteLock({ lockFactory })` to the adapter    |
+| All three behaviours combined           | Apply all three plugins via `withPlugin(adapter, p1, p2, p3)` |
+
+**Before (built-in behaviour):**
+
+```ts
+// Schema validation and jitter were built into Cache/CacheResolver
+const cache = new Cache({ adapter, schema: mySchema });
+```
+
+**After (explicit plugin composition):**
+
+```ts
+const enhancedAdapter = withPlugin(
+    adapter,
+    withCacheSchema({ schema: mySchema }),
+    withCacheJitter(),
+);
+const cache = new Cache({ adapter: enhancedAdapter });
+```
+
+If you do not apply any plugins, the cache behaves as a pure passthrough — no validation, no jitter, no locking. This reduces overhead when these features are not needed.
+
+### Refactoring Details
+
+- **`CacheSettingsBase`**: Removed `schema` and `lockFactory` options. Now only contains `defaultTtl` and `context`.
+- **`CacheResolverSettings`**: Simplified to extend the lean `CacheSettingsBase`. No longer carries schema or write-lock configuration.
+- **`CacheWriteSettings`**: Removed. TTL is now passed as an inline `ITimeSpan | null` parameter directly on `add`, `put`, `getOrAdd`, etc.
+- **`withCacheFactory`**: Updated to accept inline TTL parameter instead of `CacheWriteSettings`.
+- **`ICache` contract**: `getOrAdd` now accepts `ttl?: ITimeSpan | null` as its third parameter instead of a `CacheWriteSettings` object.
+
+### Fixes
+
+- Added missing trailing comma to `getOrAdd` method signature in `ICache`.
+
+### Tests
+
+- Restructured `with*Prefix` test suites across all components (cache, circuit-breaker, file-storage, lock, rate-limiter, semaphore, shared-lock) for improved readability and consistency.
+- New dedicated test suites for each plugin (`with-cache-jitter.test.ts`, `with-cache-schema.test.ts`, `with-cache-write-lock.test.ts`) verifying isolation and composition correctness.

--- a/.changeset/with-prefix-plugins.md
+++ b/.changeset/with-prefix-plugins.md
@@ -1,0 +1,84 @@
+---
+"@daiso-tech/core": minor
+---
+
+Refactored the built-in namespacing system into opt-in `with*Prefix` plugins across all affected components. The `@daiso-tech/core/namespace` module (`INamespace`, `IKey`, `Namespace` class, `NoOpNamespace` class) has been removed. Key management is now simplified to plain strings, and prefixing is handled via middleware plugins when needed.
+
+### What changed
+
+**Removed `@daiso-tech/core/namespace` module** — The following are no longer available:
+- `INamespace` contract — factory interface for creating namespaced keys
+- `IKey` interface — hierarchically-organized key with namespace awareness
+- `Namespace` class — configurable namespace with delimiter and root identifier support
+- `NoOpNamespace` class — namespace that passes keys through unchanged
+
+**Removed `namespace` setting** from component constructors:
+- `Cache` — `CacheSettingsBase.namespace`
+- `EventBus` — `EventBusSettingsBase.namespace`
+- `LockFactory` — `LockFactorySettingsBase.namespace`
+- `CircuitBreakerFactory`, `FileStorage`, `RateLimiterFactory`, `SemaphoreFactory`, `SharedLockFactory` — same pattern
+
+**Simplified key types** across all components:
+- Method parameters changed from `IKey` to `string`
+- `removeMany(keys: Iterable<string>)` → `removeMany(keys: Array<string>)`
+- Error classes (`KeyNotFoundCacheError`, `KeyExistsCacheError`, etc.) now accept `string` instead of `IKey`
+- `ILockState.key` changed from `IKey` to `string`
+
+### Replacement: `with*Prefix` plugins
+
+Key prefixing is now opt-in via middleware plugins. Available plugins:
+
+| Component | Plugin |
+|---|---|
+| cache | `withCachePrefix` |
+| circuit-breaker | `withCircuitBreakerPrefix` |
+| file-storage | `withFileStoragePrefix` |
+| lock | `withLockPrefix` |
+| rate-limiter | `withRateLimiterPrefix` |
+| semaphore | `withSemaphorePrefix` |
+| shared-lock | `withSharedLockPrefix` |
+
+### Usage
+
+```ts
+import { withPlugin } from "@daiso-tech/core/middleware";
+import { withCachePrefix } from "@daiso-tech/core/cache/plugins";
+
+const adapter = new MemoryCacheAdapter();
+const prefixedAdapter = withPlugin(adapter, withCachePrefix("tenant-42:"));
+
+// Keys are automatically prefixed:
+await prefixedAdapter.add(context, "my-key", "value");
+// Internally calls adapter.add(context, "tenant-42:my-key", "value")
+```
+
+### Migration
+
+**If you used `Namespace` directly** — replace with a `with*Prefix` plugin on the adapter:
+
+```diff
+-import { Cache, Namespace } from "@daiso-tech/core";
+-
+-const cache = new Cache({
+-    adapter: new MemoryCacheAdapter(),
+-    namespace: new Namespace("my-app"),
+-});
++import { Cache } from "@daiso-tech/core";
++import { withPlugin } from "@daiso-tech/core/middleware";
++import { withCachePrefix } from "@daiso-tech/core/cache/plugins";
++
++const adapter = withPlugin(new MemoryCacheAdapter(), withCachePrefix("my-app:"));
++const cache = new Cache({ adapter });
+```
+
+**If you imported `INamespace` or `IKey` types** — update to use plain `string` instead.
+
+**If you were using `NoOpNamespace`** — simply omit the `namespace` setting (it was the default).
+
+### Use cases
+
+- **Multi-tenant systems** — Prefix keys with a tenant identifier to isolate data
+- **Environment isolation** — Separate dev, staging, and production data
+- **Versioning** — Prefix keys with a schema version
+- **Module scoping** — Organize keys by feature to avoid collisions
+

--- a/.changeset/with-prefix-plugins.md
+++ b/.changeset/with-prefix-plugins.md
@@ -7,18 +7,21 @@ Refactored the built-in namespacing system into opt-in `with*Prefix` plugins acr
 ### What changed
 
 **Removed `@daiso-tech/core/namespace` module** — The following are no longer available:
+
 - `INamespace` contract — factory interface for creating namespaced keys
 - `IKey` interface — hierarchically-organized key with namespace awareness
 - `Namespace` class — configurable namespace with delimiter and root identifier support
 - `NoOpNamespace` class — namespace that passes keys through unchanged
 
 **Removed `namespace` setting** from component constructors:
+
 - `Cache` — `CacheSettingsBase.namespace`
 - `EventBus` — `EventBusSettingsBase.namespace`
 - `LockFactory` — `LockFactorySettingsBase.namespace`
 - `CircuitBreakerFactory`, `FileStorage`, `RateLimiterFactory`, `SemaphoreFactory`, `SharedLockFactory` — same pattern
 
 **Simplified key types** across all components:
+
 - Method parameters changed from `IKey` to `string`
 - `removeMany(keys: Iterable<string>)` → `removeMany(keys: Array<string>)`
 - Error classes (`KeyNotFoundCacheError`, `KeyExistsCacheError`, etc.) now accept `string` instead of `IKey`
@@ -28,15 +31,15 @@ Refactored the built-in namespacing system into opt-in `with*Prefix` plugins acr
 
 Key prefixing is now opt-in via middleware plugins. Available plugins:
 
-| Component | Plugin |
-|---|---|
-| cache | `withCachePrefix` |
+| Component       | Plugin                     |
+| --------------- | -------------------------- |
+| cache           | `withCachePrefix`          |
 | circuit-breaker | `withCircuitBreakerPrefix` |
-| file-storage | `withFileStoragePrefix` |
-| lock | `withLockPrefix` |
-| rate-limiter | `withRateLimiterPrefix` |
-| semaphore | `withSemaphorePrefix` |
-| shared-lock | `withSharedLockPrefix` |
+| file-storage    | `withFileStoragePrefix`    |
+| lock            | `withLockPrefix`           |
+| rate-limiter    | `withRateLimiterPrefix`    |
+| semaphore       | `withSemaphorePrefix`      |
+| shared-lock     | `withSharedLockPrefix`     |
 
 ### Usage
 
@@ -81,4 +84,3 @@ await prefixedAdapter.add(context, "my-key", "value");
 - **Environment isolation** — Separate dev, staging, and production data
 - **Versioning** — Prefix keys with a schema version
 - **Module scoping** — Organize keys by feature to avoid collisions
-

--- a/src/cache/contracts/cache.contract.ts
+++ b/src/cache/contracts/cache.contract.ts
@@ -13,35 +13,6 @@ import {
 } from "@/utilities/_module.js";
 
 /**
- * Configuration settings for cache write operations.
- *
- * IMPORT_PATH: `"@daiso-tech/core/cache/contracts"`
- * @group Contracts
- */
-export type CacheWriteSettings = {
-    /**
-     * Time-to-live (TTL) duration for cached entries.
-     * When set, entries will automatically expire after this duration.
-     * Pass `null` to cache entries without automatic expiration.
-     */
-    ttl?: ITimeSpan | null;
-
-    /**
-     * Random jitter factor (0-1) to add variance to expiration times.
-     * Prevents thundering herd problems when many entries expire simultaneously.
-     * A value of 0.1 adds ±10% randomness to the TTL.
-     */
-    jitter?: number;
-
-    /**
-     * Used internally for testing to control random number generation.
-     *
-     * @internal
-     */
-    _mathRandom?: () => number;
-};
-
-/**
  * The `IReadableCache` contract defines a read-only interface for accessing cached key-value pairs.
  * It provides methods to retrieve values independent of the underlying cache storage backend (Redis, Memcached, database, etc.).
  * Use this contract when you need read-only access to cache data without mutation capabilities.
@@ -100,24 +71,6 @@ export type IReadableCache<TType = unknown> = {
 };
 
 /**
- * Configuration settings for cache get-or-add operations.
- * Extends {@link CacheWriteSettings | `CacheWriteSettings`} to support atomic read-compute-write patterns.
- *
- * IMPORT_PATH: `"@daiso-tech/core/cache/contracts"`
- * @group Contracts
- */
-export type GetOrAddSettings = CacheWriteSettings & {
-    /**
-     * Enable distributed locking for the get-or-add operation.
-     * When enabled, uses a lock to ensure only one client computes and caches the value,
-     * preventing cache stampedes when multiple clients request the same missing key.
-     *
-     * @default false
-     */
-    enableLocking?: boolean;
-};
-
-/**
  * The `ICache` contract defines a way for storing and reading as key-value pairs independent of data storage.
  *
  * IMPORT_PATH: `"@daiso-tech/core/cache/contracts"`
@@ -140,7 +93,7 @@ export type ICache<TType = unknown> = IReadableCache<TType> & {
     getOrAdd(
         key: string,
         valueToAdd: AsyncLazyable<NoneFunc<TType>>,
-        settings?: GetOrAddSettings,
+        ttl?: ITimeSpan | null
     ): Promise<TType>;
 
     /**
@@ -151,11 +104,7 @@ export type ICache<TType = unknown> = IReadableCache<TType> & {
      * @returns Returns true when key doesn't exists otherwise false will be returned.
      * @throws {ValidationError}
      */
-    add(
-        key: string,
-        value: TType,
-        settings?: CacheWriteSettings,
-    ): Promise<boolean>;
+    add(key: string, value: TType, ttl?: ITimeSpan): Promise<boolean>;
 
     /**
      * The `addOrFail` method adds a `key` with given `value` when key doesn't exists.
@@ -164,11 +113,7 @@ export type ICache<TType = unknown> = IReadableCache<TType> & {
      * @throws {KeyExistsCacheError}
      * @throws {ValidationError}
      */
-    addOrFail(
-        key: string,
-        value: TType,
-        settings?: CacheWriteSettings,
-    ): Promise<void>;
+    addOrFail(key: string, value: TType, ttl?: ITimeSpan): Promise<void>;
 
     /**
      * The `put` methods upsert the given key and replaces the ttl when updated.
@@ -178,11 +123,7 @@ export type ICache<TType = unknown> = IReadableCache<TType> & {
      * @returns Returns true if the `key` where replaced otherwise false is returned.
      * @throws {ValidationError}
      */
-    put(
-        key: string,
-        value: TType,
-        settings?: CacheWriteSettings,
-    ): Promise<boolean>;
+    put(key: string, value: TType, ttl?: ITimeSpan): Promise<boolean>;
 
     /**
      * The `update` method updates the given `key` with given `value`.

--- a/src/cache/contracts/cache.contract.ts
+++ b/src/cache/contracts/cache.contract.ts
@@ -93,7 +93,7 @@ export type ICache<TType = unknown> = IReadableCache<TType> & {
     getOrAdd(
         key: string,
         valueToAdd: AsyncLazyable<NoneFunc<TType>>,
-        ttl?: ITimeSpan | null
+        ttl?: ITimeSpan | null,
     ): Promise<TType>;
 
     /**

--- a/src/cache/implementations/derivables/cache-resolver/cache-resolver.ts
+++ b/src/cache/implementations/derivables/cache-resolver/cache-resolver.ts
@@ -2,8 +2,6 @@
  * @module Cache
  */
 
-import { type StandardSchemaV1 } from "@standard-schema/spec";
-
 import {
     type CacheAdapterVariants,
     type ICache,
@@ -14,7 +12,6 @@ import {
     type CacheSettingsBase,
 } from "@/cache/implementations/derivables/cache/_module.js";
 import { type IReadableContext } from "@/execution-context/contracts/_module.js";
-import { type LockFactoryInput } from "@/lock/contracts/_module.js";
 import { type ITimeSpan } from "@/time-span/contracts/_module.js";
 import {
     DefaultAdapterNotDefinedError,
@@ -36,20 +33,18 @@ export type CacheAdapters<TAdapters extends string = string> = Partial<
  * IMPORT_PATH: `"@daiso-tech/core/cache"`
  * @group Derivables
  */
-export type CacheResolverSettings<
-    TAdapters extends string = string,
-    TType = unknown,
-> = CacheSettingsBase<TType> & {
-    /**
-     * Named registry of cache adapters. Each key is an adapter alias and the corresponding value is the adapter instance.
-     */
-    adapters: CacheAdapters<TAdapters>;
+export type CacheResolverSettings<TAdapters extends string = string> =
+    CacheSettingsBase & {
+        /**
+         * Named registry of cache adapters. Each key is an adapter alias and the corresponding value is the adapter instance.
+         */
+        adapters: CacheAdapters<TAdapters>;
 
-    /**
-     * The alias of the adapter to use when none is explicitly specified. Must be a key in the `adapters` map.
-     */
-    defaultAdapter?: NoInfer<TAdapters>;
-};
+        /**
+         * The alias of the adapter to use when none is explicitly specified. Must be a key in the `adapters` map.
+         */
+        defaultAdapter?: NoInfer<TAdapters>;
+    };
 
 /**
  * The `CacheResolver` class is immutable.
@@ -84,9 +79,7 @@ export class CacheResolver<
      *   defaultAdapter: "memory",
      * });
      */
-    constructor(
-        private readonly settings: CacheResolverSettings<TAdapters, TType>,
-    ) {}
+    constructor(private readonly settings: CacheResolverSettings<TAdapters>) {}
 
     setDefaultTtl(ttl: ITimeSpan | null): CacheResolver<TAdapters, TType> {
         return new CacheResolver({
@@ -95,26 +88,8 @@ export class CacheResolver<
         });
     }
 
-    setSchema<TSchemaOutputType>(
-        schema: StandardSchemaV1<TSchemaOutputType>,
-    ): CacheResolver<TAdapters, TSchemaOutputType> {
-        return new CacheResolver({
-            ...this.settings,
-            schema,
-        });
-    }
-
     setType<TOutputType>(): CacheResolver<TAdapters, TOutputType> {
-        return new CacheResolver(
-            this.settings as CacheResolverSettings<TAdapters, TOutputType>,
-        );
-    }
-
-    setJitter(jitter: number): CacheResolver<TAdapters, TType> {
-        return new CacheResolver({
-            ...this.settings,
-            defaultJitter: jitter,
-        });
+        return new CacheResolver(this.settings);
     }
 
     setExecutionContext(
@@ -123,15 +98,6 @@ export class CacheResolver<
         return new CacheResolver({
             ...this.settings,
             context,
-        });
-    }
-
-    setLockFactory(
-        lockFactory: LockFactoryInput,
-    ): CacheResolver<TAdapters, TType> {
-        return new CacheResolver({
-            ...this.settings,
-            lockFactory,
         });
     }
 

--- a/src/cache/implementations/derivables/cache/cache.test.ts
+++ b/src/cache/implementations/derivables/cache/cache.test.ts
@@ -1,144 +1,18 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
-import { z } from "zod";
+import { beforeEach, describe, expect, test } from "vitest";
 
 import { MemoryCacheAdapter } from "@/cache/implementations/adapters/_module.js";
 import { Cache } from "@/cache/implementations/derivables/_module.js";
 import { cacheTestSuite } from "@/cache/implementations/test-utilities/_module.js";
-import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
-import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
-import { NoOpLockAdapter } from "@/lock/implementations/adapters/_module.js";
-import { LockFactory } from "@/lock/implementations/derivables/_module.js";
-import { Lock } from "@/lock/implementations/derivables/lock-factory/lock.js";
-import { ValidationError } from "@/utilities/_module.js";
 
 describe("class: Cache", () => {
     cacheTestSuite({
         createCache: () =>
             new Cache({
                 adapter: new MemoryCacheAdapter(),
-                defaultJitter: null,
             }),
         test,
         beforeEach,
         expect,
         describe,
-    });
-    describe("standard schema:", () => {
-        let adapter: MemoryCacheAdapter;
-        let cache: Cache<string>;
-        beforeEach(() => {
-            adapter = new MemoryCacheAdapter();
-            cache = new Cache({
-                adapter,
-                schema: z.string(),
-            });
-        });
-        describe("input validation:", () => {
-            test("method: add", async () => {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                const invalidInput: string = 0 as any;
-                const promise = cache.add("a", invalidInput);
-                await expect(promise).rejects.toBeInstanceOf(ValidationError);
-            });
-            test("method: addOrFail", async () => {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                const invalidInput: string = 0 as any;
-                const promise = cache.addOrFail("a", invalidInput);
-                await expect(promise).rejects.toBeInstanceOf(ValidationError);
-            });
-            test("method: getOrAdd", async () => {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                const invalidInput: string = 0 as any;
-                const promise = cache.getOrAdd("a", invalidInput);
-                await expect(promise).rejects.toBeInstanceOf(ValidationError);
-            });
-            test("method: update", async () => {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                const invalidInput: string = 0 as any;
-                const promise = cache.update("a", invalidInput);
-                await expect(promise).rejects.toBeInstanceOf(ValidationError);
-            });
-            test("method: updateOrFail", async () => {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                const invalidInput: string = 0 as any;
-                const promise = cache.updateOrFail("a", invalidInput);
-                await expect(promise).rejects.toBeInstanceOf(ValidationError);
-            });
-            test("method: put", async () => {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                const invalidInput: string = 0 as any;
-                const promise = cache.put("a", invalidInput);
-                await expect(promise).rejects.toBeInstanceOf(ValidationError);
-            });
-        });
-        describe("output validation:", () => {
-            const noOpContext = new ExecutionContext(
-                new NoOpExecutionContextAdapter(),
-            );
-            test("method: get", async () => {
-                await adapter.add(noOpContext, "a", 1, null);
-                const promise = cache.get("a");
-                await expect(promise).rejects.toBeInstanceOf(ValidationError);
-            });
-            test("method: getOrFail", async () => {
-                await adapter.add(noOpContext, "a", 1, null);
-                const promise = cache.getOrFail("a");
-                await expect(promise).rejects.toBeInstanceOf(ValidationError);
-            });
-            test("method: getAndRemove", async () => {
-                await adapter.add(noOpContext, "a", 1, null);
-                const promise = cache.getAndRemove("a");
-                await expect(promise).rejects.toBeInstanceOf(ValidationError);
-            });
-            test("method: getOr", async () => {
-                await adapter.add(noOpContext, "a", 1, null);
-                const promise = cache.getOr("a", "1");
-                await expect(promise).rejects.toBeInstanceOf(ValidationError);
-            });
-            test("method: getOrAdd", async () => {
-                await adapter.add(noOpContext, "a", 1, null);
-                const promise = cache.getOrAdd("a", "1");
-                await expect(promise).rejects.toBeInstanceOf(ValidationError);
-            });
-        });
-        describe("Locking:", () => {
-            test("Should call lockFactory.create().runOrFail() when enableLocking is true", async () => {
-                const lockFactory = new LockFactory({
-                    adapter: new NoOpLockAdapter(),
-                });
-                const createSpy = vi.spyOn(lockFactory, "create");
-                const runOrFailSpy = vi.spyOn(Lock.prototype, "runOrFail");
-                const lockingCache = new Cache<string>({
-                    adapter: new MemoryCacheAdapter(),
-                    lockFactory,
-                });
-
-                await lockingCache.getOrAdd("a", "value", {
-                    enableLocking: true,
-                });
-
-                expect(createSpy).toHaveBeenCalledWith("a");
-                expect(runOrFailSpy).toHaveBeenCalledOnce();
-            });
-
-            test("Should not call lockFactory.create().runOrFail() when enableLocking is false", async () => {
-                const lockFactory = new LockFactory({
-                    adapter: new NoOpLockAdapter(),
-                });
-                const createSpy = vi.spyOn(lockFactory, "create");
-                const runOrFailSpy = vi.spyOn(Lock.prototype, "runOrFail");
-                const lockingCache = new Cache<string>({
-                    adapter: new MemoryCacheAdapter(),
-                    lockFactory,
-                });
-
-                await lockingCache.getOrAdd("a", "value", {
-                    enableLocking: false,
-                });
-
-                expect(createSpy).not.toHaveBeenCalled();
-                expect(runOrFailSpy).not.toHaveBeenCalled();
-            });
-        });
     });
 });

--- a/src/cache/implementations/derivables/cache/cache.ts
+++ b/src/cache/implementations/derivables/cache/cache.ts
@@ -2,41 +2,21 @@
  * @module Cache
  */
 
-import { type StandardSchemaV1 } from "@standard-schema/spec";
-
 import {
     type ICache,
     type ICacheAdapter,
     KeyNotFoundCacheError,
     KeyExistsCacheError,
-    type CacheWriteSettings,
-    type GetOrAddSettings,
 } from "@/cache/contracts/_module.js";
 import { type CacheAdapterVariants } from "@/cache/contracts/types.js";
 import { resolveCacheAdapter } from "@/cache/implementations/derivables/cache/resolve-cache-adapter.js";
 import { type IReadableContext } from "@/execution-context/contracts/_module.js";
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
-import {
-    type ILockFactory,
-    type LockFactoryInput,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    type ILockAdapter,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    type IDatabaseLockAdapter,
-} from "@/lock/contracts/_module.js";
-import { NoOpLockAdapter } from "@/lock/implementations/adapters/_module.js";
-import {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    type LockFactory,
-    resolveLockFactoryInput,
-} from "@/lock/implementations/derivables/_module.js";
 import { type ITimeSpan } from "@/time-span/contracts/_module.js";
 import { TimeSpan } from "@/time-span/implementations/_module.js";
 import {
     resolveAsyncLazyable,
-    validate,
-    withJitter,
     type AsyncLazyable,
     type NoneFunc,
 } from "@/utilities/_module.js";
@@ -48,30 +28,12 @@ import {
  * IMPORT_PATH: `"@daiso-tech/core/cache"`
  * @group Derivables
  */
-export type CacheSettingsBase<TType = unknown> = {
-    /**
-     * You can provide any [standard schema](https://standardschema.dev/) compliant object to validate all input and output data to ensure runtime type safety.
-     */
-    schema?: StandardSchemaV1<TType>;
-
-    /**
-     * You can enable validating cache values when retrieving them.
-     * @default true
-     */
-    shouldValidateOutput?: boolean;
-
+export type CacheSettingsBase = {
     /**
      * You can decide the default ttl value. If null is passed then no ttl will be used by default.
      * @default null
      */
     defaultTtl?: ITimeSpan | null;
-
-    /**
-     * You can pass jitter value to ensure the backoff will not execute at the same time.
-     * If you pas null you can disable the jitrter.
-     * @default 0.2
-     */
-    defaultJitter?: number | null;
 
     /**
      * You can pass {@link IReadableContext | `IReadableContext`} that will be used by context-aware adapters.
@@ -84,18 +46,6 @@ export type CacheSettingsBase<TType = unknown> = {
      * ```
      */
     context?: IReadableContext;
-
-    /**
-     * You can provide an {@link ILockFactoryBase | `ILockFactoryBase`}, an {@link ILockAdapter | `ILockAdapter`} or an {@link IDatabaseLockAdapter | `IDatabaseLockAdapter`} instance to handle locking when {@link GetOrAddSettings | `GetOrAddSettings.enableLocking`} is set to true during a `getOrAdd` call.
-     * If you provide an adapter, it will be automatically wrapped in an {@link LockFactory | `LockFactory`} instance.
-     * @default
-     * ```ts
-     * import { NoOpLockAdapter } from "@daiso-tech/core/lock/no-op-lock-adapter";
-     *
-     * new NoOpLockAdapter()
-     * ```
-     */
-    lockFactory?: LockFactoryInput;
 };
 
 /**
@@ -105,7 +55,7 @@ export type CacheSettingsBase<TType = unknown> = {
  * IMPORT_PATH: `"@daiso-tech/core/cache"`
  * @group Derivables
  */
-export type CacheSettings<TType = unknown> = CacheSettingsBase<TType> & {
+export type CacheSettings = CacheSettingsBase & {
     /**
      * The underlying cache adapter that handles the actual storage operations.
      */
@@ -119,11 +69,7 @@ export type CacheSettings<TType = unknown> = CacheSettingsBase<TType> & {
 export class Cache<TType = unknown> implements ICache<TType> {
     private readonly adapter: ICacheAdapter<TType>;
     private readonly defaultTtl: TimeSpan | null;
-    private readonly schema: StandardSchemaV1<TType> | undefined;
-    private readonly shouldValidateOutput: boolean;
-    private readonly defaultJitter: number | null;
     private readonly context: IReadableContext;
-    private readonly lockFactory: ILockFactory;
 
     /**
      *
@@ -154,25 +100,17 @@ export class Cache<TType = unknown> implements ICache<TType> {
      * });
      * ```
      */
-    constructor(settings: CacheSettings<TType>) {
+    constructor(settings: CacheSettings) {
         const {
-            shouldValidateOutput = true,
-            schema,
             adapter,
             defaultTtl = null,
-            defaultJitter = 0.2,
             context = new ExecutionContext(new NoOpExecutionContextAdapter()),
-            lockFactory = new NoOpLockAdapter(),
         } = settings;
 
-        this.lockFactory = resolveLockFactoryInput(lockFactory);
         this.context = context;
-        this.shouldValidateOutput = shouldValidateOutput;
-        this.schema = schema;
         this.defaultTtl =
             defaultTtl === null ? null : TimeSpan.fromTimeSpan(defaultTtl);
         this.adapter = resolveCacheAdapter(adapter);
-        this.defaultJitter = defaultJitter;
     }
 
     async exists(key: string): Promise<boolean> {
@@ -186,16 +124,7 @@ export class Cache<TType = unknown> implements ICache<TType> {
     }
 
     async get(key: string): Promise<TType | null> {
-        let value = await this.adapter.get(this.context, key);
-        if (
-            this.shouldValidateOutput &&
-            this.schema !== undefined &&
-            value !== null
-        ) {
-            value = await validate(this.schema, value);
-        }
-
-        return value;
+        return await this.adapter.get(this.context, key);
     }
 
     async getOrFail(key: string): Promise<TType> {
@@ -207,16 +136,7 @@ export class Cache<TType = unknown> implements ICache<TType> {
     }
 
     async getAndRemove(key: string): Promise<TType | null> {
-        let value = await this.adapter.getAndRemove(this.context, key);
-        if (
-            this.shouldValidateOutput &&
-            this.schema !== undefined &&
-            value !== null
-        ) {
-            value = await validate(this.schema, value);
-        }
-
-        return value;
+        return await this.adapter.getAndRemove(this.context, key);
     }
 
     async getOr(
@@ -232,88 +152,39 @@ export class Cache<TType = unknown> implements ICache<TType> {
         return value;
     }
 
-    private async _getOrAdd(
+    async getOrAdd(
         key: string,
         valueToAdd: AsyncLazyable<NoneFunc<TType>>,
-        settings?: GetOrAddSettings,
+        ttl: ITimeSpan | null = this.defaultTtl,
     ): Promise<TType> {
-        const ttl = this.resolveCacheWriteSettings(settings);
+        const value = await this.adapter.get(this.context, key);
 
-        let value = await this.adapter.get(this.context, key);
-        if (
-            this.shouldValidateOutput &&
-            this.schema !== undefined &&
-            value !== null
-        ) {
-            value = await validate(this.schema, value);
-        }
         if (value === null) {
-            let resolvedValueToAdd = await resolveAsyncLazyable(valueToAdd);
-            if (this.schema !== undefined) {
-                resolvedValueToAdd = (await validate(
-                    this.schema,
-                    resolvedValueToAdd,
-                )) as NoneFunc<TType>;
-            }
-            await this.adapter.add(this.context, key, resolvedValueToAdd, ttl);
+            const resolvedValueToAdd = await resolveAsyncLazyable(valueToAdd);
+
+            await this.adapter.add(
+                this.context,
+                key,
+                resolvedValueToAdd,
+                ttl === null ? null : TimeSpan.fromTimeSpan(ttl),
+            );
             return resolvedValueToAdd;
         }
 
         return value;
     }
 
-    async getOrAdd(
-        key: string,
-        valueToAdd: AsyncLazyable<NoneFunc<TType>>,
-        settings?: GetOrAddSettings,
-    ): Promise<TType> {
-        const enableLocking = settings?.enableLocking ?? false;
-
-        if (enableLocking) {
-            return await this.lockFactory.create(key).runOrFail(async () => {
-                return await this._getOrAdd(key, valueToAdd, settings);
-            });
-        }
-        return await this._getOrAdd(key, valueToAdd, settings);
-    }
-
-    private resolveCacheWriteSettings(
-        settings: CacheWriteSettings = {},
-    ): TimeSpan | null {
-        const {
-            ttl = this.defaultTtl,
-            jitter = this.defaultJitter,
-            _mathRandom = Math.random,
-        } = settings;
-        if (ttl === null) {
-            return null;
-        }
-
-        const ttlAsTimeSpan = TimeSpan.fromTimeSpan(ttl);
-        if (jitter === null) {
-            return ttlAsTimeSpan;
-        }
-
-        return TimeSpan.fromMilliseconds(
-            withJitter({
-                jitter,
-                randomValue: _mathRandom(),
-                value: ttlAsTimeSpan.toMilliseconds(),
-            }),
-        );
-    }
-
     async add(
         key: string,
         value: TType,
-        settings?: CacheWriteSettings,
+        ttl: ITimeSpan | null = this.defaultTtl,
     ): Promise<boolean> {
-        const ttl = this.resolveCacheWriteSettings(settings);
-
-        if (this.schema !== undefined) {
-            value = await validate(this.schema, value);
-        }
-        const hasAdded = await this.adapter.add(this.context, key, value, ttl);
+        const hasAdded = await this.adapter.add(
+            this.context,
+            key,
+            value,
+            ttl === null ? null : TimeSpan.fromTimeSpan(ttl),
+        );
 
         return hasAdded;
     }
@@ -321,9 +192,9 @@ export class Cache<TType = unknown> implements ICache<TType> {
     async addOrFail(
         key: string,
         value: TType,
-        settings?: CacheWriteSettings,
+        ttl: ITimeSpan | null = this.defaultTtl,
     ): Promise<void> {
-        const isNotFound = await this.add(key, value, settings);
+        const isNotFound = await this.add(key, value, ttl);
         if (!isNotFound) {
             throw KeyExistsCacheError.create(key);
         }
@@ -332,26 +203,18 @@ export class Cache<TType = unknown> implements ICache<TType> {
     async put(
         key: string,
         value: TType,
-        settings?: CacheWriteSettings,
+        ttl: ITimeSpan | null = this.defaultTtl,
     ): Promise<boolean> {
-        const ttl = this.resolveCacheWriteSettings(settings);
-
-        if (this.schema !== undefined) {
-            value = await validate(this.schema, value);
-        }
         const hasUpdated = await this.adapter.put(
             this.context,
             key,
             value,
-            ttl,
+            ttl === null ? null : TimeSpan.fromTimeSpan(ttl),
         );
         return hasUpdated;
     }
 
     async update(key: string, value: TType): Promise<boolean> {
-        if (this.schema !== undefined) {
-            value = await validate(this.schema, value);
-        }
         const hasUpdated = await this.adapter.update(this.context, key, value);
 
         return hasUpdated;

--- a/src/cache/implementations/middlewares/with-cache-factory.test.ts
+++ b/src/cache/implementations/middlewares/with-cache-factory.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-import { type GetOrAddSettings } from "@/cache/contracts/_module.js";
 import { NoOpCacheAdapter } from "@/cache/implementations/adapters/_module.js";
 import { Cache } from "@/cache/implementations/derivables/_module.js";
 import { withCacheFactory } from "@/cache/implementations/middlewares/with-cache-factory.js";
@@ -26,19 +25,16 @@ describe("function: withCacheFactory", () => {
 
         async function fn(_value: string): Promise<void> {}
         const key = "key";
-        const settings: GetOrAddSettings = {
-            jitter: 0.5,
-            ttl: TimeSpan.fromSeconds(20),
-        };
+        const ttl = TimeSpan.fromSeconds(20);
         await use(
             fn,
             withCache({
-                ...settings,
+                ttl,
                 key: (value) => value,
             }),
         )(key);
 
         expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(key, expect.any(Function), settings);
+        expect(spy).toHaveBeenCalledWith(key, expect.any(Function), ttl);
     });
 });

--- a/src/cache/implementations/middlewares/with-cache-factory.ts
+++ b/src/cache/implementations/middlewares/with-cache-factory.ts
@@ -2,11 +2,9 @@
  * @module Cache
  */
 
-import {
-    type CacheWriteSettings,
-    type ICache,
-} from "@/cache/contracts/_module.js";
+import { type ICache } from "@/cache/contracts/_module.js";
 import { type MiddlewareFn } from "@/middleware/contracts/_module.js";
+import { type ITimeSpan } from "@/time-span/contracts/_module.js";
 import { callInvokable, type Invokable } from "@/utilities/_module.js";
 
 /**
@@ -17,7 +15,9 @@ import { callInvokable, type Invokable } from "@/utilities/_module.js";
  */
 export type WithCacheSettings<
     TParameters extends Array<unknown> = Array<unknown>,
-> = CacheWriteSettings & {
+> = {
+    ttl?: ITimeSpan | null;
+
     /**
      * A function or static value that produces the cache key from the
      * wrapped function's arguments.
@@ -45,12 +45,12 @@ export function withCacheFactory(cache: Pick<ICache, "getOrAdd">) {
     return <TParameters extends Array<unknown>, TReturn>(
         settings: WithCacheSettings<TParameters>,
     ): MiddlewareFn<TParameters, Promise<TReturn>> => {
-        const { key = (...args) => JSON.stringify(args), ...rest } = settings;
+        const { key = (...args) => JSON.stringify(args), ttl } = settings;
         return async ({ next, args }) => {
             return cache.getOrAdd(
                 callInvokable(key, ...args),
                 next,
-                rest,
+                ttl,
             ) as Promise<TReturn>;
         };
     };

--- a/src/cache/implementations/middlewares/with-cache-factory.ts
+++ b/src/cache/implementations/middlewares/with-cache-factory.ts
@@ -19,7 +19,7 @@ export type WithCacheSettings<
     ttl?: ITimeSpan | null;
 
     /**
-     * A function or static value that produces the cache key from the
+     *  A function that produces the cache key from the
      * wrapped function's arguments.
      */
     key: Invokable<TParameters, string>;

--- a/src/cache/implementations/plugins/_module-exports.ts
+++ b/src/cache/implementations/plugins/_module-exports.ts
@@ -1,1 +1,4 @@
+export * from "@/cache/implementations/plugins/with-cache-jitter/_module.js";
 export * from "@/cache/implementations/plugins/with-cache-prefix/_module.js";
+export * from "@/cache/implementations/plugins/with-cache-schema/_module.js";
+export * from "@/cache/implementations/plugins/with-cache-write-lock/_module.js";

--- a/src/cache/implementations/plugins/with-cache-jitter/_module.ts
+++ b/src/cache/implementations/plugins/with-cache-jitter/_module.ts
@@ -1,0 +1,1 @@
+export * from "@/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.js";

--- a/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.test.ts
+++ b/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { NoOpCacheAdapter } from "@/cache/implementations/adapters/_module.js";
+import { withCacheJitter } from "@/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.js";
+import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
+import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enhance-factory.js";
+import { useFactory } from "@/middleware/implementations/use-factory/_module.js";
+import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
+import { TimeSpan } from "@/time-span/implementations/_module.js";
+
+describe("function: withCacheJitter", () => {
+    const context = new Context(new Map());
+    const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe("method: add", () => {
+        test("Should apply jitter to TTL", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "add");
+            const mathRandom = vi.fn().mockReturnValue(0.5);
+
+            const enhanced = withPlugin(
+                adapter,
+                withCacheJitter({
+                    defaultJitter: 0.2,
+                    _mathRandom: mathRandom,
+                }),
+            );
+
+            const ttl = TimeSpan.fromMinutes(1);
+            const expectedMs = (1 - 0.2 * 0.5) * ttl.toMilliseconds();
+
+            await enhanced.add(context, "myKey", "value", ttl);
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                "myKey",
+                "value",
+                TimeSpan.fromMilliseconds(expectedMs),
+            );
+        });
+
+        test("Should not apply jitter when TTL is null", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "add");
+            const mathRandom = vi.fn().mockReturnValue(0.5);
+
+            const enhanced = withPlugin(
+                adapter,
+                withCacheJitter({ _mathRandom: mathRandom }),
+            );
+
+            await enhanced.add(context, "myKey", "value", null);
+
+            expect(spy).toHaveBeenCalledWith(context, "myKey", "value", null);
+        });
+
+        test("Should use default jitter of 0.2 when not specified", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "add");
+            const mathRandom = vi.fn().mockReturnValue(0.5);
+
+            const enhanced = withPlugin(
+                adapter,
+                withCacheJitter({ _mathRandom: mathRandom }),
+            );
+
+            const ttl = TimeSpan.fromMinutes(1);
+            const expectedMs = (1 - 0.2 * 0.5) * ttl.toMilliseconds();
+
+            await enhanced.add(context, "myKey", "value", ttl);
+
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                "myKey",
+                "value",
+                TimeSpan.fromMilliseconds(expectedMs),
+            );
+        });
+    });
+
+    describe("method: put", () => {
+        test("Should apply jitter to TTL", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "put");
+            const mathRandom = vi.fn().mockReturnValue(0.3);
+
+            const enhanced = withPlugin(
+                adapter,
+                withCacheJitter({
+                    defaultJitter: 0.5,
+                    _mathRandom: mathRandom,
+                }),
+            );
+
+            const ttl = TimeSpan.fromMinutes(1);
+            const expectedMs = (1 - 0.5 * 0.3) * ttl.toMilliseconds();
+
+            await enhanced.put(context, "myKey", "value", ttl);
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                "myKey",
+                "value",
+                TimeSpan.fromMilliseconds(expectedMs),
+            );
+        });
+
+        test("Should not apply jitter when TTL is null", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "put");
+            const mathRandom = vi.fn().mockReturnValue(0.5);
+
+            const enhanced = withPlugin(
+                adapter,
+                withCacheJitter({ _mathRandom: mathRandom }),
+            );
+
+            await enhanced.put(context, "myKey", "value", null);
+
+            expect(spy).toHaveBeenCalledWith(context, "myKey", "value", null);
+        });
+    });
+});

--- a/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.ts
+++ b/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.ts
@@ -1,0 +1,60 @@
+/**
+ * @module Cache
+ */
+
+import { type ICacheAdapter } from "@/cache/contracts/_module.js";
+import { type PluginFn } from "@/middleware/contracts/_module.js";
+import { TimeSpan } from "@/time-span/implementations/_module.js";
+import { withJitter } from "@/utilities/_module.js";
+
+/**
+ * @group Plugins
+ */
+export type WithCacheJitterSettings = {
+    /**
+     * @default 0.2
+     */
+    defaultJitter?: number;
+
+    /**
+     * @internal
+     */
+    _mathRandom?: () => number;
+};
+
+/**
+ * @group Plugins
+ */
+export function withCacheJitter<TType>(
+    settings: WithCacheJitterSettings = {},
+): PluginFn<ICacheAdapter<TType>> {
+    const { defaultJitter = 0.2, _mathRandom = () => Math.random() } = settings;
+    function ttlWithJitter(ttl: TimeSpan | null): TimeSpan | null {
+        if (ttl === null) {
+            return null;
+        }
+        return TimeSpan.fromMilliseconds(
+            withJitter({
+                jitter: defaultJitter,
+                randomValue: _mathRandom(),
+                value: ttl.toMilliseconds(),
+            }),
+        );
+    }
+    return (adapter, enhance) => {
+        enhance(
+            adapter,
+            "add",
+            ({ args: [context, key, value, ttl], next }) => {
+                return next([context, key, value, ttlWithJitter(ttl)]);
+            },
+        );
+        enhance(
+            adapter,
+            "put",
+            ({ args: [context, key, value, ttl], next }) => {
+                return next([context, key, value, ttlWithJitter(ttl)]);
+            },
+        );
+    };
+}

--- a/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.ts
+++ b/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.ts
@@ -34,7 +34,7 @@ export type WithCacheJitterSettings = {
  *
  * @param settings - Configuration for the jitter behaviour.
  * @param settings.defaultJitter - The jitter factor as a ratio of the original
- *                                 TTL (e.g., `0.2` means ±20 %).
+ *                                 TTL (e.g., `0.2` means ±20 %).
  *                                 @default 0.2
  * @returns A middleware plugin that wraps an `ICacheAdapter`.
  *

--- a/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.ts
+++ b/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.ts
@@ -34,7 +34,7 @@ export type WithCacheJitterSettings = {
  *
  * @param settings - Configuration for the jitter behaviour.
  * @param settings.defaultJitter - The jitter factor as a ratio of the original
- *                                 TTL (e.g., `0.2` means ±20 %).
+ *                                 TTL (e.g., `0.2` means 20 %).
  *                                 @default 0.2
  * @returns A middleware plugin that wraps an `ICacheAdapter`.
  *

--- a/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.ts
+++ b/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.ts
@@ -8,6 +8,8 @@ import { TimeSpan } from "@/time-span/implementations/_module.js";
 import { withJitter } from "@/utilities/_module.js";
 
 /**
+ * Settings for the {@link withCacheJitter} plugin.
+ *
  * @group Plugins
  */
 export type WithCacheJitterSettings = {
@@ -23,6 +25,21 @@ export type WithCacheJitterSettings = {
 };
 
 /**
+ * Creates a plugin that adds random jitter to TTL values on cache `add` and
+ * `put` operations.
+ *
+ * Applying jitter to TTLs helps prevent cache stampedes / thundering-herd
+ * problems by staggering the expiration times of cache entries that were
+ * originally created with the same TTL.
+ *
+ * @param settings - Configuration for the jitter behaviour.
+ * @param settings.defaultJitter - The jitter factor as a ratio of the original
+ *                                 TTL (e.g., `0.2` means ±20 %).
+ *                                 @default 0.2
+ * @returns A middleware plugin that wraps an `ICacheAdapter`.
+ *
+ * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
+ * @typeParam TType - The type of values stored in the cache.
  * @group Plugins
  */
 export function withCacheJitter<TType>(

--- a/src/cache/implementations/plugins/with-cache-prefix/with-cache-prefix.ts
+++ b/src/cache/implementations/plugins/with-cache-prefix/with-cache-prefix.ts
@@ -6,6 +6,18 @@ import { type ICacheAdapter } from "@/cache/contracts/_module.js";
 import { type PluginFn } from "@/middleware/contracts/_module.js";
 
 /**
+ * Creates a plugin that prefixes all keys passed to a cache adapter.
+ *
+ * Every method that accepts a cache key will have the given `prefix` prepended
+ * before the call is forwarded to the underlying adapter. This is useful for
+ * namespacing cache entries when multiple independent consumers share the same
+ * cache backend.
+ *
+ * @param prefix - The string to prepend to every cache key.
+ * @returns A middleware plugin that wraps an `ICacheAdapter`.
+ *
+ * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
+ * @typeParam TType - The type of values stored in the cache.
  * @group Plugins
  */
 export function withCachePrefix<TType>(

--- a/src/cache/implementations/plugins/with-cache-prefix/with-cache-prefix.ts
+++ b/src/cache/implementations/plugins/with-cache-prefix/with-cache-prefix.ts
@@ -2,13 +2,15 @@
  * @module Cache
  */
 
-import { type ICacheAdapter } from "@/cache/contracts/cache-adapter.contract.js";
+import { type ICacheAdapter } from "@/cache/contracts/_module.js";
 import { type PluginFn } from "@/middleware/contracts/_module.js";
 
 /**
  * @group Plugins
  */
-export function withCachePrefix(prefix: string): PluginFn<ICacheAdapter> {
+export function withCachePrefix<TType>(
+    prefix: string,
+): PluginFn<ICacheAdapter<TType>> {
     function withPrefix(key: string): string {
         return prefix + key;
     }

--- a/src/cache/implementations/plugins/with-cache-schema/_module.ts
+++ b/src/cache/implementations/plugins/with-cache-schema/_module.ts
@@ -1,0 +1,1 @@
+export * from "@/cache/implementations/plugins/with-cache-schema/with-cache-schema.js";

--- a/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.test.ts
+++ b/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test, vi } from "vitest";
+import { z } from "zod";
+
+import { NoOpCacheAdapter } from "@/cache/implementations/adapters/_module.js";
+import { withCacheSchema } from "@/cache/implementations/plugins/with-cache-schema/with-cache-schema.js";
+import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
+import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enhance-factory.js";
+import { useFactory } from "@/middleware/implementations/use-factory/_module.js";
+import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
+import { TimeSpan } from "@/time-span/implementations/_module.js";
+
+describe("function: withCacheSchema", () => {
+    const context = new Context(new Map());
+    const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
+    const passingSchema = z.string();
+    const failingSchema = z.string().min(100);
+
+    describe("method: add", () => {
+        test("Should validate input", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "add");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: passingSchema }),
+            );
+
+            await enhanced.add(
+                context,
+                "myKey",
+                "validValue",
+                TimeSpan.fromMinutes(5),
+            );
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                "myKey",
+                "validValue",
+                TimeSpan.fromMinutes(5),
+            );
+        });
+
+        test("Should throw when input validation fails", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: failingSchema }),
+            );
+
+            await expect(
+                enhanced.add(
+                    context,
+                    "myKey",
+                    "invalidValue",
+                    TimeSpan.fromMinutes(5),
+                ),
+            ).rejects.toThrow();
+        });
+    });
+
+    describe("method: put", () => {
+        test("Should validate input", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "put");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: passingSchema }),
+            );
+
+            await enhanced.put(
+                context,
+                "myKey",
+                "validValue",
+                TimeSpan.fromMinutes(5),
+            );
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                "myKey",
+                "validValue",
+                TimeSpan.fromMinutes(5),
+            );
+        });
+
+        test("Should throw when input validation fails", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: failingSchema }),
+            );
+
+            await expect(
+                enhanced.put(
+                    context,
+                    "myKey",
+                    "invalidValue",
+                    TimeSpan.fromMinutes(5),
+                ),
+            ).rejects.toThrow();
+        });
+    });
+
+    describe("method: update", () => {
+        test("Should validate input", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "update");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: passingSchema }),
+            );
+
+            await enhanced.update(context, "myKey", "validValue");
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, "myKey", "validValue");
+        });
+
+        test("Should throw when input validation fails", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: failingSchema }),
+            );
+
+            await expect(
+                enhanced.update(context, "myKey", "invalidValue"),
+            ).rejects.toThrow();
+        });
+    });
+
+    describe("method: get", () => {
+        test("Should validate output", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            vi.spyOn(adapter, "get").mockResolvedValue("storedValue");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: passingSchema }),
+            );
+
+            const result = await enhanced.get(context, "myKey");
+
+            expect(result).toBe("storedValue");
+        });
+
+        test("Should throw when output validation fails", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            vi.spyOn(adapter, "get").mockResolvedValue("invalidValue");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: failingSchema }),
+            );
+
+            await expect(enhanced.get(context, "myKey")).rejects.toThrow();
+        });
+    });
+
+    describe("method: getAndRemove", () => {
+        test("Should validate output", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            vi.spyOn(adapter, "getAndRemove").mockResolvedValue("storedValue");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: passingSchema }),
+            );
+
+            const result = await enhanced.getAndRemove(context, "myKey");
+
+            expect(result).toBe("storedValue");
+        });
+
+        test("Should throw when output validation fails", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            vi.spyOn(adapter, "getAndRemove").mockResolvedValue("invalidValue");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: failingSchema }),
+            );
+
+            await expect(
+                enhanced.getAndRemove(context, "myKey"),
+            ).rejects.toThrow();
+        });
+    });
+
+    describe("options", () => {
+        test("Should skip output validation when shouldValidateOutput is false", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            vi.spyOn(adapter, "get").mockResolvedValue("someValue");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({
+                    schema: failingSchema,
+                    shouldValidateOutput: false,
+                }),
+            );
+
+            const result = await enhanced.get(context, "myKey");
+
+            expect(result).toBe("someValue");
+        });
+
+        test("Should still validate input when shouldValidateOutput is false", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "add");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({
+                    schema: passingSchema,
+                    shouldValidateOutput: false,
+                }),
+            );
+
+            await enhanced.add(
+                context,
+                "myKey",
+                "validValue",
+                TimeSpan.fromMinutes(5),
+            );
+
+            expect(spy).toHaveBeenCalledOnce();
+        });
+    });
+});

--- a/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.test.ts
+++ b/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.test.ts
@@ -153,6 +153,19 @@ describe("function: withCacheSchema", () => {
 
             await expect(enhanced.get(context, "myKey")).rejects.toThrow();
         });
+
+        test("Should pass null through without validation when key is not found", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            vi.spyOn(adapter, "get").mockResolvedValue(null);
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: passingSchema }),
+            );
+
+            const result = await enhanced.get(context, "myKey");
+
+            expect(result).toBeNull();
+        });
     });
 
     describe("method: getAndRemove", () => {
@@ -180,6 +193,19 @@ describe("function: withCacheSchema", () => {
             await expect(
                 enhanced.getAndRemove(context, "myKey"),
             ).rejects.toThrow();
+        });
+
+        test("Should pass null through without validation when key is not found", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            vi.spyOn(adapter, "getAndRemove").mockResolvedValue(null);
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: passingSchema }),
+            );
+
+            const result = await enhanced.getAndRemove(context, "myKey");
+
+            expect(result).toBeNull();
         });
     });
 

--- a/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.ts
+++ b/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.ts
@@ -9,6 +9,9 @@ import { type PluginFn } from "@/middleware/contracts/_module.js";
 import { validate } from "@/utilities/_module.js";
 
 /**
+ * Settings for the {@link withCacheSchema} plugin.
+ *
+ * @typeParam TType - The type to validate against.
  * @group Plugins
  */
 export type WithCacheSchemaSettings<TType = unknown> = {
@@ -21,6 +24,23 @@ export type WithCacheSchemaSettings<TType = unknown> = {
 };
 
 /**
+ * Creates a plugin that validates cache values against a standard schema.
+ *
+ * On `add`, `put`, and `update` operations the input value is validated
+ * against the provided schema before being stored. Optionally, `get` and
+ * `getAndRemove` outputs can also be validated on retrieval to ensure data
+ * integrity.
+ *
+ * @param settings - Configuration for the schema validation.
+ * @param settings.schema - A standard-schema compliant schema to validate
+ *                          values against.
+ * @param settings.shouldValidateOutput - Whether to validate values returned
+ *                                        by `get` and `getAndRemove`.
+ *                                        @default true
+ * @returns A middleware plugin that wraps an `ICacheAdapter`.
+ *
+ * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
+ * @typeParam TType - The type of values stored in the cache.
  * @group Plugins
  */
 export function withCacheSchema<TType>(

--- a/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.ts
+++ b/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.ts
@@ -1,0 +1,64 @@
+/**
+ * @module Cache
+ */
+
+import { type StandardSchemaV1 } from "@standard-schema/spec";
+
+import { type ICacheAdapter } from "@/cache/contracts/_module.js";
+import { type PluginFn } from "@/middleware/contracts/_module.js";
+import { validate } from "@/utilities/_module.js";
+
+/**
+ * @group Plugins
+ */
+export type WithCacheSchemaSettings<TType = unknown> = {
+    schema: StandardSchemaV1<TType>;
+
+    /**
+     * @default true
+     */
+    shouldValidateOutput?: boolean;
+};
+
+/**
+ * @group Plugins
+ */
+export function withCacheSchema<TType>(
+    settings: WithCacheSchemaSettings<TType>,
+): PluginFn<ICacheAdapter<TType>> {
+    const { schema, shouldValidateOutput = true } = settings;
+
+    return (adapter, enhance) => {
+        if (shouldValidateOutput) {
+            enhance(adapter, "get", async ({ next }) => {
+                return validate(schema, await next());
+            });
+        }
+        if (shouldValidateOutput) {
+            enhance(adapter, "getAndRemove", async ({ next }) => {
+                return validate(schema, await next());
+            });
+        }
+        enhance(
+            adapter,
+            "add",
+            async ({ args: [context, key, value, ttl], next }) => {
+                return next([context, key, await validate(schema, value), ttl]);
+            },
+        );
+        enhance(
+            adapter,
+            "put",
+            async ({ args: [context, key, value, ttl], next }) => {
+                return next([context, key, await validate(schema, value), ttl]);
+            },
+        );
+        enhance(
+            adapter,
+            "update",
+            async ({ args: [context, key, value], next }) => {
+                return next([context, key, await validate(schema, value)]);
+            },
+        );
+    };
+}

--- a/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.ts
+++ b/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.ts
@@ -51,12 +51,20 @@ export function withCacheSchema<TType>(
     return (adapter, enhance) => {
         if (shouldValidateOutput) {
             enhance(adapter, "get", async ({ next }) => {
-                return validate(schema, await next());
+                const value = await next();
+                if (value === null) {
+                    return value;
+                }
+                return validate(schema, value);
             });
         }
         if (shouldValidateOutput) {
             enhance(adapter, "getAndRemove", async ({ next }) => {
-                return validate(schema, await next());
+                const value = await next();
+                if (value === null) {
+                    return value;
+                }
+                return validate(schema, value);
             });
         }
         enhance(

--- a/src/cache/implementations/plugins/with-cache-write-lock/_module.ts
+++ b/src/cache/implementations/plugins/with-cache-write-lock/_module.ts
@@ -1,0 +1,1 @@
+export * from "@/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.js";

--- a/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.test.ts
+++ b/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { NoOpCacheAdapter } from "@/cache/implementations/adapters/_module.js";
+import { withCacheWriteLock } from "@/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.js";
+import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
+import { NoOpLockAdapter } from "@/lock/implementations/adapters/no-op-lock-adapter/no-op-lock-adapter.js";
+import { LockFactory } from "@/lock/implementations/derivables/lock-factory/lock-factory.js";
+import { Lock } from "@/lock/implementations/derivables/lock-factory/lock.js";
+import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enhance-factory.js";
+import { useFactory } from "@/middleware/implementations/use-factory/_module.js";
+import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
+import { TimeSpan } from "@/time-span/implementations/_module.js";
+
+describe("function: withCacheWriteLock", () => {
+    const context = new Context(new Map());
+    const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    function createLockFactory(): LockFactory {
+        return new LockFactory({ adapter: new NoOpLockAdapter() });
+    }
+
+    describe("method: add", () => {
+        test("Should acquire lock", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "add");
+            const lockFactory = createLockFactory();
+            const runSpy = vi.spyOn(Lock.prototype, "runOrFail");
+            const createSpy = vi.spyOn(lockFactory, "create");
+
+            const enhanced = withPlugin(
+                adapter,
+                withCacheWriteLock({ lockFactory }),
+            );
+
+            console.log("1.");
+            await enhanced.add(
+                context,
+                "myKey",
+                "value",
+                TimeSpan.fromMinutes(5),
+            );
+            console.log("2.");
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith("myKey");
+            expect(runSpy).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe("method: put", () => {
+        test("Should acquire lock", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "put");
+            const lockFactory = createLockFactory();
+            const runSpy = vi.spyOn(Lock.prototype, "runOrFail");
+            const createSpy = vi.spyOn(lockFactory, "create");
+
+            const enhanced = withPlugin(
+                adapter,
+                withCacheWriteLock({ lockFactory }),
+            );
+
+            await enhanced.put(
+                context,
+                "myKey",
+                "value",
+                TimeSpan.fromMinutes(5),
+            );
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith("myKey");
+            expect(runSpy).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe("method: update", () => {
+        test("Should acquire lock", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "update");
+            const lockFactory = createLockFactory();
+            const runSpy = vi.spyOn(Lock.prototype, "runOrFail");
+            const createSpy = vi.spyOn(lockFactory, "create");
+
+            const enhanced = withPlugin(
+                adapter,
+                withCacheWriteLock({ lockFactory }),
+            );
+
+            await enhanced.update(context, "myKey", "newValue");
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith("myKey");
+            expect(runSpy).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe("method: increment", () => {
+        test("Should acquire lock", async () => {
+            const adapter = new NoOpCacheAdapter<number>();
+            const spy = vi.spyOn(adapter, "increment");
+            const lockFactory = createLockFactory();
+            const runSpy = vi.spyOn(Lock.prototype, "runOrFail");
+            const createSpy = vi.spyOn(lockFactory, "create");
+
+            const enhanced = withPlugin(
+                adapter,
+                withCacheWriteLock({ lockFactory }),
+            );
+
+            await enhanced.increment(context, "myKey", 5);
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith("myKey");
+            expect(runSpy).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe("method: getAndRemove", () => {
+        test("Should acquire lock", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "getAndRemove");
+            const lockFactory = createLockFactory();
+            const runSpy = vi.spyOn(Lock.prototype, "runOrFail");
+            const createSpy = vi.spyOn(lockFactory, "create");
+
+            const enhanced = withPlugin(
+                adapter,
+                withCacheWriteLock({ lockFactory }),
+            );
+
+            await enhanced.getAndRemove(context, "myKey");
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith("myKey");
+            expect(runSpy).toHaveBeenCalledOnce();
+        });
+
+        test("Should pass through the underlying adapter response", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            vi.spyOn(adapter, "getAndRemove").mockResolvedValue("storedValue");
+            const lockFactory = createLockFactory();
+
+            const enhanced = withPlugin(
+                adapter,
+                withCacheWriteLock({ lockFactory }),
+            );
+
+            const result = await enhanced.getAndRemove(context, "myKey");
+
+            expect(result).toBe("storedValue");
+        });
+    });
+
+    describe("method: removeMany", () => {
+        test("Should acquire lock for each key", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "removeMany");
+            const lockFactory = createLockFactory();
+            const runSpy = vi.spyOn(Lock.prototype, "runOrFail");
+            const createSpy = vi.spyOn(lockFactory, "create");
+
+            const enhanced = withPlugin(
+                adapter,
+                withCacheWriteLock({ lockFactory }),
+            );
+
+            await enhanced.removeMany(context, ["key1", "key2", "key3"]);
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith("key1");
+            expect(createSpy).toHaveBeenCalledWith("key2");
+            expect(createSpy).toHaveBeenCalledWith("key3");
+            expect(runSpy).toHaveBeenCalledTimes(3);
+        });
+    });
+
+    describe("options", () => {
+        test("Should only lock specified methods when onlyMethods is provided", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const getSpy = vi.spyOn(adapter, "get");
+            const lockFactory = createLockFactory();
+            const runSpy = vi.spyOn(Lock.prototype, "runOrFail");
+            const createSpy = vi.spyOn(lockFactory, "create");
+
+            const enhanced = withPlugin(
+                adapter,
+                withCacheWriteLock({
+                    lockFactory,
+                    onlyMethods: ["add"],
+                }),
+            );
+
+            await enhanced.add(
+                context,
+                "myKey",
+                "value",
+                TimeSpan.fromMinutes(5),
+            );
+            expect(createSpy).toHaveBeenCalledWith("myKey");
+            expect(runSpy).toHaveBeenCalledTimes(1);
+
+            vi.clearAllMocks();
+            await enhanced.get(context, "myKey");
+            expect(createSpy).not.toHaveBeenCalled();
+            expect(runSpy).not.toHaveBeenCalled();
+            expect(getSpy).toHaveBeenCalledOnce();
+        });
+    });
+});

--- a/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.test.ts
+++ b/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.test.ts
@@ -176,6 +176,48 @@ describe("function: withCacheWriteLock", () => {
             expect(createSpy).toHaveBeenCalledWith("key3");
             expect(runSpy).toHaveBeenCalledTimes(3);
         });
+
+        test("Should deduplicate keys when acquiring locks", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "removeMany");
+            const lockFactory = createLockFactory();
+            const runSpy = vi.spyOn(Lock.prototype, "runOrFail");
+            const createSpy = vi.spyOn(lockFactory, "create");
+
+            const enhanced = withPlugin(
+                adapter,
+                withCacheWriteLock({ lockFactory }),
+            );
+
+            await enhanced.removeMany(context, [
+                "key1",
+                "key2",
+                "key1",
+                "key3",
+            ]);
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledTimes(3);
+            expect(createSpy).toHaveBeenCalledWith("key1");
+            expect(createSpy).toHaveBeenCalledWith("key2");
+            expect(createSpy).toHaveBeenCalledWith("key3");
+            expect(runSpy).toHaveBeenCalledTimes(3);
+        });
+
+        test("Should pass through the underlying adapter response", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            vi.spyOn(adapter, "removeMany").mockResolvedValue(true);
+            const lockFactory = createLockFactory();
+
+            const enhanced = withPlugin(
+                adapter,
+                withCacheWriteLock({ lockFactory }),
+            );
+
+            const result = await enhanced.removeMany(context, ["key1", "key2"]);
+
+            expect(result).toBe(true);
+        });
     });
 
     describe("options", () => {

--- a/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.ts
+++ b/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.ts
@@ -1,0 +1,123 @@
+/**
+ * @module Cache
+ */
+
+import { type ICacheAdapter } from "@/cache/contracts/_module.js";
+import { type ILockFactory } from "@/lock/contracts/_module.js";
+import { type PluginFn } from "@/middleware/contracts/_module.js";
+
+/**
+ * @group Plugins
+ */
+export type WithCacheWriteLockMethods = keyof Pick<
+    ICacheAdapter,
+    "getAndRemove" | "add" | "put" | "update" | "increment" | "removeMany"
+>;
+
+/**
+ * @group Plugins
+ */
+export type WithCacheWriteLockSettings = {
+    lockFactory: ILockFactory;
+
+    /**
+     * @default
+     * ```ts
+     * ["getAndRemove", "add", "put", "update", "increment", "removeMany"]
+     * ```
+     */
+    onlyMethods?: Array<WithCacheWriteLockMethods>;
+};
+
+/**
+ * @group Plugins
+ */
+export function withCacheWriteLock<TType>(
+    settings: WithCacheWriteLockSettings,
+): PluginFn<ICacheAdapter<TType>> {
+    const {
+        lockFactory,
+        onlyMethods = [
+            "getAndRemove",
+            "add",
+            "put",
+            "update",
+            "increment",
+            "removeMany",
+        ],
+    } = settings;
+    return (adapter, enhance) => {
+        if (
+            onlyMethods.includes(
+                "getAndRemove" satisfies WithCacheWriteLockMethods,
+            )
+        ) {
+            enhance(
+                adapter,
+                "getAndRemove",
+                ({ args: [_context, key], next }) => {
+                    return lockFactory.create(key).runOrFail(() => {
+                        return next();
+                    });
+                },
+            );
+        }
+
+        if (onlyMethods.includes("add" satisfies WithCacheWriteLockMethods)) {
+            enhance(adapter, "add", ({ args: [_context, key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
+        }
+
+        if (onlyMethods.includes("put" satisfies WithCacheWriteLockMethods)) {
+            enhance(adapter, "put", ({ args: [_context, key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
+        }
+
+        if (
+            onlyMethods.includes("update" satisfies WithCacheWriteLockMethods)
+        ) {
+            enhance(adapter, "update", ({ args: [_context, key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
+        }
+
+        if (
+            onlyMethods.includes(
+                "increment" satisfies WithCacheWriteLockMethods,
+            )
+        ) {
+            enhance(adapter, "increment", ({ args: [_context, key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
+        }
+
+        if (
+            onlyMethods.includes(
+                "removeMany" satisfies WithCacheWriteLockMethods,
+            )
+        ) {
+            enhance(
+                adapter,
+                "removeMany",
+                ({ args: [_context, keys], next }) => {
+                    let fn = () => next();
+                    for (const key of keys) {
+                        const prevFn = fn;
+                        fn = () => lockFactory.create(key).runOrFail(prevFn);
+                    }
+                    return fn();
+                },
+            );
+        }
+    };
+}

--- a/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.ts
+++ b/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.ts
@@ -7,6 +7,11 @@ import { type ILockFactory } from "@/lock/contracts/_module.js";
 import { type PluginFn } from "@/middleware/contracts/_module.js";
 
 /**
+ * Cache adapter methods that can be protected by a write lock.
+ *
+ * Only the mutable methods that modify cache state are eligible for write-lock
+ * protection.
+ *
  * @group Plugins
  */
 export type WithCacheWriteLockMethods = keyof Pick<
@@ -15,6 +20,8 @@ export type WithCacheWriteLockMethods = keyof Pick<
 >;
 
 /**
+ * Settings for the {@link withCacheWriteLock} plugin.
+ *
  * @group Plugins
  */
 export type WithCacheWriteLockSettings = {
@@ -30,6 +37,23 @@ export type WithCacheWriteLockSettings = {
 };
 
 /**
+ * Creates a plugin that acquires a distributed lock before executing mutating
+ * cache operations.
+ *
+ * This plugin wraps write operations (`add`, `put`, `update`, `increment`,
+ * `getAndRemove`, `removeMany`) with a lock acquired via {@link ILockFactory}.
+ * The lock key is derived from the cache key, ensuring that concurrent writes
+ * to the same cache entry are serialised. By default all mutating methods are
+ * protected; use `onlyMethods` to restrict which operations are locked.
+ *
+ * @param settings - Configuration for the write-lock behaviour.
+ * @param settings.lockFactory - A factory that creates named locks.
+ * @param settings.onlyMethods - The subset of methods to protect with a write
+ *                               lock. Defaults to all mutating methods.
+ * @returns A middleware plugin that wraps an `ICacheAdapter`.
+ *
+ * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
+ * @typeParam TType - The type of values stored in the cache.
  * @group Plugins
  */
 export function withCacheWriteLock<TType>(

--- a/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.ts
+++ b/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.ts
@@ -135,7 +135,7 @@ export function withCacheWriteLock<TType>(
                 "removeMany",
                 ({ args: [_context, keys], next }) => {
                     let fn = () => next();
-                    for (const key of keys) {
+                    for (const key of [...new Set(keys)].reverse()) {
                         const prevFn = fn;
                         fn = () => lockFactory.create(key).runOrFail(prevFn);
                     }

--- a/src/cache/implementations/test-utilities/cache.test-suite.ts
+++ b/src/cache/implementations/test-utilities/cache.test-suite.ts
@@ -100,9 +100,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 });
                 test("Should return false when key is expired", async () => {
                     const key = "a";
-                    await cache.add(key, 1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, 1, TTL);
                     await delayWithBuffer(TTL);
 
                     const result = await cache.exists(key);
@@ -121,7 +119,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should return true when key is unexpired", async () => {
                     const key = "a";
 
-                    await cache.add(key, 1, { ttl: LONG_TTL });
+                    await cache.add(key, 1, LONG_TTL);
 
                     const result = await cache.exists(key);
 
@@ -138,9 +136,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 });
                 test("Should return true when key is expired", async () => {
                     const key = "a";
-                    await cache.add(key, 1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, 1, TTL);
                     await delayWithBuffer(TTL);
 
                     const result = await cache.missing(key);
@@ -159,7 +155,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should return false when key is unexpired", async () => {
                     const key = "a";
 
-                    await cache.add(key, 1, { ttl: LONG_TTL });
+                    await cache.add(key, 1, LONG_TTL);
 
                     const result = await cache.missing(key);
 
@@ -176,9 +172,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 });
                 test("Should return null when key is expired", async () => {
                     const key = "a";
-                    await cache.add(key, 1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, 1, TTL);
                     await delayWithBuffer(TTL);
 
                     const result = await cache.get(key);
@@ -199,7 +193,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value = 1;
-                    await cache.add(key, value, { ttl: LONG_TTL });
+                    await cache.add(key, value, LONG_TTL);
 
                     const result = await cache.get(key);
 
@@ -218,9 +212,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 });
                 test("Should throw KeyNotFoundCacheError when key is expired", async () => {
                     const key = "a";
-                    await cache.add(key, 1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, 1, TTL);
                     await delayWithBuffer(TTL);
 
                     const result = cache.getOrFail(key);
@@ -243,7 +235,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value = 1;
-                    await cache.add(key, value, { ttl: LONG_TTL });
+                    await cache.add(key, value, LONG_TTL);
 
                     const result = await cache.getOrFail(key);
 
@@ -261,9 +253,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 });
                 test("Should return default value when key is expired", async () => {
                     const key = "a";
-                    await cache.add(key, 1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, 1, TTL);
                     await delayWithBuffer(TTL);
 
                     const defaultValue = -1;
@@ -286,7 +276,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value = 1;
-                    await cache.add(key, value, { ttl: LONG_TTL });
+                    await cache.add(key, value, LONG_TTL);
 
                     const defaultValue = -1;
                     const result = await cache.getOr(key, defaultValue);
@@ -304,9 +294,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 });
                 test("Should return null when key is expired", async () => {
                     const key = "a";
-                    await cache.add(key, 1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, 1, TTL);
                     await delayWithBuffer(TTL);
 
                     const result = await cache.getAndRemove(key);
@@ -327,7 +315,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value = 1;
-                    await cache.add(key, value, { ttl: LONG_TTL });
+                    await cache.add(key, value, LONG_TTL);
 
                     const result = await cache.getAndRemove(key);
 
@@ -348,7 +336,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value = 1;
-                    await cache.add(key, value, { ttl: LONG_TTL });
+                    await cache.add(key, value, LONG_TTL);
 
                     await cache.getAndRemove(key);
 
@@ -376,9 +364,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 });
                 test("Should return value to add when key is expired", async () => {
                     const key = "a";
-                    await cache.add(key, 1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, 1, TTL);
                     await delayWithBuffer(TTL);
 
                     const valueToAdd = -1;
@@ -388,9 +374,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 });
                 test("Should persist value when key is expired", async () => {
                     const key = "a";
-                    await cache.add(key, 1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, 1, TTL);
                     await delayWithBuffer(TTL);
 
                     const valueToAdd = -1;
@@ -426,7 +410,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value = 1;
-                    await cache.add(key, value, { ttl: LONG_TTL });
+                    await cache.add(key, value, LONG_TTL);
 
                     const valueToAdd = -1;
                     const result = await cache.getOrAdd(key, valueToAdd);
@@ -437,7 +421,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value = 1;
-                    await cache.add(key, value, { ttl: LONG_TTL });
+                    await cache.add(key, value, LONG_TTL);
 
                     const valueToAdd = -1;
                     await cache.getOrAdd(key, valueToAdd);
@@ -467,9 +451,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should return true when key is expired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.add(key, value1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, value1, TTL);
                     await delayWithBuffer(TTL);
 
                     const value2 = 2;
@@ -480,9 +462,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should persist value when key is expired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.add(key, value1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, value1, TTL);
                     await delayWithBuffer(TTL);
 
                     const value2 = 2;
@@ -506,7 +486,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value1 = 1;
-                    await cache.add(key, value1, { ttl: LONG_TTL });
+                    await cache.add(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     const result = await cache.add(key, value2);
@@ -529,7 +509,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value1 = 1;
-                    await cache.add(key, value1, { ttl: LONG_TTL });
+                    await cache.add(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     await cache.add(key, value2);
@@ -559,9 +539,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should not throw error when key is expired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.addOrFail(key, value1, {
-                        ttl: TTL,
-                    });
+                    await cache.addOrFail(key, value1, TTL);
                     await delayWithBuffer(TTL);
 
                     const value2 = 2;
@@ -572,9 +550,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should persist value when key is expired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.addOrFail(key, value1, {
-                        ttl: TTL,
-                    });
+                    await cache.addOrFail(key, value1, TTL);
                     await delayWithBuffer(TTL);
 
                     const value2 = 2;
@@ -600,9 +576,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value1 = 1;
-                    await cache.addOrFail(key, value1, {
-                        ttl: LONG_TTL,
-                    });
+                    await cache.addOrFail(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     const result = cache.addOrFail(key, value2);
@@ -633,9 +607,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value1 = 1;
-                    await cache.addOrFail(key, value1, {
-                        ttl: LONG_TTL,
-                    });
+                    await cache.addOrFail(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     try {
@@ -678,7 +650,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     await cache.add(key, value1);
 
                     const value2 = 2;
-                    await cache.put(key, value2, { ttl: TTL });
+                    await cache.put(key, value2, TTL);
 
                     await delayWithBuffer(TTL);
                     const result = await cache.get(key);
@@ -687,7 +659,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should return true when key is unexpired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.add(key, value1, { ttl: LONG_TTL });
+                    await cache.add(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     const result = await cache.put(key, value2);
@@ -697,7 +669,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should persist value when key is unexpired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.add(key, value1, { ttl: LONG_TTL });
+                    await cache.add(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     await cache.put(key, value2);
@@ -708,10 +680,10 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should persist ttl when key is unexpired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.add(key, value1, { ttl: LONG_TTL });
+                    await cache.add(key, value1, LONG_TTL);
 
                     const value2 = 2;
-                    await cache.put(key, value2, { ttl: TTL });
+                    await cache.put(key, value2, TTL);
 
                     await delayWithBuffer(TTL);
                     const result = await cache.get(key);
@@ -738,7 +710,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value = 2;
-                    await cache.put(key, value, { ttl: TTL });
+                    await cache.put(key, value, TTL);
 
                     await delayWithBuffer(TTL);
                     const result = await cache.get(key);
@@ -766,9 +738,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should return false when key is expired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.add(key, value1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, value1, TTL);
                     await delayWithBuffer(TTL);
 
                     const value2 = 2;
@@ -779,9 +749,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should not persist value when key is expired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.add(key, value1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, value1, TTL);
                     await delayWithBuffer(TTL);
 
                     const value2 = 2;
@@ -805,7 +773,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value1 = 1;
-                    await cache.add(key, value1, { ttl: LONG_TTL });
+                    await cache.add(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     const result = await cache.update(key, value2);
@@ -828,7 +796,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value1 = 1;
-                    await cache.add(key, value1, { ttl: LONG_TTL });
+                    await cache.add(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     await cache.update(key, value2);
@@ -866,9 +834,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should throw KeyNotFoundCacheError when key is expired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.add(key, value1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, value1, TTL);
                     await delayWithBuffer(TTL);
 
                     const value2 = 2;
@@ -881,9 +847,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should not persist value when key is expired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.add(key, value1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, value1, TTL);
                     await delayWithBuffer(TTL);
 
                     const value2 = 2;
@@ -913,7 +877,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value1 = 1;
-                    await cache.add(key, value1, { ttl: LONG_TTL });
+                    await cache.add(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     const result = cache.updateOrFail(key, value2);
@@ -936,7 +900,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value1 = 1;
-                    await cache.add(key, value1, { ttl: LONG_TTL });
+                    await cache.add(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     await cache.updateOrFail(key, value2);
@@ -966,9 +930,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should return false when key is expired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.add(key, value1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, value1, TTL);
                     await delayWithBuffer(TTL);
 
                     const value2 = 2;
@@ -979,9 +941,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should not persist value when key is expired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.add(key, value1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, value1, TTL);
                     await delayWithBuffer(TTL);
 
                     const value2 = 2;
@@ -1005,7 +965,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value1 = 1;
-                    await cache.add(key, value1, { ttl: LONG_TTL });
+                    await cache.add(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     const result = await cache.increment(key, value2);
@@ -1028,7 +988,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value1 = 1;
-                    await cache.add(key, value1, { ttl: LONG_TTL });
+                    await cache.add(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     await cache.increment(key, value2);
@@ -1066,9 +1026,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should throw KeyNotFoundCacheError when key is expired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.add(key, value1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, value1, TTL);
                     await delayWithBuffer(TTL);
 
                     const value2 = 2;
@@ -1081,9 +1039,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should not persist value when key is expired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.add(key, value1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, value1, TTL);
                     await delayWithBuffer(TTL);
 
                     const value2 = 2;
@@ -1113,7 +1069,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value1 = 1;
-                    await cache.add(key, value1, { ttl: LONG_TTL });
+                    await cache.add(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     const result = cache.incrementOrFail(key, value2);
@@ -1136,7 +1092,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value1 = 1;
-                    await cache.add(key, value1, { ttl: LONG_TTL });
+                    await cache.add(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     await cache.incrementOrFail(key, value2);
@@ -1166,9 +1122,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should return false when key is expired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.add(key, value1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, value1, TTL);
                     await delayWithBuffer(TTL);
 
                     const value2 = 2;
@@ -1179,9 +1133,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should not persist value when key is expired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.add(key, value1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, value1, TTL);
                     await delayWithBuffer(TTL);
 
                     const value2 = 2;
@@ -1205,7 +1157,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value1 = 1;
-                    await cache.add(key, value1, { ttl: LONG_TTL });
+                    await cache.add(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     const result = await cache.decrement(key, value2);
@@ -1228,7 +1180,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value1 = 1;
-                    await cache.add(key, value1, { ttl: LONG_TTL });
+                    await cache.add(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     await cache.decrement(key, value2);
@@ -1266,9 +1218,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should throw KeyNotFoundCacheError when key is expired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.add(key, value1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, value1, TTL);
                     await delayWithBuffer(TTL);
 
                     const value2 = 2;
@@ -1281,9 +1231,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should not persist value when key is expired", async () => {
                     const key = "a";
                     const value1 = 1;
-                    await cache.add(key, value1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, value1, TTL);
                     await delayWithBuffer(TTL);
 
                     const value2 = 2;
@@ -1313,7 +1261,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value1 = 1;
-                    await cache.add(key, value1, { ttl: LONG_TTL });
+                    await cache.add(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     const result = cache.decrementOrFail(key, value2);
@@ -1336,7 +1284,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const key = "a";
 
                     const value1 = 1;
-                    await cache.add(key, value1, { ttl: LONG_TTL });
+                    await cache.add(key, value1, LONG_TTL);
 
                     const value2 = 2;
                     await cache.decrementOrFail(key, value2);
@@ -1355,9 +1303,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 });
                 test("Should return false when key is expired", async () => {
                     const key = "a";
-                    await cache.add(key, 1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, 1, TTL);
                     await delayWithBuffer(TTL);
 
                     const result = await cache.remove(key);
@@ -1376,7 +1322,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should return true when key is unexpired", async () => {
                     const key = "a";
 
-                    await cache.add(key, 1, { ttl: LONG_TTL });
+                    await cache.add(key, 1, LONG_TTL);
 
                     const result = await cache.remove(key);
 
@@ -1395,7 +1341,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should persist removal when key is unexpired", async () => {
                     const key = "a";
 
-                    await cache.add(key, 1, { ttl: LONG_TTL });
+                    await cache.add(key, 1, LONG_TTL);
 
                     await cache.remove(key);
 
@@ -1415,9 +1361,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 });
                 test("Should throw KeyNotFoundCacheError when key is expired", async () => {
                     const key = "a";
-                    await cache.add(key, 1, {
-                        ttl: TTL,
-                    });
+                    await cache.add(key, 1, TTL);
                     await delayWithBuffer(TTL);
 
                     const result = cache.removeOrFail(key);
@@ -1438,7 +1382,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should not throw error when key is unexpired", async () => {
                     const key = "a";
 
-                    await cache.add(key, 1, { ttl: LONG_TTL });
+                    await cache.add(key, 1, LONG_TTL);
 
                     const result = cache.removeOrFail(key);
 
@@ -1457,7 +1401,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                 test("Should persist removal when key is unexpired", async () => {
                     const key = "a";
 
-                    await cache.add(key, 1, { ttl: LONG_TTL });
+                    await cache.add(key, 1, LONG_TTL);
 
                     await cache.removeOrFail(key);
 
@@ -1470,7 +1414,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const keyA = "a";
                     const keyB = "b";
                     const keyC = "c";
-                    await cache.add(keyA, 1, { ttl: TTL });
+                    await cache.add(keyA, 1, TTL);
                     await delayWithBuffer(TTL);
 
                     const result = await cache.removeMany([keyA, keyB, keyC]);
@@ -1481,7 +1425,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const keyA = "a";
                     const keyB = "b";
                     const keyC = "c";
-                    await cache.add(keyA, 1, { ttl: TTL });
+                    await cache.add(keyA, 1, TTL);
                     await delayWithBuffer(TTL);
 
                     await cache.add(keyC, 2);
@@ -1493,7 +1437,7 @@ export function cacheTestSuite(settings: CacheTestSuiteSettings): void {
                     const keyA = "a";
                     const keyB = "b";
                     const keyC = "c";
-                    await cache.add(keyA, 1, { ttl: TTL });
+                    await cache.add(keyA, 1, TTL);
                     await delayWithBuffer(TTL);
 
                     await cache.add(keyC, 2);

--- a/src/circuit-breaker/implementations/middlewares/with-circuit-breaker-factory.ts
+++ b/src/circuit-breaker/implementations/middlewares/with-circuit-breaker-factory.ts
@@ -24,7 +24,7 @@ export type WithCircuitBreakerSettings<
     TParameters extends Array<unknown> = Array<unknown>,
 > = ErrorPolicySettings & {
     /**
-     * A function or static value that produces a unique identifier for the
+     *  A function that produces a unique identifier for the
      * circuit from the wrapped function's arguments. Each unique key gets its
      * own circuit state.
      */

--- a/src/circuit-breaker/implementations/plugins/with-circuit-breaker-prefix/with-circuit-breaker-prefix.test.ts
+++ b/src/circuit-breaker/implementations/plugins/with-circuit-breaker-prefix/with-circuit-breaker-prefix.test.ts
@@ -7,7 +7,7 @@ import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enh
 import { useFactory } from "@/middleware/implementations/use-factory/_module.js";
 import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
 
-describe("function: withCircuitBreakerPrefix", () => {
+describe("plugin: withCircuitBreakerPrefix", () => {
     const context = new Context(new Map());
     const prefix = "test-prefix:";
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
@@ -16,75 +16,105 @@ describe("function: withCircuitBreakerPrefix", () => {
         vi.clearAllMocks();
     });
 
-    test("Should prefix keys for getState", async () => {
-        const adapter = new NoOpCircuitBreakerAdapter();
-        const spy = vi.spyOn(adapter, "getState");
+    describe("method: getState", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpCircuitBreakerAdapter();
+            const spy = vi.spyOn(adapter, "getState");
 
-        const enhanced = withPlugin(adapter, withCircuitBreakerPrefix(prefix));
+            const enhanced = withPlugin(
+                adapter,
+                withCircuitBreakerPrefix(prefix),
+            );
 
-        await enhanced.getState(context, "myKey");
+            await enhanced.getState(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
     });
 
-    test("Should prefix keys for isolate", async () => {
-        const adapter = new NoOpCircuitBreakerAdapter();
-        const spy = vi.spyOn(adapter, "isolate");
+    describe("method: isolate", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpCircuitBreakerAdapter();
+            const spy = vi.spyOn(adapter, "isolate");
 
-        const enhanced = withPlugin(adapter, withCircuitBreakerPrefix(prefix));
+            const enhanced = withPlugin(
+                adapter,
+                withCircuitBreakerPrefix(prefix),
+            );
 
-        await enhanced.isolate(context, "myKey");
+            await enhanced.isolate(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
     });
 
-    test("Should prefix keys for reset", async () => {
-        const adapter = new NoOpCircuitBreakerAdapter();
-        const spy = vi.spyOn(adapter, "reset");
+    describe("method: reset", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpCircuitBreakerAdapter();
+            const spy = vi.spyOn(adapter, "reset");
 
-        const enhanced = withPlugin(adapter, withCircuitBreakerPrefix(prefix));
+            const enhanced = withPlugin(
+                adapter,
+                withCircuitBreakerPrefix(prefix),
+            );
 
-        await enhanced.reset(context, "myKey");
+            await enhanced.reset(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
     });
 
-    test("Should prefix keys for trackFailure", async () => {
-        const adapter = new NoOpCircuitBreakerAdapter();
-        const spy = vi.spyOn(adapter, "trackFailure");
+    describe("method: trackFailure", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpCircuitBreakerAdapter();
+            const spy = vi.spyOn(adapter, "trackFailure");
 
-        const enhanced = withPlugin(adapter, withCircuitBreakerPrefix(prefix));
+            const enhanced = withPlugin(
+                adapter,
+                withCircuitBreakerPrefix(prefix),
+            );
 
-        await enhanced.trackFailure(context, "myKey");
+            await enhanced.trackFailure(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
     });
 
-    test("Should prefix keys for trackSuccess", async () => {
-        const adapter = new NoOpCircuitBreakerAdapter();
-        const spy = vi.spyOn(adapter, "trackSuccess");
+    describe("method: trackSuccess", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpCircuitBreakerAdapter();
+            const spy = vi.spyOn(adapter, "trackSuccess");
 
-        const enhanced = withPlugin(adapter, withCircuitBreakerPrefix(prefix));
+            const enhanced = withPlugin(
+                adapter,
+                withCircuitBreakerPrefix(prefix),
+            );
 
-        await enhanced.trackSuccess(context, "myKey");
+            await enhanced.trackSuccess(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
     });
 
-    test("Should prefix keys for updateState", async () => {
-        const adapter = new NoOpCircuitBreakerAdapter();
-        const spy = vi.spyOn(adapter, "updateState");
+    describe("method: updateState", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpCircuitBreakerAdapter();
+            const spy = vi.spyOn(adapter, "updateState");
 
-        const enhanced = withPlugin(adapter, withCircuitBreakerPrefix(prefix));
+            const enhanced = withPlugin(
+                adapter,
+                withCircuitBreakerPrefix(prefix),
+            );
 
-        await enhanced.updateState(context, "myKey");
+            await enhanced.updateState(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
     });
 });

--- a/src/circuit-breaker/implementations/plugins/with-circuit-breaker-prefix/with-circuit-breaker-prefix.ts
+++ b/src/circuit-breaker/implementations/plugins/with-circuit-breaker-prefix/with-circuit-breaker-prefix.ts
@@ -6,6 +6,17 @@ import { type ICircuitBreakerAdapter } from "@/circuit-breaker/contracts/_module
 import { type PluginFn } from "@/middleware/contracts/_module.js";
 
 /**
+ * Creates a plugin that prefixes all keys passed to a circuit-breaker adapter.
+ *
+ * Every method that accepts a circuit-breaker key will have the given `prefix`
+ * prepended before the call is forwarded to the underlying adapter. This is
+ * useful for namespacing circuit-breaker state when multiple independent
+ * consumers share the same backend.
+ *
+ * @param prefix - The string to prepend to every circuit-breaker key.
+ * @returns A middleware plugin that wraps an `ICircuitBreakerAdapter`.
+ *
+ * IMPORT_PATH: `"@daiso-tech/core/circuit-breaker/plugins"`
  * @group Plugins
  */
 export function withCircuitBreakerPrefix(

--- a/src/circuit-breaker/implementations/plugins/with-circuit-breaker-prefix/with-circuit-breaker-prefix.ts
+++ b/src/circuit-breaker/implementations/plugins/with-circuit-breaker-prefix/with-circuit-breaker-prefix.ts
@@ -2,7 +2,7 @@
  * @module CircuitBreaker
  */
 
-import { type ICircuitBreakerAdapter } from "@/circuit-breaker/contracts/circuit-breaker-adapter.contract.js";
+import { type ICircuitBreakerAdapter } from "@/circuit-breaker/contracts/_module.js";
 import { type PluginFn } from "@/middleware/contracts/_module.js";
 
 /**

--- a/src/file-storage/implementations/plugins/with-file-storage-prefix/with-file-storage-prefix.test.ts
+++ b/src/file-storage/implementations/plugins/with-file-storage-prefix/with-file-storage-prefix.test.ts
@@ -8,7 +8,7 @@ import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enh
 import { useFactory } from "@/middleware/implementations/use-factory/_module.js";
 import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
 
-describe("function: withFileStoragePrefix", () => {
+describe("plugin: withFileStoragePrefix", () => {
     const context = new Context(new Map());
     const prefix = "test-prefix:";
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
@@ -17,366 +17,416 @@ describe("function: withFileStoragePrefix", () => {
         vi.clearAllMocks();
     });
 
-    test("Should prefix keys for getPublicUrl", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "getPublicUrl");
+    describe("method: getPublicUrl", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "getPublicUrl");
 
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-        await enhanced.getPublicUrl(context, "myKey");
+            await enhanced.getPublicUrl(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
-    });
-
-    test("Should prefix keys for getSignedDownloadUrl", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "getSignedDownloadUrl");
-
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
-
-        await enhanced.getSignedDownloadUrl(context, "myKey", {
-            expirationInSeconds: 3600,
-            contentType: null,
-            contentDisposition: null,
-        });
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, {
-            expirationInSeconds: 3600,
-            contentType: null,
-            contentDisposition: null,
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
         });
     });
 
-    test("Should prefix keys for getSignedUploadUrl", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "getSignedUploadUrl");
+    describe("method: getSignedDownloadUrl", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "getSignedDownloadUrl");
 
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-        await enhanced.getSignedUploadUrl(context, "myKey", {
-            expirationInSeconds: 3600,
-            contentType: null,
-        });
+            await enhanced.getSignedDownloadUrl(context, "myKey", {
+                expirationInSeconds: 3600,
+                contentType: null,
+                contentDisposition: null,
+            });
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, {
-            expirationInSeconds: 3600,
-            contentType: null,
-        });
-    });
-
-    test("Should prefix keys for exists", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "exists");
-
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
-
-        await enhanced.exists(context, "myKey");
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
-    });
-
-    test("Should prefix keys for getStream", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "getStream");
-
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
-
-        await enhanced.getStream(context, "myKey");
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
-    });
-
-    test("Should prefix keys for getBytes", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "getBytes");
-
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
-
-        await enhanced.getBytes(context, "myKey");
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
-    });
-
-    test("Should prefix keys for getMetaData", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "getMetaData");
-
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
-
-        await enhanced.getMetaData(context, "myKey");
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
-    });
-
-    test("Should prefix keys for add", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "add");
-
-        const content: WritableFileAdapterContent = {
-            data: new Uint8Array(),
-            fileSizeInBytes: 0,
-            contentType: "text/plain",
-            contentLanguage: null,
-            contentEncoding: null,
-            contentDisposition: null,
-            cacheControl: null,
-        };
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
-
-        await enhanced.add(context, "myKey", content);
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, content);
-    });
-
-    test("Should prefix keys for addStream", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "addStream");
-
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
-
-        const stream: AsyncIterable<Uint8Array> = {
-            [Symbol.asyncIterator]: () => ({
-                next: () =>
-                    Promise.resolve({
-                        done: true,
-                        value: undefined as unknown as Uint8Array,
-                    }),
-            }),
-        };
-        await enhanced.addStream(context, "myKey", {
-            data: stream,
-            fileSizeInBytes: null,
-            contentType: "text/plain",
-            contentLanguage: null,
-            contentEncoding: null,
-            contentDisposition: null,
-            cacheControl: null,
-        });
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, {
-            data: stream,
-            fileSizeInBytes: null,
-            contentType: "text/plain",
-            contentLanguage: null,
-            contentEncoding: null,
-            contentDisposition: null,
-            cacheControl: null,
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, {
+                expirationInSeconds: 3600,
+                contentType: null,
+                contentDisposition: null,
+            });
         });
     });
 
-    test("Should prefix keys for update", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "update");
+    describe("method: getSignedUploadUrl", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "getSignedUploadUrl");
 
-        const content: WritableFileAdapterContent = {
-            data: new Uint8Array(),
-            fileSizeInBytes: 0,
-            contentType: "text/plain",
-            contentLanguage: null,
-            contentEncoding: null,
-            contentDisposition: null,
-            cacheControl: null,
-        };
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-        await enhanced.update(context, "myKey", content);
+            await enhanced.getSignedUploadUrl(context, "myKey", {
+                expirationInSeconds: 3600,
+                contentType: null,
+            });
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, content);
-    });
-
-    test("Should prefix keys for updateStream", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "updateStream");
-
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
-
-        const stream2: AsyncIterable<Uint8Array> = {
-            [Symbol.asyncIterator]: () => ({
-                next: () =>
-                    Promise.resolve({
-                        done: true,
-                        value: undefined as unknown as Uint8Array,
-                    }),
-            }),
-        };
-        await enhanced.updateStream(context, "myKey", {
-            data: stream2,
-            fileSizeInBytes: null,
-            contentType: "text/plain",
-            contentLanguage: null,
-            contentEncoding: null,
-            contentDisposition: null,
-            cacheControl: null,
-        });
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, {
-            data: stream2,
-            fileSizeInBytes: null,
-            contentType: "text/plain",
-            contentLanguage: null,
-            contentEncoding: null,
-            contentDisposition: null,
-            cacheControl: null,
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, {
+                expirationInSeconds: 3600,
+                contentType: null,
+            });
         });
     });
 
-    test("Should prefix keys for put", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "put");
+    describe("method: exists", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "exists");
 
-        const content: WritableFileAdapterContent = {
-            data: new Uint8Array(),
-            fileSizeInBytes: 0,
-            contentType: "text/plain",
-            contentLanguage: null,
-            contentEncoding: null,
-            contentDisposition: null,
-            cacheControl: null,
-        };
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-        await enhanced.put(context, "myKey", content);
+            await enhanced.exists(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, content);
-    });
-
-    test("Should prefix keys for putStream", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "putStream");
-
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
-
-        const stream3: AsyncIterable<Uint8Array> = {
-            [Symbol.asyncIterator]: () => ({
-                next: () =>
-                    Promise.resolve({
-                        done: true,
-                        value: undefined as unknown as Uint8Array,
-                    }),
-            }),
-        };
-        await enhanced.putStream(context, "myKey", {
-            data: stream3,
-            fileSizeInBytes: null,
-            contentType: "text/plain",
-            contentLanguage: null,
-            contentEncoding: null,
-            contentDisposition: null,
-            cacheControl: null,
-        });
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, {
-            data: stream3,
-            fileSizeInBytes: null,
-            contentType: "text/plain",
-            contentLanguage: null,
-            contentEncoding: null,
-            contentDisposition: null,
-            cacheControl: null,
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
         });
     });
 
-    test("Should prefix keys for copy", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "copy");
+    describe("method: getStream", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "getStream");
 
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-        await enhanced.copy(context, "sourceKey", "destKey");
+            await enhanced.getStream(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(
-            context,
-            `${prefix}sourceKey`,
-            "destKey",
-        );
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
     });
 
-    test("Should prefix keys for copyAndReplace", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "copyAndReplace");
+    describe("method: getBytes", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "getBytes");
 
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-        await enhanced.copyAndReplace(context, "sourceKey", "destKey");
+            await enhanced.getBytes(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(
-            context,
-            `${prefix}sourceKey`,
-            "destKey",
-        );
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
     });
 
-    test("Should prefix keys for move", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "move");
+    describe("method: getMetaData", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "getMetaData");
 
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-        await enhanced.move(context, "sourceKey", "destKey");
+            await enhanced.getMetaData(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(
-            context,
-            `${prefix}sourceKey`,
-            "destKey",
-        );
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
     });
 
-    test("Should prefix keys for moveAndReplace", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "moveAndReplace");
+    describe("method: add", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "add");
 
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+            const content: WritableFileAdapterContent = {
+                data: new Uint8Array(),
+                fileSizeInBytes: 0,
+                contentType: "text/plain",
+                contentLanguage: null,
+                contentEncoding: null,
+                contentDisposition: null,
+                cacheControl: null,
+            };
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-        await enhanced.moveAndReplace(context, "sourceKey", "destKey");
+            await enhanced.add(context, "myKey", content);
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(
-            context,
-            `${prefix}sourceKey`,
-            "destKey",
-        );
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                `${prefix}myKey`,
+                content,
+            );
+        });
     });
 
-    test("Should prefix keys for removeMany", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "removeMany");
+    describe("method: addStream", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "addStream");
 
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-        await enhanced.removeMany(context, ["key1", "key2"]);
+            const stream: AsyncIterable<Uint8Array> = {
+                [Symbol.asyncIterator]: () => ({
+                    next: () =>
+                        Promise.resolve({
+                            done: true,
+                            value: undefined as unknown as Uint8Array,
+                        }),
+                }),
+            };
+            await enhanced.addStream(context, "myKey", {
+                data: stream,
+                fileSizeInBytes: null,
+                contentType: "text/plain",
+                contentLanguage: null,
+                contentEncoding: null,
+                contentDisposition: null,
+                cacheControl: null,
+            });
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, [
-            `${prefix}key1`,
-            `${prefix}key2`,
-        ]);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, {
+                data: stream,
+                fileSizeInBytes: null,
+                contentType: "text/plain",
+                contentLanguage: null,
+                contentEncoding: null,
+                contentDisposition: null,
+                cacheControl: null,
+            });
+        });
     });
 
-    test("Should prefix keys for removeByPrefix", async () => {
-        const adapter = new NoOpFileStorageAdapter();
-        const spy = vi.spyOn(adapter, "removeByPrefix");
+    describe("method: update", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "update");
 
-        const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+            const content: WritableFileAdapterContent = {
+                data: new Uint8Array(),
+                fileSizeInBytes: 0,
+                contentType: "text/plain",
+                contentLanguage: null,
+                contentEncoding: null,
+                contentDisposition: null,
+                cacheControl: null,
+            };
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-        await enhanced.removeByPrefix(context, "myKey");
+            await enhanced.update(context, "myKey", content);
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                `${prefix}myKey`,
+                content,
+            );
+        });
+    });
+
+    describe("method: updateStream", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "updateStream");
+
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+
+            const stream2: AsyncIterable<Uint8Array> = {
+                [Symbol.asyncIterator]: () => ({
+                    next: () =>
+                        Promise.resolve({
+                            done: true,
+                            value: undefined as unknown as Uint8Array,
+                        }),
+                }),
+            };
+            await enhanced.updateStream(context, "myKey", {
+                data: stream2,
+                fileSizeInBytes: null,
+                contentType: "text/plain",
+                contentLanguage: null,
+                contentEncoding: null,
+                contentDisposition: null,
+                cacheControl: null,
+            });
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, {
+                data: stream2,
+                fileSizeInBytes: null,
+                contentType: "text/plain",
+                contentLanguage: null,
+                contentEncoding: null,
+                contentDisposition: null,
+                cacheControl: null,
+            });
+        });
+    });
+
+    describe("method: put", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "put");
+
+            const content: WritableFileAdapterContent = {
+                data: new Uint8Array(),
+                fileSizeInBytes: 0,
+                contentType: "text/plain",
+                contentLanguage: null,
+                contentEncoding: null,
+                contentDisposition: null,
+                cacheControl: null,
+            };
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+
+            await enhanced.put(context, "myKey", content);
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                `${prefix}myKey`,
+                content,
+            );
+        });
+    });
+
+    describe("method: putStream", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "putStream");
+
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+
+            const stream3: AsyncIterable<Uint8Array> = {
+                [Symbol.asyncIterator]: () => ({
+                    next: () =>
+                        Promise.resolve({
+                            done: true,
+                            value: undefined as unknown as Uint8Array,
+                        }),
+                }),
+            };
+            await enhanced.putStream(context, "myKey", {
+                data: stream3,
+                fileSizeInBytes: null,
+                contentType: "text/plain",
+                contentLanguage: null,
+                contentEncoding: null,
+                contentDisposition: null,
+                cacheControl: null,
+            });
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, {
+                data: stream3,
+                fileSizeInBytes: null,
+                contentType: "text/plain",
+                contentLanguage: null,
+                contentEncoding: null,
+                contentDisposition: null,
+                cacheControl: null,
+            });
+        });
+    });
+
+    describe("method: copy", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "copy");
+
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+
+            await enhanced.copy(context, "sourceKey", "destKey");
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                `${prefix}sourceKey`,
+                "destKey",
+            );
+        });
+    });
+
+    describe("method: copyAndReplace", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "copyAndReplace");
+
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+
+            await enhanced.copyAndReplace(context, "sourceKey", "destKey");
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                `${prefix}sourceKey`,
+                "destKey",
+            );
+        });
+    });
+
+    describe("method: move", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "move");
+
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+
+            await enhanced.move(context, "sourceKey", "destKey");
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                `${prefix}sourceKey`,
+                "destKey",
+            );
+        });
+    });
+
+    describe("method: moveAndReplace", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "moveAndReplace");
+
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+
+            await enhanced.moveAndReplace(context, "sourceKey", "destKey");
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                `${prefix}sourceKey`,
+                "destKey",
+            );
+        });
+    });
+
+    describe("method: removeMany", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "removeMany");
+
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+
+            await enhanced.removeMany(context, ["key1", "key2"]);
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, [
+                `${prefix}key1`,
+                `${prefix}key2`,
+            ]);
+        });
+    });
+
+    describe("method: removeByPrefix", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpFileStorageAdapter();
+            const spy = vi.spyOn(adapter, "removeByPrefix");
+
+            const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
+
+            await enhanced.removeByPrefix(context, "myKey");
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
     });
 });

--- a/src/file-storage/implementations/plugins/with-file-storage-prefix/with-file-storage-prefix.ts
+++ b/src/file-storage/implementations/plugins/with-file-storage-prefix/with-file-storage-prefix.ts
@@ -9,6 +9,17 @@ import {
 import { type PluginFn } from "@/middleware/contracts/_module.js";
 
 /**
+ * Creates a plugin that prefixes all file keys passed to a file-storage adapter.
+ *
+ * Every method that accepts a file key (identifier/path) will have the given
+ * `prefix` prepended before the call is forwarded to the underlying adapter.
+ * This includes public URL generation, signed URL generation, existence checks,
+ * streaming, metadata, and all CRUD operations.
+ *
+ * @param prefix - The string to prepend to every file key.
+ * @returns A middleware plugin that wraps a file-storage adapter.
+ *
+ * IMPORT_PATH: `"@daiso-tech/core/file-storage/plugins"`
  * @group Plugins
  */
 export function withFileStoragePrefix(

--- a/src/file-storage/implementations/plugins/with-file-storage-prefix/with-file-storage-prefix.ts
+++ b/src/file-storage/implementations/plugins/with-file-storage-prefix/with-file-storage-prefix.ts
@@ -5,7 +5,7 @@
 import {
     type IFileUrlAdapter,
     type IFileStorageAdapter,
-} from "@/file-storage/contracts/file-storage-adapter.contract.js";
+} from "@/file-storage/contracts/_module.js";
 import { type PluginFn } from "@/middleware/contracts/_module.js";
 
 /**

--- a/src/lock/implementations/middlewares/with-lock-factory.ts
+++ b/src/lock/implementations/middlewares/with-lock-factory.ts
@@ -19,14 +19,14 @@ export type WithLockSettings<
     TParameters extends Array<unknown> = Array<unknown>,
 > = {
     /**
-     * A function or static value that produces the lock key from the wrapped
+     *  A function that produces the lock key from the wrapped
      * function's arguments. The lock is acquired on this key, ensuring mutual
      * exclusion across processes for the same key.
      */
     key: Invokable<TParameters, string>;
 
     /**
-     * A function or static value that produces a unique identifier for the
+     *  A function that produces a unique identifier for the
      * current lock acquisition attempt. The lock ID distinguishes competing
      * consumers trying to acquire the same lock.
      *

--- a/src/lock/implementations/plugins/with-lock-prefix/with-lock-prefix.test.ts
+++ b/src/lock/implementations/plugins/with-lock-prefix/with-lock-prefix.test.ts
@@ -8,7 +8,7 @@ import { useFactory } from "@/middleware/implementations/use-factory/_module.js"
 import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
 import { TimeSpan } from "@/time-span/implementations/_module.js";
 
-describe("function: withLockPrefix", () => {
+describe("plugin: withLockPrefix", () => {
     const context = new Context(new Map());
     const prefix = "test-prefix:";
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
@@ -17,83 +17,97 @@ describe("function: withLockPrefix", () => {
         vi.clearAllMocks();
     });
 
-    test("Should prefix keys for acquire", async () => {
-        const adapter = new NoOpLockAdapter();
-        const spy = vi.spyOn(adapter, "acquire");
+    describe("method: acquire", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpLockAdapter();
+            const spy = vi.spyOn(adapter, "acquire");
 
-        const enhanced = withPlugin(adapter, withLockPrefix(prefix));
+            const enhanced = withPlugin(adapter, withLockPrefix(prefix));
 
-        await enhanced.acquire(
-            context,
-            "myKey",
-            "lockId",
-            TimeSpan.fromSeconds(30),
-        );
+            await enhanced.acquire(
+                context,
+                "myKey",
+                "lockId",
+                TimeSpan.fromSeconds(30),
+            );
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(
-            context,
-            `${prefix}myKey`,
-            "lockId",
-            TimeSpan.fromSeconds(30),
-        );
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                `${prefix}myKey`,
+                "lockId",
+                TimeSpan.fromSeconds(30),
+            );
+        });
     });
 
-    test("Should prefix keys for forceRelease", async () => {
-        const adapter = new NoOpLockAdapter();
-        const spy = vi.spyOn(adapter, "forceRelease");
+    describe("method: forceRelease", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpLockAdapter();
+            const spy = vi.spyOn(adapter, "forceRelease");
 
-        const enhanced = withPlugin(adapter, withLockPrefix(prefix));
+            const enhanced = withPlugin(adapter, withLockPrefix(prefix));
 
-        await enhanced.forceRelease(context, "myKey");
+            await enhanced.forceRelease(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
     });
 
-    test("Should prefix keys for getState", async () => {
-        const adapter = new NoOpLockAdapter();
-        const spy = vi.spyOn(adapter, "getState");
+    describe("method: getState", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpLockAdapter();
+            const spy = vi.spyOn(adapter, "getState");
 
-        const enhanced = withPlugin(adapter, withLockPrefix(prefix));
+            const enhanced = withPlugin(adapter, withLockPrefix(prefix));
 
-        await enhanced.getState(context, "myKey");
+            await enhanced.getState(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
     });
 
-    test("Should prefix keys for refresh", async () => {
-        const adapter = new NoOpLockAdapter();
-        const spy = vi.spyOn(adapter, "refresh");
+    describe("method: refresh", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpLockAdapter();
+            const spy = vi.spyOn(adapter, "refresh");
 
-        const enhanced = withPlugin(adapter, withLockPrefix(prefix));
+            const enhanced = withPlugin(adapter, withLockPrefix(prefix));
 
-        await enhanced.refresh(
-            context,
-            "myKey",
-            "lockId",
-            TimeSpan.fromSeconds(30),
-        );
+            await enhanced.refresh(
+                context,
+                "myKey",
+                "lockId",
+                TimeSpan.fromSeconds(30),
+            );
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(
-            context,
-            `${prefix}myKey`,
-            "lockId",
-            TimeSpan.fromSeconds(30),
-        );
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                `${prefix}myKey`,
+                "lockId",
+                TimeSpan.fromSeconds(30),
+            );
+        });
     });
 
-    test("Should prefix keys for release", async () => {
-        const adapter = new NoOpLockAdapter();
-        const spy = vi.spyOn(adapter, "release");
+    describe("method: release", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpLockAdapter();
+            const spy = vi.spyOn(adapter, "release");
 
-        const enhanced = withPlugin(adapter, withLockPrefix(prefix));
+            const enhanced = withPlugin(adapter, withLockPrefix(prefix));
 
-        await enhanced.release(context, "myKey", "lockId");
+            await enhanced.release(context, "myKey", "lockId");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, "lockId");
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                `${prefix}myKey`,
+                "lockId",
+            );
+        });
     });
 });

--- a/src/lock/implementations/plugins/with-lock-prefix/with-lock-prefix.ts
+++ b/src/lock/implementations/plugins/with-lock-prefix/with-lock-prefix.ts
@@ -2,7 +2,7 @@
  * @module Lock
  */
 
-import { type ILockAdapter } from "@/lock/contracts/lock-adapter.contract.js";
+import { type ILockAdapter } from "@/lock/contracts/_module.js";
 import { type PluginFn } from "@/middleware/contracts/_module.js";
 
 /**

--- a/src/lock/implementations/plugins/with-lock-prefix/with-lock-prefix.ts
+++ b/src/lock/implementations/plugins/with-lock-prefix/with-lock-prefix.ts
@@ -6,6 +6,17 @@ import { type ILockAdapter } from "@/lock/contracts/_module.js";
 import { type PluginFn } from "@/middleware/contracts/_module.js";
 
 /**
+ * Creates a plugin that prefixes all keys passed to a lock adapter.
+ *
+ * Every method that accepts a lock key will have the given `prefix` prepended
+ * before the call is forwarded to the underlying adapter. This is useful for
+ * namespacing locks when multiple independent consumers share the same lock
+ * backend.
+ *
+ * @param prefix - The string to prepend to every lock key.
+ * @returns A middleware plugin that wraps an `ILockAdapter`.
+ *
+ * IMPORT_PATH: `"@daiso-tech/core/lock/plugins"`
  * @group Plugins
  */
 export function withLockPrefix(prefix: string): PluginFn<ILockAdapter> {

--- a/src/middleware/contracts/enhance.contract.ts
+++ b/src/middleware/contracts/enhance.contract.ts
@@ -121,3 +121,35 @@ export type Enhance = <TInstance, TField extends InferMethodNames<TInstance>>(
         >
     >,
 ) => void;
+
+/*
+```ts
+class Example {
+    a(arg: string): void {}
+
+    b(arg: string): void {
+        this.a(arg);
+    }
+}
+
+const instance = new Example(); 
+function withPrefix<TReturn>(prefix: string): MiddlewareFn<[key: string], TReturn> {
+    return ({ args: [key], next }) => {
+        return next([prefix + key])
+    }
+}
+enhance(instance, "a", withPrefix("@/"));
+enhance(instance, "b", withPrefix("@/"));
+``` 
+
+When calling instance a:
+
+```ts
+// Key will be "@/test"
+instance.a("test");
+
+// Key will be "@/test"
+// But the underlying key pased to method `a` will be doubled prefixed "@/@/test"
+instance.b("test");
+```
+*/

--- a/src/middleware/contracts/enhance.contract.ts
+++ b/src/middleware/contracts/enhance.contract.ts
@@ -121,35 +121,3 @@ export type Enhance = <TInstance, TField extends InferMethodNames<TInstance>>(
         >
     >,
 ) => void;
-
-/*
-```ts
-class Example {
-    a(arg: string): void {}
-
-    b(arg: string): void {
-        this.a(arg);
-    }
-}
-
-const instance = new Example(); 
-function withPrefix<TReturn>(prefix: string): MiddlewareFn<[key: string], TReturn> {
-    return ({ args: [key], next }) => {
-        return next([prefix + key])
-    }
-}
-enhance(instance, "a", withPrefix("@/"));
-enhance(instance, "b", withPrefix("@/"));
-``` 
-
-When calling instance a:
-
-```ts
-// Key will be "@/test"
-instance.a("test");
-
-// Key will be "@/test"
-// But the underlying key pased to method `a` will be doubled prefixed "@/@/test"
-instance.b("test");
-```
-*/

--- a/src/rate-limiter/implementations/middlewares/with-rate-limiter-factory.ts
+++ b/src/rate-limiter/implementations/middlewares/with-rate-limiter-factory.ts
@@ -11,17 +11,48 @@ import {
 } from "@/utilities/_module.js";
 
 /**
+ * Settings for the rate-limiter middleware.
+ *
+ * @typeParam TParameters - Tuple type of the wrapped function's parameters.
  * @group Middleware
  */
 export type WithRateLimiterSettings<
     TParameters extends Array<unknown> = Array<unknown>,
 > = ErrorPolicySettings & {
+    /**
+     * A function or static value that produces the rate-limiter key from the
+     * wrapped function's arguments. Each unique key gets its own rate-limit
+     * counter.
+     */
     key: Invokable<TParameters, string>;
+
+    /**
+     * When `true`, only failed (errored) invocations count toward the rate
+     * limit. Successful calls are ignored.
+     *
+     * @default false
+     */
     onlyError?: boolean;
+
+    /**
+     * Maximum number of invocations allowed within the configured window.
+     */
     limit: number;
 };
 
 /**
+ * A higher-order function that creates a middleware factory which wraps
+ * function calls with a rate limiter.
+ *
+ * Each unique key (derived from the wrapped function's arguments) gets its
+ * own rate-limit counter. When the maximum number of invocations (`limit`)
+ * is exceeded within the configured window subsequent calls throw a
+ * rate-limit error instead of executing the wrapped function.
+ *
+ * @param rateLimiterFactory - The rate-limiter factory to use.
+ * @returns A higher-order function that accepts {@link WithRateLimiterSettings}
+ *          and returns a {@link MiddlewareFn}.
+ *
  * IMPORT_PATH: `"@daiso-tech/core/rate-limiter/middlewares"`
  * @group Middleware
  */

--- a/src/rate-limiter/implementations/middlewares/with-rate-limiter-factory.ts
+++ b/src/rate-limiter/implementations/middlewares/with-rate-limiter-factory.ts
@@ -20,7 +20,7 @@ export type WithRateLimiterSettings<
     TParameters extends Array<unknown> = Array<unknown>,
 > = ErrorPolicySettings & {
     /**
-     * A function or static value that produces the rate-limiter key from the
+     *  A function that produces the rate-limiter key from the
      * wrapped function's arguments. Each unique key gets its own rate-limit
      * counter.
      */

--- a/src/rate-limiter/implementations/plugins/with-rate-limiter-prefix/with-rate-limiter-prefix.test.ts
+++ b/src/rate-limiter/implementations/plugins/with-rate-limiter-prefix/with-rate-limiter-prefix.test.ts
@@ -7,7 +7,7 @@ import { withPluginFactory } from "@/middleware/implementations/with-plugin-fact
 import { NoOpRateLimiterAdapter } from "@/rate-limiter/implementations/adapters/_module.js";
 import { withRateLimiterPrefix } from "@/rate-limiter/implementations/plugins/with-rate-limiter-prefix/with-rate-limiter-prefix.js";
 
-describe("function: withRateLimiterPrefix", () => {
+describe("plugin: withRateLimiterPrefix", () => {
     const context = new Context(new Map());
     const prefix = "test-prefix:";
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
@@ -16,39 +16,45 @@ describe("function: withRateLimiterPrefix", () => {
         vi.clearAllMocks();
     });
 
-    test("Should prefix keys for getState", async () => {
-        const adapter = new NoOpRateLimiterAdapter();
-        const spy = vi.spyOn(adapter, "getState");
+    describe("method: getState", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpRateLimiterAdapter();
+            const spy = vi.spyOn(adapter, "getState");
 
-        const enhanced = withPlugin(adapter, withRateLimiterPrefix(prefix));
+            const enhanced = withPlugin(adapter, withRateLimiterPrefix(prefix));
 
-        await enhanced.getState(context, "myKey");
+            await enhanced.getState(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
     });
 
-    test("Should prefix keys for reset", async () => {
-        const adapter = new NoOpRateLimiterAdapter();
-        const spy = vi.spyOn(adapter, "reset");
+    describe("method: reset", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpRateLimiterAdapter();
+            const spy = vi.spyOn(adapter, "reset");
 
-        const enhanced = withPlugin(adapter, withRateLimiterPrefix(prefix));
+            const enhanced = withPlugin(adapter, withRateLimiterPrefix(prefix));
 
-        await enhanced.reset(context, "myKey");
+            await enhanced.reset(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
     });
 
-    test("Should prefix keys for updateState", async () => {
-        const adapter = new NoOpRateLimiterAdapter();
-        const spy = vi.spyOn(adapter, "updateState");
+    describe("method: updateState", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpRateLimiterAdapter();
+            const spy = vi.spyOn(adapter, "updateState");
 
-        const enhanced = withPlugin(adapter, withRateLimiterPrefix(prefix));
+            const enhanced = withPlugin(adapter, withRateLimiterPrefix(prefix));
 
-        await enhanced.updateState(context, "myKey", 10);
+            await enhanced.updateState(context, "myKey", 10);
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, 10);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, 10);
+        });
     });
 });

--- a/src/rate-limiter/implementations/plugins/with-rate-limiter-prefix/with-rate-limiter-prefix.ts
+++ b/src/rate-limiter/implementations/plugins/with-rate-limiter-prefix/with-rate-limiter-prefix.ts
@@ -3,7 +3,7 @@
  */
 
 import { type PluginFn } from "@/middleware/contracts/_module.js";
-import { type IRateLimiterAdapter } from "@/rate-limiter/contracts/rate-limiter-adapter.contract.js";
+import { type IRateLimiterAdapter } from "@/rate-limiter/contracts/_module.js";
 
 /**
  * @group Plugins

--- a/src/rate-limiter/implementations/plugins/with-rate-limiter-prefix/with-rate-limiter-prefix.ts
+++ b/src/rate-limiter/implementations/plugins/with-rate-limiter-prefix/with-rate-limiter-prefix.ts
@@ -6,6 +6,17 @@ import { type PluginFn } from "@/middleware/contracts/_module.js";
 import { type IRateLimiterAdapter } from "@/rate-limiter/contracts/_module.js";
 
 /**
+ * Creates a plugin that prefixes all keys passed to a rate-limiter adapter.
+ *
+ * Every method that accepts a rate-limiter key will have the given `prefix`
+ * prepended before the call is forwarded to the underlying adapter. This is
+ * useful for namespacing rate-limiter state when multiple independent consumers
+ * share the same backend.
+ *
+ * @param prefix - The string to prepend to every rate-limiter key.
+ * @returns A middleware plugin that wraps an `IRateLimiterAdapter`.
+ *
+ * IMPORT_PATH: `"@daiso-tech/core/rate-limiter/plugins"`
  * @group Plugins
  */
 export function withRateLimiterPrefix(

--- a/src/semaphore/implementations/middlewares/with-semaphore-factory.ts
+++ b/src/semaphore/implementations/middlewares/with-semaphore-factory.ts
@@ -19,14 +19,14 @@ export type WithSemaphoreSettings<
     TParameters extends Array<unknown> = Array<unknown>,
 > = {
     /**
-     * A function or static value that produces the semaphore key from the
+     *  A function that produces the semaphore key from the
      * wrapped function's arguments. All consumers using the same key share
      * the same semaphore limit.
      */
     key: Invokable<TParameters, string>;
 
     /**
-     * A function or static value that produces a unique slot identifier for
+     *  A function that produces a unique slot identifier for
      * the current acquisition attempt. Each concurrent consumer needs a
      * distinct slot ID.
      *

--- a/src/semaphore/implementations/plugins/with-semaphore-prefix/with-semaphore-prefix.test.ts
+++ b/src/semaphore/implementations/plugins/with-semaphore-prefix/with-semaphore-prefix.test.ts
@@ -8,7 +8,7 @@ import { NoOpSemaphoreAdapter } from "@/semaphore/implementations/adapters/_modu
 import { withSemaphorePrefix } from "@/semaphore/implementations/plugins/with-semaphore-prefix/with-semaphore-prefix.js";
 import { TimeSpan } from "@/time-span/implementations/_module.js";
 
-describe("function: withSemaphorePrefix", () => {
+describe("plugin: withSemaphorePrefix", () => {
     const context = new Context(new Map());
     const prefix = "test-prefix:";
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
@@ -17,85 +17,99 @@ describe("function: withSemaphorePrefix", () => {
         vi.clearAllMocks();
     });
 
-    test("Should prefix keys for acquire", async () => {
-        const adapter = new NoOpSemaphoreAdapter();
-        const spy = vi.spyOn(adapter, "acquire");
+    describe("method: acquire", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpSemaphoreAdapter();
+            const spy = vi.spyOn(adapter, "acquire");
 
-        const enhanced = withPlugin(adapter, withSemaphorePrefix(prefix));
+            const enhanced = withPlugin(adapter, withSemaphorePrefix(prefix));
 
-        await enhanced.acquire({
-            context,
-            key: "myKey",
-            slotId: "slot1",
-            limit: 5,
-            ttl: TimeSpan.fromSeconds(30),
+            await enhanced.acquire({
+                context,
+                key: "myKey",
+                slotId: "slot1",
+                limit: 5,
+                ttl: TimeSpan.fromSeconds(30),
+            });
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith({
+                context,
+                key: `${prefix}myKey`,
+                slotId: "slot1",
+                limit: 5,
+                ttl: TimeSpan.fromSeconds(30),
+            });
         });
+    });
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith({
-            context,
-            key: `${prefix}myKey`,
-            slotId: "slot1",
-            limit: 5,
-            ttl: TimeSpan.fromSeconds(30),
+    describe("method: forceReleaseAll", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpSemaphoreAdapter();
+            const spy = vi.spyOn(adapter, "forceReleaseAll");
+
+            const enhanced = withPlugin(adapter, withSemaphorePrefix(prefix));
+
+            await enhanced.forceReleaseAll(context, "myKey");
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
         });
     });
 
-    test("Should prefix keys for forceReleaseAll", async () => {
-        const adapter = new NoOpSemaphoreAdapter();
-        const spy = vi.spyOn(adapter, "forceReleaseAll");
+    describe("method: getState", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpSemaphoreAdapter();
+            const spy = vi.spyOn(adapter, "getState");
 
-        const enhanced = withPlugin(adapter, withSemaphorePrefix(prefix));
+            const enhanced = withPlugin(adapter, withSemaphorePrefix(prefix));
 
-        await enhanced.forceReleaseAll(context, "myKey");
+            await enhanced.getState(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
     });
 
-    test("Should prefix keys for getState", async () => {
-        const adapter = new NoOpSemaphoreAdapter();
-        const spy = vi.spyOn(adapter, "getState");
+    describe("method: refresh", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpSemaphoreAdapter();
+            const spy = vi.spyOn(adapter, "refresh");
 
-        const enhanced = withPlugin(adapter, withSemaphorePrefix(prefix));
+            const enhanced = withPlugin(adapter, withSemaphorePrefix(prefix));
 
-        await enhanced.getState(context, "myKey");
+            await enhanced.refresh(
+                context,
+                "myKey",
+                "slot1",
+                TimeSpan.fromSeconds(30),
+            );
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                `${prefix}myKey`,
+                "slot1",
+                TimeSpan.fromSeconds(30),
+            );
+        });
     });
 
-    test("Should prefix keys for refresh", async () => {
-        const adapter = new NoOpSemaphoreAdapter();
-        const spy = vi.spyOn(adapter, "refresh");
+    describe("method: release", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpSemaphoreAdapter();
+            const spy = vi.spyOn(adapter, "release");
 
-        const enhanced = withPlugin(adapter, withSemaphorePrefix(prefix));
+            const enhanced = withPlugin(adapter, withSemaphorePrefix(prefix));
 
-        await enhanced.refresh(
-            context,
-            "myKey",
-            "slot1",
-            TimeSpan.fromSeconds(30),
-        );
+            await enhanced.release(context, "myKey", "slot1");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(
-            context,
-            `${prefix}myKey`,
-            "slot1",
-            TimeSpan.fromSeconds(30),
-        );
-    });
-
-    test("Should prefix keys for release", async () => {
-        const adapter = new NoOpSemaphoreAdapter();
-        const spy = vi.spyOn(adapter, "release");
-
-        const enhanced = withPlugin(adapter, withSemaphorePrefix(prefix));
-
-        await enhanced.release(context, "myKey", "slot1");
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, "slot1");
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                `${prefix}myKey`,
+                "slot1",
+            );
+        });
     });
 });

--- a/src/semaphore/implementations/plugins/with-semaphore-prefix/with-semaphore-prefix.ts
+++ b/src/semaphore/implementations/plugins/with-semaphore-prefix/with-semaphore-prefix.ts
@@ -1,11 +1,22 @@
 /**
- * @module RateLimiter
+ * @module Semaphore
  */
 
 import { type PluginFn } from "@/middleware/contracts/_module.js";
 import { type ISemaphoreAdapter } from "@/semaphore/contracts/_module.js";
 
 /**
+ * Creates a plugin that prefixes all keys passed to a semaphore adapter.
+ *
+ * Every method that accepts a semaphore key will have the given `prefix`
+ * prepended before the call is forwarded to the underlying adapter. This is
+ * useful for namespacing semaphore state when multiple independent consumers
+ * share the same backend.
+ *
+ * @param prefix - The string to prepend to every semaphore key.
+ * @returns A middleware plugin that wraps an `ISemaphoreAdapter`.
+ *
+ * IMPORT_PATH: `"@daiso-tech/core/semaphore/plugins"`
  * @group Plugins
  */
 export function withSemaphorePrefix(

--- a/src/semaphore/implementations/plugins/with-semaphore-prefix/with-semaphore-prefix.ts
+++ b/src/semaphore/implementations/plugins/with-semaphore-prefix/with-semaphore-prefix.ts
@@ -3,7 +3,7 @@
  */
 
 import { type PluginFn } from "@/middleware/contracts/_module.js";
-import { type ISemaphoreAdapter } from "@/semaphore/contracts/semaphore-adapter.contract.js";
+import { type ISemaphoreAdapter } from "@/semaphore/contracts/_module.js";
 
 /**
  * @group Plugins

--- a/src/shared-lock/implementations/middlewares/with-shared-lock-factory.ts
+++ b/src/shared-lock/implementations/middlewares/with-shared-lock-factory.ts
@@ -40,14 +40,14 @@ export type WithSharedLockFactorySettings<
     TParameters extends Array<unknown> = Array<unknown>,
 > = {
     /**
-     * A function or static value that produces the lock key from the wrapped
+     *  A function that produces the lock key from the wrapped
      * function's arguments. All consumers using the same key share the same
      * lock state.
      */
     key: Invokable<TParameters, string>;
 
     /**
-     * A function or static value that produces a unique identifier for the
+     *  A function that produces a unique identifier for the
      * current lock acquisition attempt. The lock ID distinguishes competing
      * consumers trying to acquire the same lock.
      *

--- a/src/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.test.ts
+++ b/src/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.test.ts
@@ -8,7 +8,7 @@ import { NoOpSharedLockAdapter } from "@/shared-lock/implementations/adapters/_m
 import { withSharedLockPrefix } from "@/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.js";
 import { TimeSpan } from "@/time-span/implementations/_module.js";
 
-describe("function: withSharedLockPrefix", () => {
+describe("plugin: withSharedLockPrefix", () => {
     const context = new Context(new Map());
     const prefix = "test-prefix:";
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
@@ -17,153 +17,175 @@ describe("function: withSharedLockPrefix", () => {
         vi.clearAllMocks();
     });
 
-    test("Should prefix keys for forceRelease", async () => {
-        const adapter = new NoOpSharedLockAdapter();
-        const spy = vi.spyOn(adapter, "forceRelease");
+    describe("method: forceRelease", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpSharedLockAdapter();
+            const spy = vi.spyOn(adapter, "forceRelease");
 
-        const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
+            const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
-        await enhanced.forceRelease(context, "myKey");
+            await enhanced.forceRelease(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
-    });
-
-    test("Should prefix keys for getState", async () => {
-        const adapter = new NoOpSharedLockAdapter();
-        const spy = vi.spyOn(adapter, "getState");
-
-        const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
-
-        await enhanced.getState(context, "myKey");
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
-    });
-
-    test("Should prefix keys for acquireWriter", async () => {
-        const adapter = new NoOpSharedLockAdapter();
-        const spy = vi.spyOn(adapter, "acquireWriter");
-
-        const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
-
-        await enhanced.acquireWriter(
-            context,
-            "myKey",
-            "lockId",
-            TimeSpan.fromSeconds(30),
-        );
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(
-            context,
-            `${prefix}myKey`,
-            "lockId",
-            TimeSpan.fromSeconds(30),
-        );
-    });
-
-    test("Should prefix keys for forceReleaseWriter", async () => {
-        const adapter = new NoOpSharedLockAdapter();
-        const spy = vi.spyOn(adapter, "forceReleaseWriter");
-
-        const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
-
-        await enhanced.forceReleaseWriter(context, "myKey");
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
-    });
-
-    test("Should prefix keys for refreshWriter", async () => {
-        const adapter = new NoOpSharedLockAdapter();
-        const spy = vi.spyOn(adapter, "refreshWriter");
-
-        const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
-
-        await enhanced.refreshWriter(
-            context,
-            "myKey",
-            "lockId",
-            TimeSpan.fromSeconds(30),
-        );
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(
-            context,
-            `${prefix}myKey`,
-            "lockId",
-            TimeSpan.fromSeconds(30),
-        );
-    });
-
-    test("Should prefix keys for releaseWriter", async () => {
-        const adapter = new NoOpSharedLockAdapter();
-        const spy = vi.spyOn(adapter, "releaseWriter");
-
-        const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
-
-        await enhanced.releaseWriter(context, "myKey", "lockId");
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, "lockId");
-    });
-
-    test("Should prefix keys for acquireReader", async () => {
-        const adapter = new NoOpSharedLockAdapter();
-        const spy = vi.spyOn(adapter, "acquireReader");
-
-        const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
-
-        await enhanced.acquireReader({
-            context,
-            key: "myKey",
-            lockId: "lock1",
-            limit: 5,
-            ttl: TimeSpan.fromSeconds(30),
-        });
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith({
-            context,
-            key: `${prefix}myKey`,
-            lockId: "lock1",
-            limit: 5,
-            ttl: TimeSpan.fromSeconds(30),
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
         });
     });
 
-    test("Should prefix keys for forceReleaseAllReaders", async () => {
-        const adapter = new NoOpSharedLockAdapter();
-        const spy = vi.spyOn(adapter, "forceReleaseAllReaders");
+    describe("method: getState", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpSharedLockAdapter();
+            const spy = vi.spyOn(adapter, "getState");
 
-        const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
+            const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
-        await enhanced.forceReleaseAllReaders(context, "myKey");
+            await enhanced.getState(context, "myKey");
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
     });
 
-    test("Should prefix keys for refreshReader", async () => {
-        const adapter = new NoOpSharedLockAdapter();
-        const spy = vi.spyOn(adapter, "refreshReader");
+    describe("method: acquireWriter", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpSharedLockAdapter();
+            const spy = vi.spyOn(adapter, "acquireWriter");
 
-        const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
+            const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
-        await enhanced.refreshReader(
-            context,
-            "myKey",
-            "lockId",
-            TimeSpan.fromSeconds(30),
-        );
+            await enhanced.acquireWriter(
+                context,
+                "myKey",
+                "lockId",
+                TimeSpan.fromSeconds(30),
+            );
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(
-            context,
-            `${prefix}myKey`,
-            "lockId",
-            TimeSpan.fromSeconds(30),
-        );
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                `${prefix}myKey`,
+                "lockId",
+                TimeSpan.fromSeconds(30),
+            );
+        });
+    });
+
+    describe("method: forceReleaseWriter", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpSharedLockAdapter();
+            const spy = vi.spyOn(adapter, "forceReleaseWriter");
+
+            const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
+
+            await enhanced.forceReleaseWriter(context, "myKey");
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
+    });
+
+    describe("method: refreshWriter", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpSharedLockAdapter();
+            const spy = vi.spyOn(adapter, "refreshWriter");
+
+            const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
+
+            await enhanced.refreshWriter(
+                context,
+                "myKey",
+                "lockId",
+                TimeSpan.fromSeconds(30),
+            );
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                `${prefix}myKey`,
+                "lockId",
+                TimeSpan.fromSeconds(30),
+            );
+        });
+    });
+
+    describe("method: releaseWriter", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpSharedLockAdapter();
+            const spy = vi.spyOn(adapter, "releaseWriter");
+
+            const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
+
+            await enhanced.releaseWriter(context, "myKey", "lockId");
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                `${prefix}myKey`,
+                "lockId",
+            );
+        });
+    });
+
+    describe("method: acquireReader", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpSharedLockAdapter();
+            const spy = vi.spyOn(adapter, "acquireReader");
+
+            const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
+
+            await enhanced.acquireReader({
+                context,
+                key: "myKey",
+                lockId: "lock1",
+                limit: 5,
+                ttl: TimeSpan.fromSeconds(30),
+            });
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith({
+                context,
+                key: `${prefix}myKey`,
+                lockId: "lock1",
+                limit: 5,
+                ttl: TimeSpan.fromSeconds(30),
+            });
+        });
+    });
+
+    describe("method: forceReleaseAllReaders", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpSharedLockAdapter();
+            const spy = vi.spyOn(adapter, "forceReleaseAllReaders");
+
+            const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
+
+            await enhanced.forceReleaseAllReaders(context, "myKey");
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+        });
+    });
+
+    describe("method: refreshReader", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpSharedLockAdapter();
+            const spy = vi.spyOn(adapter, "refreshReader");
+
+            const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
+
+            await enhanced.refreshReader(
+                context,
+                "myKey",
+                "lockId",
+                TimeSpan.fromSeconds(30),
+            );
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                `${prefix}myKey`,
+                "lockId",
+                TimeSpan.fromSeconds(30),
+            );
+        });
     });
 });

--- a/src/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.test.ts
+++ b/src/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.test.ts
@@ -188,4 +188,22 @@ describe("plugin: withSharedLockPrefix", () => {
             );
         });
     });
+
+    describe("method: releaseReader", () => {
+        test("Should prefix the key", async () => {
+            const adapter = new NoOpSharedLockAdapter();
+            const spy = vi.spyOn(adapter, "releaseReader");
+
+            const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
+
+            await enhanced.releaseReader(context, "myKey", "lockId");
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith(
+                context,
+                `${prefix}myKey`,
+                "lockId",
+            );
+        });
+    });
 });

--- a/src/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.ts
+++ b/src/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.ts
@@ -1,11 +1,22 @@
 /**
- * @module RateLimiter
+ * @module SharedLock
  */
 
 import { type PluginFn } from "@/middleware/contracts/_module.js";
 import { type ISharedLockAdapter } from "@/shared-lock/contracts/_module.js";
 
 /**
+ * Creates a plugin that prefixes all keys passed to a shared-lock adapter.
+ *
+ * Every method that accepts a lock key will have the given `prefix` prepended
+ * before the call is forwarded to the underlying adapter. This applies to both
+ * writer and reader operations, including acquire, release, refresh, and
+ * force-release methods.
+ *
+ * @param prefix - The string to prepend to every shared-lock key.
+ * @returns A middleware plugin that wraps an `ISharedLockAdapter`.
+ *
+ * IMPORT_PATH: `"@daiso-tech/core/shared-lock/plugins"`
  * @group Plugins
  */
 export function withSharedLockPrefix(

--- a/src/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.ts
+++ b/src/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.ts
@@ -89,5 +89,12 @@ export function withSharedLockPrefix(
                 return next([context, withPrefix(key), ...rest]);
             },
         );
+        enhance(
+            adapter,
+            "releaseReader",
+            ({ args: [context, key, ...rest], next }) => {
+                return next([context, withPrefix(key), ...rest]);
+            },
+        );
     };
 }

--- a/src/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.ts
+++ b/src/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.ts
@@ -3,7 +3,7 @@
  */
 
 import { type PluginFn } from "@/middleware/contracts/_module.js";
-import { type ISharedLockAdapter } from "@/shared-lock/contracts/shared-lock-adapter.contract.js";
+import { type ISharedLockAdapter } from "@/shared-lock/contracts/_module.js";
 
 /**
  * @group Plugins

--- a/website/docs/components/cache/cache_middleware.md
+++ b/website/docs/components/cache/cache_middleware.md
@@ -22,7 +22,8 @@ The Cache middleware intercepts function calls and caches their return values us
 import { withCacheFactory } from "@daiso-tech/core/cache/middlewares";
 import { Cache } from "@daiso-tech/core/cache";
 import { use } from "@daiso-tech/core/middleware";
-import { MemoryCacheAdapter } from "@daiso-tech/core/cache/adapter/memory-cache-adapter";
+import { MemoryCacheAdapter } from "@daiso-tech/core/cache/memory-cache-adapter";
+import { TimeSpan } from "@daiso-tech/core/time-span";
 
 const cache = new Cache({
     adapter: new MemoryCacheAdapter(),
@@ -39,7 +40,7 @@ const cachedFetchUser = use(
     fetchUser,
     withCache({
         key: (userId) => `user:${userId}`,
-        ttl: new TimeSpan("10m"), // Cache for 10 minutes
+        ttl: TimeSpan.fromMinutes(10), // Cache for 10 minutes
     }),
 );
 

--- a/website/docs/components/cache/cache_plugin.md
+++ b/website/docs/components/cache/cache_plugin.md
@@ -11,18 +11,20 @@ keywords:
     - withCachePrefix
 ---
 
-# Cache plugin
+# Cache Plugins
+
+## withCachePrefix plugin
 
 The Cache prefix plugin intercepts calls to a cache adapter and transparently prefixes all cache keys with a configurable string. This enables logical key namespacing without modifying the adapter implementation.
 
-## Use cases
+### Use cases
 
 - **Multi-tenant systems** — Prefix keys with a tenant identifier to isolate cache data between tenants
 - **Environment isolation** — Separate development, staging, and production cache data
 - **Versioning** — Prefix keys with a schema version for cache invalidation across deployments
 - **Module scoping** — Organize cache keys by feature or module to avoid collisions
 
-## How it works
+### How it works
 
 The `withCachePrefix` function returns a [`PluginFn`](/docs/components/middleware) that calls `enhance` on each adapter method that accepts a cache key. When an enhanced method is invoked, the plugin intercepts the call, prepends the configured prefix to the key argument, and forwards the modified arguments to the original method.
 
@@ -41,10 +43,9 @@ The plugin prefixes keys for the following methods:
 
 Methods that do not accept a key (`removeAll`) are unaffected.
 
-## Usage
+### Usage
 
 ```ts
-import { enhance } from "@daiso-tech/core/middleware";
 import { withPlugin } from "@daiso-tech/core/middleware";
 import { MemoryCacheAdapter } from "@daiso-tech/core/cache/memory-cache-adapter";
 import { withCachePrefix } from "@daiso-tech/core/cache/plugins";
@@ -59,7 +60,7 @@ await prefixedAdapter.add(context, "my-key", "value");
 await prefixedAdapter.get(context, "my-key"); // -> "value"
 ```
 
-### Using with Cache class
+#### Using with Cache class
 
 The plugin can be applied directly to the adapter passed to the `Cache` constructor:
 
@@ -80,7 +81,7 @@ const cache = new Cache({
 await cache.add("user:123", data);
 ```
 
-## Before/after behavior
+### Before/after behavior
 
 **Before** — Keys are stored as-is:
 
@@ -98,7 +99,7 @@ adapter.get(context, "user:123")  →  looks up key "tenant:user:123"
 For more information about the `withPlugin` function and applying plugins to adapters, see the [Middleware plugin](/docs/components/middleware#plugin) documentation.
 :::
 
-## Multiple keys — `removeMany`
+### Multiple keys — `removeMany`
 
 The `removeMany` method receives an array of keys. The plugin maps over the array, prefixing each entry:
 

--- a/website/docs/components/cache/cache_plugin.md
+++ b/website/docs/components/cache/cache_plugin.md
@@ -179,7 +179,7 @@ const cache = new Cache({
 });
 
 // TTLs passed through the Cache class will also be jittered
-await cache.add("my-key", data, { ttl: TimeSpan.fromMinutes(1) });
+await cache.add("my-key", data, TimeSpan.fromMinutes(1));
 ```
 
 ### Settings
@@ -206,8 +206,6 @@ The Cache schema plugin validates cache values against a [standard schema](https
 ### How it works
 
 The `withCacheSchema` function returns a [`PluginFn`](/docs/components/middleware) that calls `enhance` on the `add`, `put`, `update`, `get`, and `getAndRemove` methods. For write operations (`add`, `put`, `update`), the value is validated before being passed to the underlying method. For read operations (`get`, `getAndRemove`), the returned value is validated after retrieval.
-
-Validation is performed using the [`validate`](/docs/components/utilities#validate) utility, which checks the value against the provided `StandardSchemaV1` compliant schema.
 
 | Method         | When validation occurs     | Configurable                         |
 | -------------- | -------------------------- | ------------------------------------ |
@@ -311,7 +309,7 @@ For more information about the `withPlugin` function and applying plugins to ada
 
 ## withCacheWriteLock plugin
 
-The Cache write lock plugin acquires a distributed lock before executing mutating cache operations. It wraps write operations (`add`, `put`, `update`, `increment`, `getAndRemove`, `removeMany`) with a lock acquired via an [`ILockFactory`](/docs/components/lock), ensuring that concurrent writes to the same cache entry are serialised.
+The Cache write lock plugin acquires a distributed lock before executing mutating cache operations. It wraps write operations (`add`, `put`, `update`, `increment`, `getAndRemove`, `removeMany`) with a lock acquired via an [`ILockFactory`](../lock/lock_usage.md), ensuring that concurrent writes to the same cache entry are serialised.
 
 ### Use cases
 
@@ -402,5 +400,5 @@ await cache.add("my-key", data);
 
 :::info
 For more information about the `withPlugin` function and applying plugins to adapters, see the [Middleware plugin](/docs/components/middleware#plugin) documentation.
-For more information about lock factories, see the [Lock](/docs/components/lock) documentation.
+For more information about lock factories, see the [Lock](../lock/lock_usage.md) documentation.
 :::

--- a/website/docs/components/cache/cache_plugin.md
+++ b/website/docs/components/cache/cache_plugin.md
@@ -98,6 +98,10 @@ adapter.get(context, "user:123")  →  looks up key "user:123"
 adapter.get(context, "user:123")  →  looks up key "tenant:user:123"
 ```
 
+:::danger
+Because `withPlugin` uses `enhance` under the hood, the same edge case applies: if one enhanced method internally calls another enhanced method via `this`, the middleware will apply **twice**. Be mindful of inter-method calls when applying plugins that enhance multiple methods on the same instance.
+:::
+
 :::info
 For more information about the `withPlugin` function and applying plugins to adapters, see the [Middleware plugin](/docs/components/middleware#plugin) documentation.
 :::
@@ -187,6 +191,10 @@ await cache.add("my-key", data, TimeSpan.fromMinutes(1));
 | Option          | Type     | Default | Description                                                                |
 | --------------- | -------- | ------- | -------------------------------------------------------------------------- |
 | `defaultJitter` | `number` | `0.2`   | The jitter factor as a ratio of the original TTL (e.g., `0.2` means ±20 %) |
+
+:::danger
+Because `withPlugin` uses `enhance` under the hood, the same edge case applies: if one enhanced method internally calls another enhanced method via `this`, the middleware will apply **twice**. Be mindful of inter-method calls when applying plugins that enhance multiple methods on the same instance.
+:::
 
 :::info
 For more information about the `withPlugin` function and applying plugins to adapters, see the [Middleware plugin](/docs/components/middleware#plugin) documentation.
@@ -303,6 +311,10 @@ await cache.add("user:1", {
 | `schema`               | `StandardSchemaV1<T>` | _(required)_ | A standard-schema compliant schema to validate values against   |
 | `shouldValidateOutput` | `boolean`             | `true`       | Whether to validate values returned by `get` and `getAndRemove` |
 
+:::danger
+Because `withPlugin` uses `enhance` under the hood, the same edge case applies: if one enhanced method internally calls another enhanced method via `this`, the middleware will apply **twice**. Be mindful of inter-method calls when applying plugins that enhance multiple methods on the same instance.
+:::
+
 :::info
 For more information about the `withPlugin` function and applying plugins to adapters, see the [Middleware plugin](/docs/components/middleware#plugin) documentation.
 :::
@@ -397,6 +409,10 @@ await cache.add("my-key", data);
 | ------------- | ---------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------- |
 | `lockFactory` | `ILockFactory`                     | _(required)_                                                          | A factory that creates named locks                 |
 | `onlyMethods` | `Array<WithCacheWriteLockMethods>` | `["getAndRemove", "add", "put", "update", "increment", "removeMany"]` | The subset of methods to protect with a write lock |
+
+:::danger
+Because `withPlugin` uses `enhance` under the hood, the same edge case applies: if one enhanced method internally calls another enhanced method via `this`, the middleware will apply **twice**. Be mindful of inter-method calls when applying plugins that enhance multiple methods on the same instance.
+:::
 
 :::info
 For more information about the `withPlugin` function and applying plugins to adapters, see the [Middleware plugin](/docs/components/middleware#plugin) documentation.

--- a/website/docs/components/cache/cache_plugin.md
+++ b/website/docs/components/cache/cache_plugin.md
@@ -9,6 +9,9 @@ keywords:
     - Cache
     - Plugins
     - withCachePrefix
+    - withCacheJitter
+    - withCacheSchema
+    - withCacheWriteLock
 ---
 
 # Cache Plugins
@@ -107,3 +110,297 @@ The `removeMany` method receives an array of keys. The plugin maps over the arra
 adapter.removeMany(context, ["a", "b", "c"]);
 // -> adapter.removeMany(context, ["prefix:a", "prefix:b", "prefix:c"])
 ```
+
+## withCacheJitter plugin
+
+The Cache jitter plugin adds random jitter to TTL values on cache `add` and `put` operations. Applying jitter to TTLs helps prevent cache stampedes (thundering-herd problems) by staggering the expiration times of cache entries that were originally created with the same TTL.
+
+### Use cases
+
+- **Cache stampede prevention** — Stagger cache entry expiry times to avoid multiple concurrent cache refreshes
+- **Load smoothing** — Distribute cache refresh load across time rather than having it spike at predictable intervals
+- **Distributed systems** — Reduce synchronized expiration across many cache nodes or instances
+
+### How it works
+
+The `withCacheJitter` function returns a [`PluginFn`](/docs/components/middleware) that calls `enhance` on the `add` and `put` methods of the adapter. When either method is invoked, the plugin intercepts the call, applies a random jitter factor to the TTL, and forwards the modified arguments to the original method.
+
+The jitter is calculated as a random percentage of the original TTL. For example, with the default `defaultJitter` of `0.2` (20 %), a TTL of 60 seconds will be randomly adjusted to somewhere between 48 and 72 seconds.
+
+| Method | TTL argument   | Behaviour                        |
+| ------ | -------------- | -------------------------------- |
+| `add`  | Third argument | Applies random jitter to the TTL |
+| `put`  | Third argument | Applies random jitter to the TTL |
+
+Methods that do not accept a TTL are unaffected.
+
+### Usage
+
+```ts
+import { withPlugin } from "@daiso-tech/core/middleware";
+import { MemoryCacheAdapter } from "@daiso-tech/core/cache/memory-cache-adapter";
+import { withCacheJitter } from "@daiso-tech/core/cache/plugins";
+import { TimeSpan } from "@daiso-tech/core/time-span";
+
+const adapter = new MemoryCacheAdapter();
+
+// Apply the jitter plugin with default jitter factor (0.2)
+const jitteredAdapter = withPlugin(adapter, withCacheJitter());
+
+// Apply with custom jitter factor (30 %)
+const customJitterAdapter = withPlugin(
+    adapter,
+    withCacheJitter({ defaultJitter: 0.3 }),
+);
+
+// The TTL will be randomly adjusted by ±20 %
+await jitteredAdapter.add(context, "my-key", "value", TimeSpan.fromMinutes(1));
+await jitteredAdapter.put(
+    context,
+    "my-key",
+    "new-value",
+    TimeSpan.fromMinutes(5),
+);
+```
+
+#### Using with Cache class
+
+```ts
+import { Cache } from "@daiso-tech/core/cache";
+import { MemoryCacheAdapter } from "@daiso-tech/core/cache/memory-cache-adapter";
+import { withPlugin } from "@daiso-tech/core/middleware";
+import { withCacheJitter } from "@daiso-tech/core/cache/plugins";
+
+const adapter = new MemoryCacheAdapter();
+const jitteredAdapter = withPlugin(adapter, withCacheJitter());
+
+const cache = new Cache({
+    adapter: jitteredAdapter,
+});
+
+// TTLs passed through the Cache class will also be jittered
+await cache.add("my-key", data, { ttl: TimeSpan.fromMinutes(1) });
+```
+
+### Settings
+
+| Option          | Type     | Default | Description                                                                |
+| --------------- | -------- | ------- | -------------------------------------------------------------------------- |
+| `defaultJitter` | `number` | `0.2`   | The jitter factor as a ratio of the original TTL (e.g., `0.2` means ±20 %) |
+
+:::info
+For more information about the `withPlugin` function and applying plugins to adapters, see the [Middleware plugin](/docs/components/middleware#plugin) documentation.
+:::
+
+## withCacheSchema plugin
+
+The Cache schema plugin validates cache values against a [standard schema](https://github.com/standard-schema/standard-schema) before storing or retrieving them. On `add`, `put`, and `update` operations, the input value is validated against the provided schema before being stored. Optionally, `get` and `getAndRemove` outputs can also be validated on retrieval to ensure data integrity.
+
+### Use cases
+
+- **Data integrity** — Ensure only valid data conforming to a schema is stored in the cache
+- **Early error detection** — Catch malformed data at write time rather than at read time
+- **Type safety** — Enforce runtime type checks alongside compile-time types
+- **Defensive caching** — Validate data retrieved from shared or untrusted cache stores
+
+### How it works
+
+The `withCacheSchema` function returns a [`PluginFn`](/docs/components/middleware) that calls `enhance` on the `add`, `put`, `update`, `get`, and `getAndRemove` methods. For write operations (`add`, `put`, `update`), the value is validated before being passed to the underlying method. For read operations (`get`, `getAndRemove`), the returned value is validated after retrieval.
+
+Validation is performed using the [`validate`](/docs/components/utilities#validate) utility, which checks the value against the provided `StandardSchemaV1` compliant schema.
+
+| Method         | When validation occurs     | Configurable                         |
+| -------------- | -------------------------- | ------------------------------------ |
+| `add`          | Before storing the value   | Always on                            |
+| `put`          | Before storing the value   | Always on                            |
+| `update`       | Before storing the value   | Always on                            |
+| `get`          | After retrieving the value | Controlled by `shouldValidateOutput` |
+| `getAndRemove` | After retrieving the value | Controlled by `shouldValidateOutput` |
+
+### Usage
+
+```ts
+import { withPlugin } from "@daiso-tech/core/middleware";
+import { MemoryCacheAdapter } from "@daiso-tech/core/cache/memory-cache-adapter";
+import { withCacheSchema } from "@daiso-tech/core/cache/plugins";
+import { z } from "zod"; // or any StandardSchemaV1-compatible library
+
+const UserSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    email: z.string().email(),
+});
+
+const adapter = new MemoryCacheAdapter();
+
+// Apply the schema plugin
+const validatedAdapter = withPlugin(
+    adapter,
+    withCacheSchema({ schema: UserSchema }),
+);
+
+// Valid data is stored successfully
+await validatedAdapter.add(context, "user:1", {
+    id: "1",
+    name: "Alice",
+    email: "alice@example.com",
+});
+
+// Invalid data throws a validation error
+await validatedAdapter.add(context, "user:2", {
+    id: "2",
+    name: "Bob",
+    email: "not-an-email", // throws
+});
+```
+
+#### Disabling output validation
+
+```ts
+const adapter = withPlugin(
+    adapter,
+    withCacheSchema({
+        schema: UserSchema,
+        shouldValidateOutput: false, // only validate on writes
+    }),
+);
+```
+
+#### Using with Cache class
+
+```ts
+import { Cache } from "@daiso-tech/core/cache";
+import { MemoryCacheAdapter } from "@daiso-tech/core/cache/memory-cache-adapter";
+import { withPlugin } from "@daiso-tech/core/middleware";
+import { withCacheSchema } from "@daiso-tech/core/cache/plugins";
+import { z } from "zod";
+
+const UserSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    email: z.string().email(),
+});
+
+const adapter = new MemoryCacheAdapter();
+const validatedAdapter = withPlugin(
+    adapter,
+    withCacheSchema({ schema: UserSchema }),
+);
+
+const cache = new Cache({
+    adapter: validatedAdapter,
+});
+
+await cache.add("user:1", {
+    id: "1",
+    name: "Alice",
+    email: "alice@example.com",
+});
+```
+
+### Settings
+
+| Option                 | Type                  | Default      | Description                                                     |
+| ---------------------- | --------------------- | ------------ | --------------------------------------------------------------- |
+| `schema`               | `StandardSchemaV1<T>` | _(required)_ | A standard-schema compliant schema to validate values against   |
+| `shouldValidateOutput` | `boolean`             | `true`       | Whether to validate values returned by `get` and `getAndRemove` |
+
+:::info
+For more information about the `withPlugin` function and applying plugins to adapters, see the [Middleware plugin](/docs/components/middleware#plugin) documentation.
+:::
+
+## withCacheWriteLock plugin
+
+The Cache write lock plugin acquires a distributed lock before executing mutating cache operations. It wraps write operations (`add`, `put`, `update`, `increment`, `getAndRemove`, `removeMany`) with a lock acquired via an [`ILockFactory`](/docs/components/lock), ensuring that concurrent writes to the same cache entry are serialised.
+
+### Use cases
+
+- **Concurrency control** — Prevent race conditions when multiple processes write to the same cache key
+- **Distributed environments** — Coordinate writes across multiple application instances
+- **Critical sections** — Ensure exclusive access for read-modify-write operations like `increment` and `update`
+- **Batch safety** — Serialise operations on multiple keys in `removeMany`
+
+### How it works
+
+The `withCacheWriteLock` function returns a [`PluginFn`](/docs/components/middleware) that calls `enhance` on the selected mutating methods of the adapter. When an enhanced method is invoked, the plugin acquires a lock keyed by the cache key (or keys, for `removeMany`) before executing the operation. The lock is released automatically after the operation completes.
+
+The lock key is derived directly from the cache key, ensuring that concurrent writes to the same cache entry are serialised while writes to different entries can proceed in parallel.
+
+By default, all mutating methods are protected:
+
+| Method         | Lock key source | Behaviour                                     |
+| -------------- | --------------- | --------------------------------------------- |
+| `add`          | Single key      | Acquires lock for the key before adding       |
+| `put`          | Single key      | Acquires lock for the key before putting      |
+| `update`       | Single key      | Acquires lock for the key before updating     |
+| `increment`    | Single key      | Acquires lock for the key before incrementing |
+| `getAndRemove` | Single key      | Acquires lock for the key before removing     |
+| `removeMany`   | Multiple keys   | Acquires locks for each key sequentially      |
+
+Read-only methods (`get`, `removeAll`, `removeByKeyPrefix`) are unaffected.
+
+### Usage
+
+```ts
+import { withPlugin } from "@daiso-tech/core/middleware";
+import { MemoryCacheAdapter } from "@daiso-tech/core/cache/memory-cache-adapter";
+import { withCacheWriteLock } from "@daiso-tech/core/cache/plugins";
+import { MemoryLockFactory } from "@daiso-tech/core/lock/memory-lock-factory";
+
+const adapter = new MemoryCacheAdapter();
+const lockFactory = new MemoryLockFactory();
+
+// Apply the write lock plugin
+const lockedAdapter = withPlugin(adapter, withCacheWriteLock({ lockFactory }));
+
+// Concurrent writes to the same key are serialised
+await Promise.all([
+    lockedAdapter.add(context, "my-key", "value1"),
+    lockedAdapter.add(context, "my-key", "value2"),
+]);
+```
+
+#### Restricting protected methods
+
+```ts
+const adapter = withPlugin(
+    adapter,
+    withCacheWriteLock({
+        lockFactory,
+        onlyMethods: ["add", "put", "update"], // only protect these methods
+    }),
+);
+```
+
+#### Using with Cache class
+
+```ts
+import { Cache } from "@daiso-tech/core/cache";
+import { MemoryCacheAdapter } from "@daiso-tech/core/cache/memory-cache-adapter";
+import { withPlugin } from "@daiso-tech/core/middleware";
+import { withCacheWriteLock } from "@daiso-tech/core/cache/plugins";
+import { MemoryLockFactory } from "@daiso-tech/core/lock/memory-lock-factory";
+
+const adapter = new MemoryCacheAdapter();
+const lockFactory = new MemoryLockFactory();
+const lockedAdapter = withPlugin(adapter, withCacheWriteLock({ lockFactory }));
+
+const cache = new Cache({
+    adapter: lockedAdapter,
+});
+
+// Mutating operations through `cache` will acquire locks
+await cache.add("my-key", data);
+```
+
+### Settings
+
+| Option        | Type                               | Default                                                               | Description                                        |
+| ------------- | ---------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------- |
+| `lockFactory` | `ILockFactory`                     | _(required)_                                                          | A factory that creates named locks                 |
+| `onlyMethods` | `Array<WithCacheWriteLockMethods>` | `["getAndRemove", "add", "put", "update", "increment", "removeMany"]` | The subset of methods to protect with a write lock |
+
+:::info
+For more information about the `withPlugin` function and applying plugins to adapters, see the [Middleware plugin](/docs/components/middleware#plugin) documentation.
+For more information about lock factories, see the [Lock](/docs/components/lock) documentation.
+:::

--- a/website/docs/components/cache/cache_resolver.md
+++ b/website/docs/components/cache/cache_resolver.md
@@ -25,6 +25,7 @@ import { RedisCacheAdapter } from "@daiso-tech/core/cache/redis-cache-adapter";
 import { Serde } from "@daiso-tech/core/serde";
 import type { ISerde } from "@daiso-tech/core/serde/contracts";
 import { SuperJsonSerdeAdapter } from "@daiso-tech/core/serde/super-json-serde-adapter";
+import { TimeSpan } from "@daiso-tech/core/time-span";
 import Redis from "ioredis";
 
 const serde = new Serde(new SuperJsonSerdeAdapter());
@@ -71,24 +72,26 @@ Note that if you specify a non-existent adapter, an error will be thrown.
 
 ### 3. Overriding default settings
 
-```ts
-import { z } from "zod";
+The `CacheResolver` provides chainable methods to override the base configuration per-use:
 
+```ts
 await cacheResolver
-    .setNamespace(new Namespace("@my-namespace"))
-    // You can overide the cache value type by calling setType or setSchema method again
-    .setType<string>()
-    .setSchema(
-        z.object({
-            name: z.string(),
-            age: z.number(),
-        }),
-    )
+    .setDefaultTtl(TimeSpan.fromMinutes(5))
+    .setExecutionContext(context)
     .use("redis")
     .add("user/jose@gmail.com", {
         name: "Jose",
         age: 20,
     });
+```
+
+You can also change the type parameter for compile-time type safety:
+
+```ts
+await cacheResolver
+    .setType<string>()
+    .use("redis")
+    .add("user/jose@gmail.com", "some-string-value");
 ```
 
 :::info

--- a/website/docs/components/cache/cache_usage.md
+++ b/website/docs/components/cache/cache_usage.md
@@ -342,13 +342,10 @@ const cache = new Cache({
 });
 
 // The lock is automatically acquired for mutating operations
-const value = await cache.getOrAdd(
-    "user:1",
-    async () => {
-        // This expensive computation runs only once even under concurrent requests
-        return await fetchUserFromDatabase(1);
-    },
-);
+const value = await cache.getOrAdd("user:1", async () => {
+    // This expensive computation runs only once even under concurrent requests
+    return await fetchUserFromDatabase(1);
+});
 ```
 
 :::info

--- a/website/docs/components/cache/cache_usage.md
+++ b/website/docs/components/cache/cache_usage.md
@@ -46,7 +46,7 @@ Here is a complete list of settings for the [`Cache`](https://daiso-tech.github.
 You can add a key with a optional TTL to overide the default:
 
 ```ts
-await cache.add("a", "value", { ttl: TimeSpan.fromSeconds("1") });
+await cache.add("a", "value", TimeSpan.fromSeconds(1));
 ```
 
 The method returns true if the key does not exists.
@@ -97,7 +97,7 @@ You can perform an upsert that replaces the ttl when updated. True will be retur
 
 ```ts
 await cache.put("a", 2);
-await cache.put("a", 4, { ttl: TimeSpan.fromSeconds(3) });
+await cache.put("a", 4, TimeSpan.fromSeconds(3));
 ```
 
 ### Removing keys
@@ -206,11 +206,13 @@ const productCache = new Cache<IProduct>({
 
 ### Runtime type safety
 
-You can enforce runtime and compiletime type safety by passing [standard schema](https://standardschema.dev/) to the cache:
+You can enforce runtime and compiletime type safety by applying the [`withCacheSchema`](cache_plugin.md#withcacheschema-plugin) plugin to the adapter:
 
 ```ts
+import { withPlugin } from "@daiso-tech/core/middleware";
 import { MemoryCacheAdapter } from "@daiso-tech/core/cache/memory-cache-adapter";
 import { Cache } from "@daiso-tech/core/cache";
+import { withCacheSchema } from "@daiso-tech/core/cache/plugins";
 import { z } from "zod";
 
 const userSchema = z.object({
@@ -219,10 +221,14 @@ const userSchema = z.object({
     age: z.number(),
 });
 
-// The type will be infered
+const adapter = withPlugin(
+    new MemoryCacheAdapter(),
+    withCacheSchema({ schema: userSchema }),
+);
+
+// The type will be infered from the schema
 const cache = new Cache({
-    adapter: new MemoryCacheAdapter(),
-    schema: userSchema,
+    adapter,
 });
 
 // A typescript and runtime error will occur because the type is not matching.
@@ -253,7 +259,7 @@ await cache.getOrAdd("ab", 1);
 You can provide synchronous or asynchronous [`Invokable<[], TValue | Promise<TValue>>`](../../utilities/invokable.md) as default values for both `getOr` and `getOrAdd` methods.
 :::
 
-You can retrieve the key and afterwards remove it and will return true if the value was found:
+You can retrieve the key and afterwards remove it:
 
 ```ts
 await cache.getAndRemove("ab");
@@ -293,57 +299,60 @@ await cache.removeOrFail("ab");
 
 TTL jitter adds a small random offset to expiration times, which resolves the [cache stampede](https://en.wikipedia.org/wiki/Cache_stampede). When many cache keys expire at the same time, every client simultaneously misses the cache and floods the data source with requests. By spreading out expiration times, jitter ensures cache misses are staggered, distributing the load on your data source evenly over time.
 
+Apply the [`withCacheJitter`](cache_plugin.md#withcachejitter-plugin) plugin to the adapter:
+
 ```ts
-await cache.add("a", 1, {
-    ttl: TimeSpan.fromMinutes(1),
-    jitter: 0.2,
+import { withPlugin } from "@daiso-tech/core/middleware";
+import { MemoryCacheAdapter } from "@daiso-tech/core/cache/memory-cache-adapter";
+import { Cache } from "@daiso-tech/core/cache";
+import { withCacheJitter } from "@daiso-tech/core/cache/plugins";
+
+const adapter = withPlugin(new MemoryCacheAdapter(), withCacheJitter());
+
+const cache = new Cache({
+    adapter,
 });
+
+await cache.add("a", 1, TimeSpan.fromMinutes(1));
 ```
 
 :::info
-You can enable jitter in the following methods: `addOrFail`, `put` and `getOrAdd`.
+For more information about jitter configuration, see the [`withCacheJitter`](cache_plugin.md#withcachejitter-plugin) plugin documentation.
 :::
 
 ### Cache locking
 
-The `getOrAdd` method supports distributed locking via the `enableLocking` setting. When multiple clients simultaneously request a key that is missing, without locking they all compute the value and write it to the cache — this is known as a [cache stampede](https://en.wikipedia.org/wiki/Cache_stampede). Enabling locking ensures that only one client computes and stores the value while the others wait and then read the cached result.
-
-To use locking, pass a `lockFactory` to the `Cache` constructor:
+The `getOrAdd` method supports distributed locking to prevent cache stampedes. When multiple clients simultaneously request a key that is missing, without locking they all compute the value and write it to the cache. Apply the [`withCacheWriteLock`](cache_plugin.md#withcachewritelock-plugin) plugin to the adapter to ensure that only one client computes and stores the value while the others wait and then read the cached result.
 
 ```ts
-import { Cache } from "@daiso-tech/core/cache";
+import { withPlugin } from "@daiso-tech/core/middleware";
 import { MemoryCacheAdapter } from "@daiso-tech/core/cache/memory-cache-adapter";
-import { RedisLockAdapter } from "@daiso-tech/core/lock/redis-lock-adapter";
-import Redis from "ioredis";
+import { Cache } from "@daiso-tech/core/cache";
+import { withCacheWriteLock } from "@daiso-tech/core/cache/plugins";
+import { MemoryLockFactory } from "@daiso-tech/core/lock/memory-lock-factory";
+
+const lockFactory = new MemoryLockFactory();
+const adapter = withPlugin(
+    new MemoryCacheAdapter(),
+    withCacheWriteLock({ lockFactory }),
+);
 
 const cache = new Cache({
-    adapter: new MemoryCacheAdapter(),
-    lockFactory: new RedisLockAdapter(
-        new Redis("YOUR_REDIS_CONNECTION_STRING"),
-    ),
+    adapter,
 });
-```
 
-Then pass `enableLocking: true` to `getOrAdd`:
-
-```ts
+// The lock is automatically acquired for mutating operations
 const value = await cache.getOrAdd(
     "user:1",
     async () => {
         // This expensive computation runs only once even under concurrent requests
         return await fetchUserFromDatabase(1);
     },
-    { enableLocking: true },
 );
 ```
 
 :::info
-You can pass `ILockFactoryBase`, `ILockAdapter`, and `IDatabaseLockAdapter` to `lockFactory` setting.
-For further information about `LockFactory` refer to the [`@daiso-tech/core/lock`](../lock/lock_usage.md) documentation.
-:::
-
-:::warning
-The `lockFactory` defaults to a `NoOpLockAdapter` implementation, so `enableLocking: true` has no effect unless you provide a real lock adapter.
+For further information about lock factories, refer to the [`@daiso-tech/core/lock`](../lock/lock_usage.md) documentation and the [`withCacheWriteLock`](cache_plugin.md#withcachewritelock-plugin) plugin documentation.
 :::
 
 ### Separating cache reading from manipulation
@@ -359,7 +368,7 @@ This separation makes it easy to visually distinguish the two contracts, making 
 ```ts
 import type { ICache, IReadableCache } from "@daiso-tech/core/cache/contracts";
 import { Cache } from "@daiso-tech/core/cache";
-import { MemoryCacheAdapter } from "@daiso-tech/core/cache/adapter/memory-cache-adapter";
+import { MemoryCacheAdapter } from "@daiso-tech/core/cache/memory-cache-adapter";
 
 async function readingFunc(cache: IReadableCache): Promise<void> {
     // You cannot access write methods like put, add and update

--- a/website/docs/components/cache/creating_cache_adapters.md
+++ b/website/docs/components/cache/creating_cache_adapters.md
@@ -66,7 +66,7 @@ import { MyDatabaseCacheAdapter } from "./MyDatabaseCacheAdapter.js";
 describe("class: MyDatabaseCacheAdapter", () => {
     databaseCacheAdapterTestSuite({
         createAdapter: async () => {
-            return new MyDatabaseCacheAdapter(),
+            return new MyDatabaseCacheAdapter();
         },
         test,
         beforeEach,
@@ -82,10 +82,10 @@ In some cases, you may need to implement a custom [`Cache`](https://daiso-tech.g
 
 ## Testing your custom ICache class
 
-We provide a complete test suite to verify your custom event-bus class implementation. Simply use the [`cacheTestSuite`](https://daiso-tech.github.io/daiso-core/functions/Cache.cacheTestSuite.html) function:
+We provide a complete test suite to verify your custom cache class implementation. Simply use the [`cacheTestSuite`](https://daiso-tech.github.io/daiso-core/functions/Cache.cacheTestSuite.html) function:
 
 - Preconfigured Vitest test cases
-- Standardized event-bus behavior validation
+- Standardized cache behavior validation
 - Common edge case coverage
 
 Usage example:

--- a/website/docs/components/circuit_breaker/circuit_breaker_plugin.md
+++ b/website/docs/components/circuit_breaker/circuit_breaker_plugin.md
@@ -95,6 +95,10 @@ adapter.getState(context, "api:users")  →  looks up circuit "api:users"
 adapter.getState(context, "api:users")  →  looks up circuit "env:api:users"
 ```
 
+:::danger
+Because `withPlugin` uses `enhance` under the hood, the same edge case applies: if one enhanced method internally calls another enhanced method via `this`, the middleware will apply **twice**. Be mindful of inter-method calls when applying plugins that enhance multiple methods on the same instance.
+:::
+
 :::info
 For more information about the `withPlugin` function and applying plugins to adapters, see the [Middleware plugin](/docs/components/middleware#plugin) documentation.
 :::

--- a/website/docs/components/circuit_breaker/circuit_breaker_plugin.md
+++ b/website/docs/components/circuit_breaker/circuit_breaker_plugin.md
@@ -11,18 +11,20 @@ keywords:
     - withCircuitBreakerPrefix
 ---
 
-# CircuitBreaker plugin
+# CircuitBreaker Plugins
+
+## withCircuitBreakerPrefix plugin
 
 The CircuitBreaker prefix plugin intercepts calls to a circuit-breaker adapter and transparently prefixes all circuit keys with a configurable string. This enables logical key namespacing without modifying the adapter implementation.
 
-## Use cases
+### Use cases
 
 - **Multi-tenant systems** — Prefix circuit keys with a tenant identifier to isolate circuit state between tenants
 - **Service versioning** — Separate circuit state for different API versions
 - **Environment isolation** — Keep development, staging, and production circuit state separate
 - **Region scoping** — Prefix keys with a region identifier in multi-region deployments
 
-## How it works
+### How it works
 
 The `withCircuitBreakerPrefix` function returns a [`PluginFn`](/docs/components/middleware) that calls `enhance` on each adapter method that accepts a circuit key. When an enhanced method is invoked, the plugin intercepts the call, prepends the configured prefix to the key argument, and forwards the modified arguments to the original method.
 
@@ -39,10 +41,9 @@ The plugin prefixes keys for the following methods:
 
 Every method on the `ICircuitBreakerAdapter` that operates on a specific circuit key is prefixed.
 
-## Usage
+### Usage
 
 ```ts
-import { enhance } from "@daiso-tech/core/middleware";
 import { withPlugin } from "@daiso-tech/core/middleware";
 import { MemoryCircuitBreakerStorageAdapter } from "@daiso-tech/core/circuit-breaker/memory-circuit-breaker-storage-adapter";
 import { DatabaseCircuitBreakerAdapter } from "@daiso-tech/core/circuit-breaker/database-circuit-breaker-adapter";
@@ -62,7 +63,7 @@ const prefixedAdapter = withPlugin(
 const state = await prefixedAdapter.getState(context, "api:users");
 ```
 
-### Using with CircuitBreakerFactory
+#### Using with CircuitBreakerFactory
 
 The plugin can be applied directly to the adapter passed to the `CircuitBreakerFactory` constructor:
 
@@ -80,7 +81,7 @@ const factory = new CircuitBreakerFactory({
 });
 ```
 
-## Before/after behavior
+### Before/after behavior
 
 **Before** — Circuit keys are used as-is:
 

--- a/website/docs/components/collection.mdx
+++ b/website/docs/components/collection.mdx
@@ -333,6 +333,7 @@ For the remaining of the documentation, we'll discuss each method available on t
         <ol><a href="#flatmap">flatMap</a></ol>
         <ol><a href="#foreach">forEach</a></ol>
         <ol><a href="#get">get</a></ol>
+        <ol><a href="#getor">getOr</a></ol>
         <ol><a href="#getorfail">getOrFail</a></ol>
         <ol><a href="#groupby">groupBy</a></ol>
     </li>
@@ -791,6 +792,18 @@ import { ListCollection } from "@daiso-tech/core/collection";
 const collection = new ListCollection([1, 4, 2, 8, -2]);
 collection.get(2); // 2
 collection.get(5); // null
+```
+
+### getOr
+
+The `getOr` method returns the item by index. If the item is not found, a default value will be returned.
+
+```ts
+import { ListCollection } from "@daiso-tech/core/collection";
+
+const collection = new ListCollection([1, 4, 2, 8, -2]);
+collection.getOr(2, -1); // 2
+collection.getOr(5, -1); // -1
 ```
 
 ### getOrFail

--- a/website/docs/components/file_storage/file_storage_plugin.md
+++ b/website/docs/components/file_storage/file_storage_plugin.md
@@ -11,18 +11,20 @@ keywords:
     - withFileStoragePrefix
 ---
 
-# FileStorage plugin
+# FileStorage Plugins
+
+## withFileStoragePrefix plugin
 
 The FileStorage prefix plugin intercepts calls to a file-storage adapter and transparently prefixes all file keys with a configurable string. This enables logical key namespacing without modifying the adapter implementation.
 
-## Use cases
+### Use cases
 
 - **Multi-tenant storage** — Prefix file keys with a tenant identifier to isolate files between tenants
 - **Environment isolation** — Separate development, staging, and production file storage
 - **Directory scoping** — Organize files into virtual directories by prepending a path prefix
 - **Bucket consolidation** — Use a single storage bucket/container with namespaced keys instead of multiple buckets
 
-## How it works
+### How it works
 
 The `withFileStoragePrefix` function returns a [`PluginFn`](/docs/components/middleware) that calls `enhance` on each adapter method that accepts a file key. When an enhanced method is invoked, the plugin intercepts the call, prepends the configured prefix to the key argument, and forwards the modified arguments to the original method.
 
@@ -50,11 +52,11 @@ The plugin prefixes keys for the following methods:
 | `removeMany`           | Second argument (`keys`)   | `keys.map(k => prefix + k)` |
 | `removeByPrefix`       | Second argument (`key`)    | `prefix + key`              |
 
-### Copy and move behavior
+#### Copy and move behavior
 
 For the `copy`, `copyAndReplace`, `move`, and `moveAndReplace` methods, only the **source** key (the first string argument after context) is prefixed. The destination key is passed through unchanged. This allows copying/moving files to an un-prefixed location.
 
-## Usage
+### Usage
 
 ```ts
 import { withPlugin } from "@daiso-tech/core/middleware";
@@ -77,7 +79,7 @@ await prefixedAdapter.copy(context, "avatars/user1.png", "backups/user1.png");
 // -> adapter.copy(context, "tenant-42/avatars/user1.png", "backups/user1.png")
 ```
 
-## Before/after behavior
+### Before/after behavior
 
 **Before** — File keys are used as-is:
 
@@ -97,7 +99,7 @@ adapter.getBytes(context, "uploads/report.pdf")
 For more information about the `withPlugin` function and applying plugins to adapters, see the [Middleware plugin](/docs/components/middleware#plugin) documentation.
 :::
 
-## Multiple keys — `removeMany`
+### Multiple keys — `removeMany`
 
 The `removeMany` method receives an array of keys. The plugin maps over the array, prefixing each entry:
 

--- a/website/docs/components/file_storage/file_storage_plugin.md
+++ b/website/docs/components/file_storage/file_storage_plugin.md
@@ -95,6 +95,10 @@ adapter.getBytes(context, "uploads/report.pdf")
 → retrieves "prod/uploads/report.pdf"
 ```
 
+:::danger
+Because `withPlugin` uses `enhance` under the hood, the same edge case applies: if one enhanced method internally calls another enhanced method via `this`, the middleware will apply **twice**. Be mindful of inter-method calls when applying plugins that enhance multiple methods on the same instance.
+:::
+
 :::info
 For more information about the `withPlugin` function and applying plugins to adapters, see the [Middleware plugin](/docs/components/middleware#plugin) documentation.
 :::

--- a/website/docs/components/lock/lock_plugin.md
+++ b/website/docs/components/lock/lock_plugin.md
@@ -97,6 +97,10 @@ adapter.acquire(context, "resource:42", "lock-id", ttl)
 → acquires lock on "prod:resource:42"
 ```
 
+:::danger
+Because `withPlugin` uses `enhance` under the hood, the same edge case applies: if one enhanced method internally calls another enhanced method via `this`, the middleware will apply **twice**. Be mindful of inter-method calls when applying plugins that enhance multiple methods on the same instance.
+:::
+
 :::info
 For more information about the `withPlugin` function and applying plugins to adapters, see the [Middleware plugin](/docs/components/middleware#plugin) documentation.
 :::

--- a/website/docs/components/lock/lock_plugin.md
+++ b/website/docs/components/lock/lock_plugin.md
@@ -11,18 +11,20 @@ keywords:
     - withLockPrefix
 ---
 
-# Lock plugin
+# Lock Plugins
+
+## withLockPrefix plugin
 
 The Lock prefix plugin intercepts calls to a lock adapter and transparently prefixes all lock keys with a configurable string. This enables logical key namespacing without modifying the adapter implementation.
 
-## Use cases
+### Use cases
 
 - **Multi-tenant locking** — Prefix lock keys with a tenant identifier to prevent cross-tenant lock contention
 - **Resource scoping** — Organize locks by resource type or module to avoid key collisions
 - **Environment isolation** — Separate development, staging, and production lock state
 - **Region isolation** — Prefix lock keys with a region identifier in multi-region deployments
 
-## How it works
+### How it works
 
 The `withLockPrefix` function returns a [`PluginFn`](/docs/components/middleware) that calls `enhance` on each adapter method that accepts a lock key. When an enhanced method is invoked, the plugin intercepts the call, prepends the configured prefix to the key argument, and forwards the modified arguments to the original method.
 
@@ -38,7 +40,7 @@ The plugin prefixes keys for the following methods:
 
 Every method on the `ILockAdapter` that operates on a specific lock key is prefixed.
 
-## Usage
+### Usage
 
 ```ts
 import { withPlugin } from "@daiso-tech/core/middleware";
@@ -59,7 +61,7 @@ const acquired = await prefixedAdapter.acquire(
 );
 ```
 
-### Using with LockFactory
+#### Using with LockFactory
 
 The plugin can be applied directly to the adapter passed to the `LockFactory` constructor:
 
@@ -79,7 +81,7 @@ const lockFactory = new LockFactory({
 // All locks acquired through lockFactory will use "worker:..." keys
 ```
 
-## Before/after behavior
+### Before/after behavior
 
 **Before** — Lock keys are used as-is:
 

--- a/website/docs/components/middleware.md
+++ b/website/docs/components/middleware.md
@@ -364,7 +364,7 @@ alice.say("Hello!");
 
 This pattern is useful for adding cross-cutting concerns (logging, validation, authorization, etc.) to class methods in a reusable and declarative way.
 
-### Applying Plugins with `withPlugin`
+### Applying Plugins with `withPlugin` {#plugin}
 
 The `withPlugin` function provides a way to apply one or more plugins to a class instance or object literal, where each plugin can use the `enhance` function to wrap methods with middleware. This is useful for encapsulating cross-cutting concerns into reusable plugin units.
 

--- a/website/docs/components/middleware.md
+++ b/website/docs/components/middleware.md
@@ -362,6 +362,10 @@ alice.say("Hello!");
 - If the target property is not a function, a `TypeError` is thrown.
 - Multiple middlewares can be provided (as an array or single value).
 
+:::danger
+Because `enhance` mutates the object **in-place**, when one enhanced method internally calls another enhanced method via `this`, the internal call goes through the already-enhanced wrapper again, causing the middleware to apply **twice**. Be mindful of inter-method calls when using `enhance` on multiple methods of the same instance.
+:::
+
 This pattern is useful for adding cross-cutting concerns (logging, validation, authorization, etc.) to class methods in a reusable and declarative way.
 
 ### Applying Plugins with `withPlugin` {#plugin}
@@ -508,6 +512,10 @@ const enhancedService = withPlugin(service, new MetricsPlugin(client));
 - Each plugin is invoked in order, receiving the copied target and the `enhance` function.
 - The `enhance` function wraps the specified method with a middleware pipeline in-place on the copy.
 - The enhanced copy is returned, leaving the original untouched.
+
+:::danger
+Because `withPlugin` uses `enhance` under the hood, the same edge case applies: if one enhanced method internally calls another enhanced method via `this`, the middleware will apply **twice**. Be mindful of inter-method calls when applying plugins that enhance multiple methods on the same instance.
+:::
 
 :::info
 This pattern is ideal for building reusable feature packs (logging, monitoring) that can be composed and applied to any class instance or object literal.

--- a/website/docs/components/rate-limiter/rate_limiter_plugin.md
+++ b/website/docs/components/rate-limiter/rate_limiter_plugin.md
@@ -94,6 +94,10 @@ adapter.getState(context, "api:login")
 → checks rate limit for "tenant-42:api:login"
 ```
 
+:::danger
+Because `withPlugin` uses `enhance` under the hood, the same edge case applies: if one enhanced method internally calls another enhanced method via `this`, the middleware will apply **twice**. Be mindful of inter-method calls when applying plugins that enhance multiple methods on the same instance.
+:::
+
 :::info
 For more information about the `withPlugin` function and applying plugins to adapters, see the [Middleware plugin](/docs/components/middleware#plugin) documentation.
 :::

--- a/website/docs/components/rate-limiter/rate_limiter_plugin.md
+++ b/website/docs/components/rate-limiter/rate_limiter_plugin.md
@@ -11,18 +11,20 @@ keywords:
     - withRateLimiterPrefix
 ---
 
-# RateLimiter plugin
+# RateLimiter Plugins
+
+## withRateLimiterPrefix plugin
 
 The RateLimiter prefix plugin intercepts calls to a rate-limiter adapter and transparently prefixes all rate-limiter keys with a configurable string. This enables logical key namespacing without modifying the adapter implementation.
 
-## Use cases
+### Use cases
 
 - **Multi-tenant rate limiting** — Prefix rate-limiter keys with a tenant identifier to apply separate rate limits per tenant
 - **Endpoint scoping** — Organize rate limits by API endpoint or route prefix
 - **Environment isolation** — Separate development, staging, and production rate limit state
 - **User tier differentiation** — Prefix keys with a tier identifier (e.g., "free:", "premium:") to apply different rate limits
 
-## How it works
+### How it works
 
 The `withRateLimiterPrefix` function returns a [`PluginFn`](/docs/components/middleware) that calls `enhance` on each adapter method that accepts a rate-limiter key. When an enhanced method is invoked, the plugin intercepts the call, prepends the configured prefix to the key argument, and forwards the modified arguments to the original method.
 
@@ -36,7 +38,7 @@ The plugin prefixes keys for the following methods:
 
 Every method on the `IRateLimiterAdapter` that operates on a specific rate-limiter key is prefixed.
 
-## Usage
+### Usage
 
 ```ts
 import { withPlugin } from "@daiso-tech/core/middleware";
@@ -58,7 +60,7 @@ const prefixedAdapter = withPlugin(
 const state = await prefixedAdapter.getState(context, "api:login");
 ```
 
-### Using with RateLimiterFactory
+#### Using with RateLimiterFactory
 
 The plugin can be applied directly to the adapter passed to the `RateLimiterFactory` constructor:
 
@@ -76,7 +78,7 @@ const factory = new RateLimiterFactory({
 });
 ```
 
-## Before/after behavior
+### Before/after behavior
 
 **Before** — Rate-limiter keys are used as-is:
 

--- a/website/docs/components/semaphore/semaphore_plugin.md
+++ b/website/docs/components/semaphore/semaphore_plugin.md
@@ -11,18 +11,20 @@ keywords:
     - withSemaphorePrefix
 ---
 
-# Semaphore plugin
+# Semaphore Plugins
+
+## withSemaphorePrefix plugin
 
 The Semaphore prefix plugin intercepts calls to a semaphore adapter and transparently prefixes all semaphore keys with a configurable string. This enables logical key namespacing without modifying the adapter implementation.
 
-## Use cases
+### Use cases
 
 - **Multi-tenant semaphores** — Prefix semaphore keys with a tenant identifier to isolate concurrency limits between tenants
 - **Resource scoping** — Organize semaphores by resource type to avoid key collisions
 - **Environment isolation** — Separate development, staging, and production semaphore state
 - **Pool differentiation** — Prefix keys with a pool name to manage independent semaphore pools
 
-## How it works
+### How it works
 
 The `withSemaphorePrefix` function returns a [`PluginFn`](/docs/components/middleware) that calls `enhance` on each adapter method that accepts a semaphore key. When an enhanced method is invoked, the plugin intercepts the call, prepends the configured prefix to the key argument, and forwards the modified arguments to the original method.
 
@@ -36,7 +38,7 @@ The plugin prefixes keys for the following methods:
 | `refresh`         | Second argument (`key`)      | `prefix + key` |
 | `release`         | Second argument (`key`)      | `prefix + key` |
 
-### Special handling for `acquire`
+#### Special handling for `acquire`
 
 The `acquire` method accepts a single settings object rather than positional arguments. The plugin destructures the settings object, prefixes the `key` field, and reconstructs the object with all other fields preserved:
 
@@ -48,7 +50,7 @@ adapter.acquire({ context, key: "my-key", slotId: "s1", limit: 5, ttl });
 adapter.acquire({ context, key: "prefix:my-key", slotId: "s1", limit: 5, ttl });
 ```
 
-## Usage
+### Usage
 
 ```ts
 import { withPlugin } from "@daiso-tech/core/middleware";
@@ -70,7 +72,7 @@ const acquired = await prefixedAdapter.acquire({
 });
 ```
 
-### Using with SemaphoreFactory
+#### Using with SemaphoreFactory
 
 The plugin can be applied directly to the adapter passed to the `SemaphoreFactory` constructor:
 
@@ -88,7 +90,7 @@ const factory = new SemaphoreFactory({
 });
 ```
 
-## Before/after behavior
+### Before/after behavior
 
 **Before** — Semaphore keys are used as-is:
 

--- a/website/docs/components/semaphore/semaphore_plugin.md
+++ b/website/docs/components/semaphore/semaphore_plugin.md
@@ -106,6 +106,10 @@ adapter.acquire({ context, key: "connections", ... })
 → acquires slot on "pool-1:connections"
 ```
 
+:::danger
+Because `withPlugin` uses `enhance` under the hood, the same edge case applies: if one enhanced method internally calls another enhanced method via `this`, the middleware will apply **twice**. Be mindful of inter-method calls when applying plugins that enhance multiple methods on the same instance.
+:::
+
 :::info
 For more information about the `withPlugin` function and applying plugins to adapters, see the [Middleware plugin](/docs/components/middleware#plugin) documentation.
 :::

--- a/website/docs/components/shared_lock/shared_lock_plugin.md
+++ b/website/docs/components/shared_lock/shared_lock_plugin.md
@@ -11,18 +11,20 @@ keywords:
     - withSharedLockPrefix
 ---
 
-# SharedLock plugin
+# SharedLock Plugins
+
+## withSharedLockPrefix plugin
 
 The SharedLock prefix plugin intercepts calls to a shared-lock adapter and transparently prefixes all lock keys with a configurable string. This enables logical key namespacing without modifying the adapter implementation.
 
-## Use cases
+### Use cases
 
 - **Multi-tenant reader-writer locks** — Prefix lock keys with a tenant identifier to isolate shared lock state between tenants
 - **Resource scoping** — Organize shared locks by resource type or module
 - **Environment isolation** — Separate development, staging, and production shared lock state
 - **Read/write path scoping** — Apply consistent namespacing to both reader and writer lock operations
 
-## How it works
+### How it works
 
 The `withSharedLockPrefix` function returns a [`PluginFn`](/docs/components/middleware) that calls `enhance` on each adapter method that accepts a shared-lock key. When an enhanced method is invoked, the plugin intercepts the call, prepends the configured prefix to the key argument, and forwards the modified arguments to the original method.
 
@@ -40,11 +42,11 @@ The plugin prefixes keys for the following methods:
 | `forceReleaseAllReaders` | Second argument (`key`)      | `prefix + key` |
 | `refreshReader`          | Second argument (`key`)      | `prefix + key` |
 
-### Writer methods
+#### Writer methods
 
 All writer-related methods (`acquireWriter`, `forceReleaseWriter`, `refreshWriter`, `releaseWriter`) receive the key as a positional argument (second parameter). The plugin prefixes this key directly.
 
-### Reader methods
+#### Reader methods
 
 Reader methods that accept a key as a positional argument (`forceReleaseAllReaders`, `refreshReader`) have their key prefixed directly. The `acquireReader` method accepts a single settings object — the plugin destructures it, prefixes the `key` field, and reconstructs the object:
 
@@ -62,7 +64,7 @@ adapter.acquireReader({
 });
 ```
 
-## Usage
+### Usage
 
 ```ts
 import { withPlugin } from "@daiso-tech/core/middleware";
@@ -87,7 +89,7 @@ await prefixedAdapter.acquireReader({
 });
 ```
 
-### Using with SharedLockFactory
+#### Using with SharedLockFactory
 
 The plugin can be applied directly to the adapter passed to the `SharedLockFactory` constructor:
 
@@ -105,7 +107,7 @@ const factory = new SharedLockFactory({
 });
 ```
 
-## Before/after behavior
+### Before/after behavior
 
 **Before** — Shared lock keys are used as-is:
 

--- a/website/docs/components/shared_lock/shared_lock_plugin.md
+++ b/website/docs/components/shared_lock/shared_lock_plugin.md
@@ -123,6 +123,10 @@ adapter.acquireWriter(context, "doc:42", "writer-1", ttl)
 → acquires writer lock on "tenant:doc:42"
 ```
 
+:::danger
+Because `withPlugin` uses `enhance` under the hood, the same edge case applies: if one enhanced method internally calls another enhanced method via `this`, the middleware will apply **twice**. Be mindful of inter-method calls when applying plugins that enhance multiple methods on the same instance.
+:::
+
 :::info
 For more information about the `withPlugin` function and applying plugins to adapters, see the [Middleware plugin](/docs/components/middleware#plugin) documentation.
 :::


### PR DESCRIPTION
- **Fixed imports and added changeset file**
- **refactor(cache): remove CacheWriteSettings and GetOrAddSettings types**
- **refactor(cache): extract schema, jitter, and lock factory to plugins**
- **refactor(cache): replace CacheWriteSettings with inline ttl in withCacheFactory**
- **feat(cache): add withCacheJitter plugin**
- **feat(cache): add withCacheSchema plugin**
- **feat(cache): add withCacheWriteLock plugin**
- **feat(cache): register new plugins in barrel exports**
- **docs(changeset): update formatting for with-prefix-plugins changeset**
- **fix(cache): add trailing comma to getOrAdd method signature**
- **test(circuit-breaker): restructure withCircuitBreakerPrefix tests**
- **test(lock): restructure withLockPrefix tests**
- **test(semaphore): restructure withSemaphorePrefix tests**
- **test(shared-lock): restructure withSharedLockPrefix tests**
- **test(rate-limiter): restructure withRateLimiterPrefix tests**
- **test(file-storage): restructure withFileStoragePrefix tests**
- **docs(cache): add JSDoc documentation to cache plugins**
- **docs(circuit-breaker): add JSDoc to withCircuitBreakerPrefix plugin**
- **docs(file-storage): add JSDoc to withFileStoragePrefix plugin**
- **docs(lock): add JSDoc to withLockPrefix plugin**
- **docs(rate-limiter): add JSDoc to plugin and middleware**
- **docs(semaphore): add JSDoc to withSemaphorePrefix plugin**
- **docs(shared-lock): add JSDoc to withSharedLockPrefix plugin**
- **docs(plugins): restructure headings and remove obsolete enhance imports**
- **docs(cache): add documentation for withCacheJitter, withCacheSchema, and withCacheWriteLock plugins**
- **docs: add cache-plugins changeset documenting the composable plugin architecture**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added composable cache plugins for TTL jitter, runtime schema validation, and distributed write locking.
  * Introduced `with*Prefix` middleware to apply key prefixing across key-based components.
  * Updated cache write operations to accept TTL directly as a parameter.
* **Breaking Changes**
  * Removed namespace-based key types and cache write settings; keys are now plain strings.
  * Cache no longer supports schema/locking configuration via settings objects.
* **Documentation**
  * Reorganized cache plugin and usage/resolver guides with updated examples and guidance.
* **Tests**
  * Added dedicated plugin test suites and updated cache test conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->