### PR TITLE
style: fix JSDoc formatting in cache and file-storage plugins

### DIFF
--- a/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.ts
+++ b/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.ts
@@ -43,8 +43,9 @@ export type WithCacheJitterSettings = {
  *                                 @default 0.2
  * @returns A middleware plugin that wraps an `ICacheAdapter`.
  *
- * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
  * @typeParam TType - The type of values stored in the cache.
+ *
+ * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
  * @group Plugins
  */
 export function withCacheJitter<TType>(

--- a/src/cache/implementations/plugins/with-cache-prefix/with-cache-prefix.ts
+++ b/src/cache/implementations/plugins/with-cache-prefix/with-cache-prefix.ts
@@ -16,8 +16,9 @@ import { type PluginFn } from "@/middleware/contracts/_module.js";
  * @param prefix - The string to prepend to every cache key.
  * @returns A middleware plugin that wraps an `ICacheAdapter`.
  *
- * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
  * @typeParam TType - The type of values stored in the cache.
+ *
+ * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
  * @group Plugins
  */
 export function withCachePrefix<TType>(

--- a/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.ts
+++ b/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.ts
@@ -11,8 +11,9 @@ import { validate } from "@/utilities/_module.js";
 /**
  * Settings for the {@link withCacheSchema} plugin.
  *
- * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
  * @typeParam TType - The type to validate against.
+ *
+ * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
  * @group Plugins
  */
 export type WithCacheSchemaSettings<TType = unknown> = {
@@ -50,8 +51,9 @@ export type WithCacheSchemaSettings<TType = unknown> = {
  *                                        @default true
  * @returns A middleware plugin that wraps an `ICacheAdapter`.
  *
- * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
  * @typeParam TType - The type of values stored in the cache.
+ *
+ * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
  * @group Plugins
  */
 export function withCacheSchema<TType>(

--- a/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.ts
+++ b/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.ts
@@ -12,6 +12,7 @@ import { type PluginFn } from "@/middleware/contracts/_module.js";
  * Only the mutable methods that modify cache state are eligible for write-lock
  * protection.
  *
+ * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
  * @group Plugins
  */
 export type WithCacheWriteLockMethods = keyof Pick<
@@ -68,8 +69,9 @@ export type WithCacheWriteLockSettings = {
  *                               lock. Defaults to all mutating methods.
  * @returns A middleware plugin that wraps an `ICacheAdapter`.
  *
- * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
  * @typeParam TType - The type of values stored in the cache.
+ *
+ * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
  * @group Plugins
  */
 export function withCacheWriteLock<TType>(

--- a/src/file-storage/implementations/plugins/with-file-storage-lock/with-file-storage-lock.ts
+++ b/src/file-storage/implementations/plugins/with-file-storage-lock/with-file-storage-lock.ts
@@ -14,6 +14,7 @@ import { type PluginFn } from "@/middleware/contracts/_module.js";
  * All methods of {@link ISignedFileStorageAdapter | `ISignedFileStorageAdapter`} that can be protected by a lock,
  * excluding `removeByPrefix` (which operates on key patterns rather than concrete keys).
  *
+ * IMPORT_PATH: `"@daiso-tech/core/file-storage/plugins"`
  * @group Plugins
  */
 export type WithFileStorageLockMethods = keyof Omit<
@@ -394,8 +395,9 @@ function withFileStorageRemovalLock(
  *                               Defaults to all methods (except `removeByPrefix`).
  * @returns A middleware plugin that wraps an `ISignedFileStorageAdapter`.
  *
- * IMPORT_PATH: `"@daiso-tech/core/file-storage/plugins"`
  * @typeParam TType - The type of values stored in the file storage.
+ *
+ * IMPORT_PATH: `"@daiso-tech/core/file-storage/plugins"`
  * @group Plugins
  */
 export function withFileStorageLock(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin documentation metadata and import path references.
  * Improved consistency in type-parameter documentation across cache and file-storage plugins.
  * No user-facing behavior or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->