### PR TITLE
refactor(cache): remove unused generic type parameter from cache plugins

### DIFF
--- a/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.ts
+++ b/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.ts
@@ -43,14 +43,12 @@ export type WithCacheJitterSettings = {
  *                                 @default 0.2
  * @returns A middleware plugin that wraps an `ICacheAdapter`.
  *
- * @typeParam TType - The type of values stored in the cache.
- *
  * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
  * @group Plugins
  */
-export function withCacheJitter<TType>(
+export function withCacheJitter(
     settings: WithCacheJitterSettings = {},
-): PluginFn<ICacheAdapter<TType>> {
+): PluginFn<ICacheAdapter> {
     const { defaultJitter = 0.2, _mathRandom = () => Math.random() } = settings;
     function ttlWithJitter(ttl: TimeSpan | null): TimeSpan | null {
         if (ttl === null) {

--- a/src/cache/implementations/plugins/with-cache-prefix/with-cache-prefix.ts
+++ b/src/cache/implementations/plugins/with-cache-prefix/with-cache-prefix.ts
@@ -16,14 +16,10 @@ import { type PluginFn } from "@/middleware/contracts/_module.js";
  * @param prefix - The string to prepend to every cache key.
  * @returns A middleware plugin that wraps an `ICacheAdapter`.
  *
- * @typeParam TType - The type of values stored in the cache.
- *
  * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
  * @group Plugins
  */
-export function withCachePrefix<TType>(
-    prefix: string,
-): PluginFn<ICacheAdapter<TType>> {
+export function withCachePrefix(prefix: string): PluginFn<ICacheAdapter> {
     function withPrefix(key: string): string {
         return prefix + key;
     }

--- a/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.ts
+++ b/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.ts
@@ -11,18 +11,16 @@ import { validate } from "@/utilities/_module.js";
 /**
  * Settings for the {@link withCacheSchema} plugin.
  *
- * @typeParam TType - The type to validate against.
- *
  * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
  * @group Plugins
  */
-export type WithCacheSchemaSettings<TType = unknown> = {
+export type WithCacheSchemaSettings = {
     /**
      * A standard-schema-compliant schema used to validate cache values.
      * Compatible with libraries such as Zod, ArkType, Valibot, and others
      * that implement the `StandardSchemaV1` specification.
      */
-    schema: StandardSchemaV1<TType>;
+    schema: StandardSchemaV1;
 
     /**
      * Whether to validate values returned by `get` and `getAndRemove`
@@ -51,14 +49,12 @@ export type WithCacheSchemaSettings<TType = unknown> = {
  *                                        @default true
  * @returns A middleware plugin that wraps an `ICacheAdapter`.
  *
- * @typeParam TType - The type of values stored in the cache.
- *
  * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
  * @group Plugins
  */
-export function withCacheSchema<TType>(
-    settings: WithCacheSchemaSettings<TType>,
-): PluginFn<ICacheAdapter<TType>> {
+export function withCacheSchema(
+    settings: WithCacheSchemaSettings,
+): PluginFn<ICacheAdapter> {
     const { schema, shouldValidateOutput = true } = settings;
 
     return (adapter, enhance) => {

--- a/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.ts
+++ b/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.ts
@@ -69,14 +69,12 @@ export type WithCacheWriteLockSettings = {
  *                               lock. Defaults to all mutating methods.
  * @returns A middleware plugin that wraps an `ICacheAdapter`.
  *
- * @typeParam TType - The type of values stored in the cache.
- *
  * IMPORT_PATH: `"@daiso-tech/core/cache/plugins"`
  * @group Plugins
  */
-export function withCacheWriteLock<TType>(
+export function withCacheWriteLock(
     settings: WithCacheWriteLockSettings,
-): PluginFn<ICacheAdapter<TType>> {
+): PluginFn<ICacheAdapter> {
     const {
         lockFactory,
         onlyMethods = [

--- a/website/docs/components/cache/cache_plugin.md
+++ b/website/docs/components/cache/cache_plugin.md
@@ -293,7 +293,7 @@ const validatedAdapter = withPlugin(
     withCacheSchema({ schema: UserSchema }),
 );
 
-const cache = new Cache({
+const cache = new Cache<z.infer<typeof UserSchema>>({
     adapter: validatedAdapter,
 });
 


### PR DESCRIPTION
Removed the unused TType generic type parameter from:
- withCacheJitter
- withCachePrefix
- withCacheSchema (including WithCacheSchemaSettings type)
- withCacheWriteLock

Also updated the cache_plugin.md documentation to use explicit
generic syntax for Cache constructor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the cache schema plugin example to show type-safe cache usage based on a validation schema.

* **Refactor**
  * Simplified TypeScript typings for cache plugins by removing unnecessary generic parameters.
  * Preserved existing runtime behavior for cache jitter, prefixes, schema validation, and write locking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->