### PR TITLE
docs(changeset): standardize formatting across all changeset files

### DIFF
--- a/.changeset/cache-plugins.md
+++ b/.changeset/cache-plugins.md
@@ -17,14 +17,30 @@ The previous architecture baked cross-cutting concerns like schema validation, T
 
 The new plugin-based architecture solves these problems by keeping the `Cache` class focused on a single responsibility — delegating to an `ICacheAdapter` — and providing each cross-cutting behaviour as an independent `PluginFn<ICacheAdapter>` that can be composed via `withPlugin(adapter, ...plugins)`.
 
+### Breaking Changes
+
+**Removed from `CacheSettingsBase`:**
+
+- `schema` — use the `withCacheSchema` plugin instead.
+- `lockFactory` — use the `withCacheWriteLock` plugin instead.
+
+**Removed types:**
+
+- `CacheWriteSettings` — TTL is now passed as an inline `ITimeSpan | null` parameter on `add`, `put`, `getOrAdd`, and related methods.
+
+**Changed API signatures:**
+
+- `Cache` constructor no longer accepts `schema` or `lockFactory` settings.
+- `CacheResolver` no longer carries schema or write-lock configuration.
+- `ICache.getOrAdd` now accepts `ttl?: ITimeSpan | null` as its third parameter instead of a `CacheWriteSettings` object.
+
 ### New Plugin-Based Capabilities
 
-The following behaviours are no longer built into `Cache` or `CacheResolver`. They are available as opt-in plugins that operate at the `ICacheAdapter` level:
+The following behaviours are no longer built into `Cache` or `CacheResolver`. They are available as opt-in plugins:
 
 **`withCacheJitter`** — Adds random jitter to TTL values on `add` and `put` operations to help prevent cache stampedes (thundering-herd problems).
 
-- Configurable via `defaultJitter` (default ±20 %).
-- Applied as a middleware that intercepts TTL parameters before they reach the adapter.
+- Configurable via `defaultJitter` (default ±20 %).
 - `WITHOUT` this plugin, TTLs are stored as-is — no jitter is applied.
 - Import path: `@daiso-tech/core/cache/plugins`
 
@@ -42,48 +58,13 @@ The following behaviours are no longer built into `Cache` or `CacheResolver`. Th
 
 ### How the New Architecture Works
 
-The `Cache` class (`src/cache/implementations/derivables/cache/cache.ts`) has been simplified to a thin wrapper that:
+The `Cache` class has been simplified to a thin wrapper that:
 
 1. Accepts an `ICacheAdapter` (optionally enhanced by plugins) via `CacheSettings.adapter`.
-2. Delegates every operation ( `get`, `add`, `put`, `update`, `increment`, `remove`, `clear`, etc.) directly to the adapter.
+2. Delegates every operation (`get`, `add`, `put`, `update`, `increment`, `remove`, `clear`, etc.) directly to the adapter.
 3. No longer performs schema validation, TTL jittering, or write-lock acquisition internally.
 
-The `CacheResolver` class (`src/cache/implementations/derivables/cache-resolver/cache-resolver.ts`) has been similarly streamlined:
-
-- Its `use()` method creates a plain `Cache` instance with no built-in plugins.
-- `CacheResolverSettings` extends `CacheSettingsBase`, which now only contains `defaultTtl` and `context`.
-- To use plugins with `CacheResolver`, users must apply plugins to the adapter _before_ registering it, or wrap the adapter at registration time.
-
-The `ICache` contract (`src/cache/contracts/cache.contract.ts`) now uses inline `ttl?: ITimeSpan | null` parameters instead of the removed `CacheWriteSettings` object for `add`, `put`, `getOrAdd`, and related methods. This simplifies the API surface and aligns with the plugin philosophy — TTL manipulation is handled at the plugin/adapter level.
-
-### Plugin Composition Pattern
-
-Plugins are applied to an `ICacheAdapter` before passing it to `Cache`:
-
-```ts
-import { withPlugin } from "@daiso-tech/core/middleware";
-import { MemoryCacheAdapter } from "@daiso-tech/core/cache/memory-cache-adapter";
-import { Cache } from "@daiso-tech/core/cache";
-import { withCacheSchema } from "@daiso-tech/core/cache/plugins";
-import { withCacheJitter } from "@daiso-tech/core/cache/plugins";
-import { withCacheWriteLock } from "@daiso-tech/core/cache/plugins";
-import { z } from "zod";
-
-// Compose multiple plugins on the adapter
-const adapter = withPlugin(
-    new MemoryCacheAdapter(),
-    withCacheSchema({ schema: z.string() }),
-    withCacheJitter({ defaultJitter: 0.1 }),
-    withCacheWriteLock({ lockFactory }),
-);
-
-// Pass the enhanced adapter to the thin Cache class
-const cache = new Cache({ adapter });
-```
-
-Plugins are applied in order and wrap the adapter's methods using the `Enhance` utility. `withPluginFactory(enhanceFactory(useFactory()))` is the standard way to create a `withPlugin` function that supports method interception.
-
-### Migration Path
+### Migration
 
 Users who relied on the previous built-in schema validation, TTL jitter, or write-lock behaviour must now explicitly compose the corresponding plugins.
 
@@ -97,36 +78,20 @@ Users who relied on the previous built-in schema validation, TTL jitter, or writ
 **Before (built-in behaviour):**
 
 ```ts
-// Schema validation and jitter were built into Cache/CacheResolver
 const cache = new Cache({ adapter, schema: mySchema });
 ```
 
 **After (explicit plugin composition):**
 
 ```ts
-const enhancedAdapter = withPlugin(
-    adapter,
+import { withPlugin } from "@daiso-tech/core/middleware";
+import { withCacheSchema } from "@daiso-tech/core/cache/plugins";
+
+const adapter = withPlugin(
+    new MemoryCacheAdapter(),
     withCacheSchema({ schema: mySchema }),
-    withCacheJitter(),
 );
-const cache = new Cache({ adapter: enhancedAdapter });
+const cache = new Cache({ adapter });
 ```
 
 If you do not apply any plugins, the cache behaves as a pure passthrough — no validation, no jitter, no locking. This reduces overhead when these features are not needed.
-
-### Refactoring Details
-
-- **`CacheSettingsBase`**: Removed `schema` and `lockFactory` options. Now only contains `defaultTtl` and `context`.
-- **`CacheResolverSettings`**: Simplified to extend the lean `CacheSettingsBase`. No longer carries schema or write-lock configuration.
-- **`CacheWriteSettings`**: Removed. TTL is now passed as an inline `ITimeSpan | null` parameter directly on `add`, `put`, `getOrAdd`, etc.
-- **`withCacheFactory`**: Updated to accept inline TTL parameter instead of `CacheWriteSettings`.
-- **`ICache` contract**: `getOrAdd` now accepts `ttl?: ITimeSpan | null` as its third parameter instead of a `CacheWriteSettings` object.
-
-### Fixes
-
-- Added missing trailing comma to `getOrAdd` method signature in `ICache`.
-
-### Tests
-
-- Restructured `with*Prefix` test suites across all components (cache, circuit-breaker, file-storage, lock, rate-limiter, semaphore, shared-lock) for improved readability and consistency.
-- New dedicated test suites for each plugin (`with-cache-jitter.test.ts`, `with-cache-schema.test.ts`, `with-cache-write-lock.test.ts`) verifying isolation and composition correctness.

--- a/.changeset/event-bus-plugins.md
+++ b/.changeset/event-bus-plugins.md
@@ -1,0 +1,150 @@
+---
+"@daiso-tech/core": minor
+---
+
+## Architectural Shift: Composable EventBus Plugins
+
+The event-bus module has undergone a significant architectural refactoring. Schema validation that was previously hard-coded into the `EventBus` class has been extracted into a standalone, composable plugin. The core `EventBus` class is now a thin passthrough that delegates operations directly to the underlying `IEventBusAdapter`, while optional capabilities are layered on via the middleware plugin system (`PluginFn`/`withPlugin`).
+
+### Motivation
+
+The previous architecture baked schema validation directly into the `EventBus` and `EventBusResolver` classes. This had several drawbacks:
+
+- **Tight coupling**: Users who didn't need schema validation still paid the overhead of importing the validation infrastructure.
+- **Difficult to extend**: Adding new cross-cutting behaviours (such as event name prefixing) required modifying the core `EventBus` class.
+- **No composability**: Behaviours could not be mixed, matched, or reordered independently.
+- **Testing complexity**: Core EventBus tests had to account for all combined validation scenarios.
+
+The new plugin-based architecture solves these problems by keeping the `EventBus` class focused on a single responsibility — delegating to an `IEventBusAdapter` — and providing each cross-cutting behaviour as an independent `PluginFn<IEventBusAdapter>` that can be composed via `withPlugin(adapter, ...plugins)`.
+
+### Breaking Changes
+
+**Removed from `EventBus` class:**
+
+- `EventBusSettings` and `EventBusSettingsBase` no longer accept `eventMapSchema` or `shouldValidateOutput`. These are now configured via the `withEventBusSchema` plugin.
+- `EventBusSettings` is no longer generic over `TEventMap` — the constructor signature is now `constructor(settings: EventBusSettings)` instead of `constructor(settings: EventBusSettings<TEventMap>)`.
+
+**Removed from `EventBusResolver` class:**
+
+- `EventBusResolverSettings` no longer accepts the `TEventMap` generic parameter — simplified to `EventBusResolverSettings<TAdapters>`.
+- The `setEventMapSchema()` method has been removed. Use the `withEventBusSchema` plugin instead.
+
+**Removed types:**
+
+- `EventMapSchema` (previously exported from `@daiso-tech/core/event-bus`) — now exported from `@daiso-tech/core/event-bus/plugins` with an updated API.
+
+**Removed behaviour:**
+
+- The `EventBus` class no longer validates event data on `dispatch`, nor validates listener output on `addListener`, `listenOnce`, `asPromise`, `subscribeOnce`, or `subscribe`. Schema validation is now opt-in via the `withEventBusSchema` plugin.
+
+### New Plugin-Based Capabilities
+
+The following behaviours are no longer built into `EventBus`. They are available as opt-in plugins:
+
+**`withEventBusSchema`** — Validates event data against a `StandardSchemaV1`-compliant schema map. On `dispatch`, the event data is validated before being forwarded to the adapter. When `shouldValidateListeners` is `true` (default), listener functions are also wrapped to validate event data before it reaches the listener.
+
+- The `defineEventMapSchema` helper provides type-safety when defining the schema map.
+- `WITHOUT` this plugin, no schema validation occurs — any event data is accepted.
+- Import path: `@daiso-tech/core/event-bus/plugins`
+
+```ts
+import { withPlugin } from "@daiso-tech/core/middleware";
+import { MemoryEventBusAdapter } from "@daiso-tech/core/event-bus/memory-event-bus-adapter";
+import { withEventBusSchema } from "@daiso-tech/core/event-bus/plugins";
+import { z } from "zod";
+
+const adapter = withPlugin(
+    new MemoryEventBusAdapter(),
+    withEventBusSchema({
+        eventMapSchema: {
+            add: z.object({ a: z.number(), b: z.number() }),
+        },
+    }),
+);
+```
+
+**`withEventBusPrefix`** — Prefixes all event names passed to an event bus adapter. Every method that accepts an event name (`dispatch`, `addListener`, `removeListener`) will have the given prefix prepended before the call is forwarded to the underlying adapter.
+
+- Useful for multi-tenant systems, environment isolation, and module scoping.
+- Import path: `@daiso-tech/core/event-bus/plugins`
+
+```ts
+import { withPlugin } from "@daiso-tech/core/middleware";
+import { MemoryEventBusAdapter } from "@daiso-tech/core/event-bus/memory-event-bus-adapter";
+import { withEventBusPrefix } from "@daiso-tech/core/event-bus/plugins";
+
+const adapter = withPlugin(
+    new MemoryEventBusAdapter(),
+    withEventBusPrefix("app:"),
+);
+```
+
+**`withListenerTracking`** — Solves the listener reference tracking problem that arises when middleware plugins wrap listener functions in `addListener`. It maintains an internal `original → wrapper` mapping so that `removeListener` correctly resolves the original listener to its wrapped counterpart before forwarding.
+
+- Use this when composing plugins that wrap listeners (like `withEventBusSchema` with `shouldValidateListeners` enabled).
+- Import path: `@daiso-tech/core/event-bus/plugins`
+
+```ts
+import { withPlugin } from "@daiso-tech/core/middleware";
+import { MemoryEventBusAdapter } from "@daiso-tech/core/event-bus/memory-event-bus-adapter";
+import {
+    withEventBusSchema,
+    withListenerTracking,
+    defineEventMapSchema,
+} from "@daiso-tech/core/event-bus/plugins";
+import { z } from "zod";
+
+const eventMapSchema = defineEventMapSchema({
+    add: z.object({ a: z.number(), b: z.number() }),
+});
+const adapter = withPlugin(
+    new MemoryEventBusAdapter(),
+    withListenerTracking(
+        withEventBusSchema({ eventMapSchema }),
+    ),
+);
+```
+
+### How the New Architecture Works
+
+The `EventBus` class has been simplified to a thin wrapper that:
+
+1. Accepts an `IEventBusAdapter` (optionally enhanced by plugins) via `EventBusSettings.adapter`.
+2. Delegates every operation (`dispatch`, `addListener`, `removeListener`, `listenOnce`, `asPromise`, `subscribeOnce`, `subscribe`) directly to the adapter.
+3. No longer performs schema validation internally.
+
+Plugins receive the adapter and an `enhance` function, allowing them to intercept and modify specific methods using the same middleware pattern used by all other daiso-core components.
+
+### Migration
+
+**Before (built-in validation):**
+
+```ts
+const eventBus = new EventBus({
+    adapter: new MemoryEventBusAdapter(),
+    eventMapSchema,
+});
+```
+
+**After (explicit plugin composition):**
+
+```ts
+import { withPlugin } from "@daiso-tech/core/middleware";
+import { withEventBusSchema } from "@daiso-tech/core/event-bus/plugins";
+
+const adapter = withPlugin(
+    new MemoryEventBusAdapter(),
+    withEventBusSchema({ eventMapSchema }),
+);
+const eventBus = new EventBus({ adapter });
+```
+
+### New Export Path
+
+A new export path has been added to `package.json`:
+
+```
+@daiso-tech/core/event-bus/plugins
+```
+
+This exports `withEventBusSchema`, `withEventBusPrefix`, `withListenerTracking`, `EventMapSchema`, `WithEventBusSchemaSettings`, and `defineEventMapSchema`.

--- a/.changeset/event-bus-plugins.md
+++ b/.changeset/event-bus-plugins.md
@@ -99,9 +99,7 @@ const eventMapSchema = defineEventMapSchema({
 });
 const adapter = withPlugin(
     new MemoryEventBusAdapter(),
-    withListenerTracking(
-        withEventBusSchema({ eventMapSchema }),
-    ),
+    withListenerTracking(withEventBusSchema({ eventMapSchema })),
 );
 ```
 

--- a/.changeset/removal-of-database-cache-adapter.md
+++ b/.changeset/removal-of-database-cache-adapter.md
@@ -2,18 +2,31 @@
 "@daiso-tech/core": minor
 ---
 
-Removed `IDatabaseCacheAdapter`, `IDatabaseCacheTransaction`, and `ICacheData` contracts, along with their `databaseCacheAdapterTestSuite`.
+## Simplified Cache Adapter Contract
 
-The `IDatabaseCacheAdapter` contract (`database-cache-adapter.contract.ts`) has been removed in favor of the simpler `ICacheAdapter` contract. This simplifies the cache adapter interface by eliminating the transaction-based database abstraction layer.
+The `IDatabaseCacheAdapter`, `IDatabaseCacheTransaction`, and `ICacheData` contracts have been removed in favor of the simpler `ICacheAdapter` contract. This eliminates the transaction-based database abstraction layer, making the cache adapter interface more straightforward.
 
-### Changes:
+### Motivation
 
-- **Removed**: `IDatabaseCacheAdapter` type contract
-- **Removed**: `IDatabaseCacheTransaction` type contract
-- **Removed**: `ICacheData` and `ICacheDataExpiration` types
-- **Removed**: `databaseCacheAdapterTestSuite` test utility
-- **Refactored**: `KyselyCacheAdapter` (at `@daiso-tech/core/cache/kysely-cache-adapter`) now implements `ICacheAdapter` directly instead of `IDatabaseCacheAdapter`
+The `IDatabaseCacheAdapter` contract introduced unnecessary complexity by wrapping all results in `ICacheData` / `ICacheDataExpiration` objects and requiring transaction support. The simpler `ICacheAdapter` contract returns primitive values directly, reducing boilerplate for adapter implementors and improving runtime performance.
 
-### Migration:
+### Breaking Changes
 
-Custom `IDatabaseCacheAdapter` implementations should migrate to `ICacheAdapter`. The contract expects methods to return primitive values (`TType | null`, `boolean`, `void`) directly instead of wrapping results in `ICacheData` / `ICacheDataExpiration` objects. Use `cacheAdapterTestSuite` instead of `databaseCacheAdapterTestSuite` for testing.
+**Removed types:**
+
+- `IDatabaseCacheAdapter`
+- `IDatabaseCacheTransaction`
+- `ICacheData`
+- `ICacheDataExpiration`
+
+**Removed test utility:**
+
+- `databaseCacheAdapterTestSuite` — use `cacheAdapterTestSuite` instead.
+
+**Refactored adapters:**
+
+- `KyselyCacheAdapter` now implements `ICacheAdapter` directly instead of `IDatabaseCacheAdapter`.
+
+### Migration
+
+Custom `IDatabaseCacheAdapter` implementations should migrate to `ICacheAdapter`. The new contract expects methods to return primitive values (`TType | null`, `boolean`, `void`) directly instead of wrapping results in `ICacheData` / `ICacheDataExpiration` objects. Use `cacheAdapterTestSuite` instead of `databaseCacheAdapterTestSuite` for testing.

--- a/.changeset/removal-of-database-lock-adapter.md
+++ b/.changeset/removal-of-database-lock-adapter.md
@@ -2,20 +2,36 @@
 "@daiso-tech/core": minor
 ---
 
-Removed `IDatabaseLockAdapter`, `IDatabaseLockTransaction`, and `ILockData` contracts, along with their `databaseLockAdapterTestSuite`.
+## Simplified Lock Adapter Contract
 
-The `IDatabaseLockAdapter` contract has been removed in favor of the simpler `ILockAdapter` contract. This simplifies the lock adapter interface by eliminating the transaction-based database abstraction layer.
+The `IDatabaseLockAdapter`, `IDatabaseLockTransaction`, and `ILockData` contracts have been removed in favor of the simpler `ILockAdapter` contract. This eliminates the transaction-based database abstraction layer, making the lock adapter interface more straightforward.
 
-### Changes:
+### Motivation
 
-- **Removed**: `IDatabaseLockAdapter` type contract
-- **Removed**: `IDatabaseLockTransaction` type contract
-- **Removed**: `ILockData` and `ILockExpirationData` types
-- **Removed**: `databaseLockAdapterTestSuite` test utility
-- **Removed**: `DatabaseLockAdapter` derivable class
-- **Refactored**: `KyselyLockAdapter` (at `@daiso-tech/core/lock/kysely-lock-adapter`) now implements `ILockAdapter` directly with `acquire`, `release`, `forceRelease`, `refresh`, and `getState` methods
+The `IDatabaseLockAdapter` contract introduced unnecessary complexity by wrapping results in `ILockData` / `ILockExpirationData` objects and requiring transaction support. The simpler `ILockAdapter` contract returns primitive values directly, reducing boilerplate for adapter implementors and improving runtime performance.
 
-### Migration:
+### Breaking Changes
+
+**Removed types:**
+
+- `IDatabaseLockAdapter`
+- `IDatabaseLockTransaction`
+- `ILockData`
+- `ILockExpirationData`
+
+**Removed test utility:**
+
+- `databaseLockAdapterTestSuite` — use `lockAdapterTestSuite` instead.
+
+**Removed classes:**
+
+- `DatabaseLockAdapter` derivable class
+
+**Refactored adapters:**
+
+- `KyselyLockAdapter` now implements `ILockAdapter` directly with `acquire`, `release`, `forceRelease`, `refresh`, and `getState` methods.
+
+### Migration
 
 Custom `IDatabaseLockAdapter` implementations should migrate to `ILockAdapter`. The new contract expects methods with the following signatures:
 

--- a/.changeset/removal-of-database-semaphore-adapter.md
+++ b/.changeset/removal-of-database-semaphore-adapter.md
@@ -2,19 +2,33 @@
 "@daiso-tech/core": minor
 ---
 
-Removed `IDatabaseSemaphoreAdapter`, `IDatabaseSemaphoreTransaction`, `ISemaphoreData`, `ISemaphoreSlotData`, and `ISemaphoreSlotExpirationData` contracts, along with their `databaseSemaphoreAdapterTestSuite`.
+## Simplified Semaphore Adapter Contract
 
-The `IDatabaseSemaphoreAdapter` contract (`database-semaphore-adapter.contract.ts`) has been removed in favor of the simpler `ISemaphoreAdapter` contract. This simplifies the semaphore adapter interface by eliminating the transaction-based database abstraction layer.
+The `IDatabaseSemaphoreAdapter`, `IDatabaseSemaphoreTransaction`, and related data contracts have been removed in favor of the simpler `ISemaphoreAdapter` contract. This eliminates the transaction-based database abstraction layer, making the semaphore adapter interface more straightforward.
 
-### Changes:
+### Motivation
 
-- **Removed**: `IDatabaseSemaphoreAdapter` type contract
-- **Removed**: `IDatabaseSemaphoreTransaction` type contract
-- **Removed**: `ISemaphoreData`, `ISemaphoreSlotData`, and `ISemaphoreSlotExpirationData` types
-- **Removed**: `databaseSemaphoreAdapterTestSuite` test utility
-- **Refactored**: `KyselySemaphoreAdapter` (at `@daiso-tech/core/semaphore/new-kysely-semaphore-adapter`) now implements `ISemaphoreAdapter` directly with `acquire`, `release`, `forceReleaseAll`, `refresh`, and `getState` methods
+The `IDatabaseSemaphoreAdapter` contract introduced unnecessary complexity by wrapping results in `ISemaphoreData`, `ISemaphoreSlotData`, and `ISemaphoreSlotExpirationData` objects and requiring transaction support. The simpler `ISemaphoreAdapter` contract returns primitive values directly, reducing boilerplate for adapter implementors and improving runtime performance.
 
-### Migration:
+### Breaking Changes
+
+**Removed types:**
+
+- `IDatabaseSemaphoreAdapter`
+- `IDatabaseSemaphoreTransaction`
+- `ISemaphoreData`
+- `ISemaphoreSlotData`
+- `ISemaphoreSlotExpirationData`
+
+**Removed test utility:**
+
+- `databaseSemaphoreAdapterTestSuite` — use `semaphoreAdapterTestSuite` instead.
+
+**Refactored adapters:**
+
+- `KyselySemaphoreAdapter` now implements `ISemaphoreAdapter` directly with `acquire`, `release`, `forceReleaseAll`, `refresh`, and `getState` methods.
+
+### Migration
 
 Custom `IDatabaseSemaphoreAdapter` implementations should migrate to `ISemaphoreAdapter`. The new contract expects methods with the following signatures:
 

--- a/.changeset/removal-of-database-shared-lock-adapter.md
+++ b/.changeset/removal-of-database-shared-lock-adapter.md
@@ -2,20 +2,39 @@
 "@daiso-tech/core": minor
 ---
 
-Removed `IDatabaseSharedLockAdapter`, `IDatabaseSharedLockTransaction`, `IWriterLockData`, `IWriterLockExpirationData`, `IReaderSemaphoreSlotExpirationData`, `IReaderSemaphoreSlotData`, and `IReaderSemaphoreData` contracts, along with their `databaseSharedLockAdapterTestSuite`.
+## Simplified Shared Lock Adapter Contract
 
-The `IDatabaseSharedLockAdapter` contract (`database-shared-lock-adapter.contract.ts`) has been removed in favor of the simpler `ISharedLockAdapter` contract. This simplifies the shared-lock adapter interface by eliminating the transaction-based database abstraction layer.
+The `IDatabaseSharedLockAdapter`, `IDatabaseSharedLockTransaction`, and related data contracts have been removed in favor of the simpler `ISharedLockAdapter` contract. This eliminates the transaction-based database abstraction layer, making the shared-lock adapter interface more straightforward.
 
-### Changes:
+### Motivation
 
-- **Removed**: `IDatabaseSharedLockAdapter` type contract
-- **Removed**: `IDatabaseSharedLockTransaction` type contract
-- **Removed**: `IWriterLockData`, `IWriterLockExpirationData`, `IReaderSemaphoreSlotExpirationData`, `IReaderSemaphoreSlotData`, and `IReaderSemaphoreData` types
-- **Removed**: `databaseSharedLockAdapterTestSuite` test utility
-- **Removed**: `DatabaseSharedLockAdapter` derivable class
-- **Refactored**: `KyselySharedLockAdapter` (at `@daiso-tech/core/shared-lock/kysely-shared-lock-adapter`) now implements `ISharedLockAdapter` directly with `acquireWriter`, `releaseWriter`, `forceReleaseWriter`, `refreshWriter`, `acquireReader`, `releaseReader`, `forceReleaseAllReaders`, `refreshReader`, `forceRelease`, and `getState` methods
+The `IDatabaseSharedLockAdapter` contract introduced unnecessary complexity by wrapping results in `IWriterLockData`, `IReaderSemaphoreData`, and related objects, while requiring transaction support. The simpler `ISharedLockAdapter` contract returns primitive values directly, reducing boilerplate for adapter implementors and improving runtime performance.
 
-### Migration:
+### Breaking Changes
+
+**Removed types:**
+
+- `IDatabaseSharedLockAdapter`
+- `IDatabaseSharedLockTransaction`
+- `IWriterLockData`
+- `IWriterLockExpirationData`
+- `IReaderSemaphoreSlotExpirationData`
+- `IReaderSemaphoreSlotData`
+- `IReaderSemaphoreData`
+
+**Removed test utility:**
+
+- `databaseSharedLockAdapterTestSuite` — use `sharedLockAdapterTestSuite` instead.
+
+**Removed classes:**
+
+- `DatabaseSharedLockAdapter` derivable class
+
+**Refactored adapters:**
+
+- `KyselySharedLockAdapter` now implements `ISharedLockAdapter` directly with `acquireWriter`, `releaseWriter`, `forceReleaseWriter`, `refreshWriter`, `acquireReader`, `releaseReader`, `forceReleaseAllReaders`, `refreshReader`, `forceRelease`, and `getState` methods.
+
+### Migration
 
 Custom `IDatabaseSharedLockAdapter` implementations should migrate to `ISharedLockAdapter`. The new contract expects methods with the following signatures:
 

--- a/.changeset/update-file-storage.md
+++ b/.changeset/update-file-storage.md
@@ -2,25 +2,32 @@
 "@daiso-tech/core": minor
 ---
 
-Updated the `IFileStorage` contract — removed node js read methods and extracted built-in locking into a standalone plugin.
+## Cross-Platform File Storage and Extracted Locking
 
-### Changes
+The `IFileStorage` contract has been updated to remove Node.js-specific read methods and extract built-in locking into a standalone plugin. The `FileStorage` class now works in non-Node.js environments such as Cloudflare Workers without requiring Node.js compatibility.
 
-- **Removed** `IFile.getBuffer` — use `IFile.getBytes` instead (returns `Uint8Array | null`).
-- **Removed** `IFile.getBufferOrFail` — use `IFile.getBytesOrFail` instead (returns `Uint8Array` or throws).
-- **Removed** `IFile.getReadable` — use `IFile.getStream` instead (returns a readable stream).
-- **Removed** `IFile.getReadableOrFail` — use `IFile.getStreamOrFail` instead (returns a readable stream or throws).
-- **Removed** built-in locking from the `FileStorage` class — locking is now provided by the standalone `withFileStorageLock` plugin.
+### Motivation
 
-Now the `FileStorage` class will work in none `Node.js` environment like `cloudflare` workers without `Node.js` compatibility.
+The previous `IFileStorage` contract included Node.js-specific methods (`getBuffer`, `getReadable`) that prevented the component from working in edge-runtime environments. Additionally, built-in locking coupled the `FileStorage` class to the lock infrastructure even for users who didn't need it. By extracting locking into a plugin and replacing Node-specific APIs with runtime-agnostic alternatives, the file-storage module is now portable across environments.
 
-### Migration
+### Breaking Changes
 
-- Replace all calls to `fileStorage.getBuffer(key)` with `fileStorage.getBytes(key)`.
-- Replace all calls to `fileStorage.getBufferOrFail(key)` with `fileStorage.getBytesOrFail(key)`.
-- Replace all calls to `fileStorage.getReadable(key)` with `fileStorage.getStream(key)`.
-- Replace all calls to `fileStorage.getReadableOrFail(key)` with `fileStorage.getStreamOrFail(key)`.
-- If you relied on the built-in locking in `FileStorage`, apply the `withFileStorageLock` plugin to your file storage adapter instead:
+**Removed methods from `IFile`:**
+
+- `IFile.getBuffer` — use `IFile.getBytes` instead (returns `Uint8Array | null`).
+- `IFile.getBufferOrFail` — use `IFile.getBytesOrFail` instead (returns `Uint8Array` or throws).
+- `IFile.getReadable` — use `IFile.getStream` instead (returns a readable stream).
+- `IFile.getReadableOrFail` — use `IFile.getStreamOrFail` instead (returns a readable stream or throws).
+
+**Removed behaviour:**
+
+- Built-in locking from the `FileStorage` class — locking is now provided by the standalone `withFileStorageLock` plugin.
+
+### New Plugin-Based Capabilities
+
+**`withFileStorageLock`** — Adds distributed locking to file storage operations.
+
+- Import path: `@daiso-tech/core/file-storage/plugins`
 
 ```ts
 import { withPlugin } from "@daiso-tech/core/middleware";
@@ -33,3 +40,11 @@ const adapter = withPlugin(
     withFileStorageLock({ lockFactory: new MemoryLockFactory() }),
 );
 ```
+
+### Migration
+
+- Replace all calls to `getBuffer(key)` with `getBytes(key)`.
+- Replace all calls to `getBufferOrFail(key)` with `getBytesOrFail(key)`.
+- Replace all calls to `getReadable(key)` with `getStream(key)`.
+- Replace all calls to `getReadableOrFail(key)` with `getStreamOrFail(key)`.
+- If you relied on the built-in locking, apply the `withFileStorageLock` plugin to your file storage adapter as shown above.

--- a/.changeset/with-prefix-plugins.md
+++ b/.changeset/with-prefix-plugins.md
@@ -39,22 +39,25 @@ The new approach removes the namespace abstraction entirely. Key prefixing is no
 
 Key prefixing is now opt-in via middleware plugins. Available plugins:
 
-| Component       | Plugin                     | Import path                              |
-| --------------- | -------------------------- | ---------------------------------------- |
-| cache           | `withCachePrefix`          | `@daiso-tech/core/cache/plugins`         |
+| Component       | Plugin                     | Import path                                |
+| --------------- | -------------------------- | ------------------------------------------ |
+| cache           | `withCachePrefix`          | `@daiso-tech/core/cache/plugins`           |
 | circuit-breaker | `withCircuitBreakerPrefix` | `@daiso-tech/core/circuit-breaker/plugins` |
-| file-storage    | `withFileStoragePrefix`    | `@daiso-tech/core/file-storage/plugins`  |
-| lock            | `withLockPrefix`           | `@daiso-tech/core/lock/plugins`          |
-| rate-limiter    | `withRateLimiterPrefix`    | `@daiso-tech/core/rate-limiter/plugins`  |
-| semaphore       | `withSemaphorePrefix`      | `@daiso-tech/core/semaphore/plugins`     |
-| shared-lock     | `withSharedLockPrefix`    | `@daiso-tech/core/shared-lock/plugins`   |
-| event-bus       | `withEventBusPrefix`       | `@daiso-tech/core/event-bus/plugins`     |
+| file-storage    | `withFileStoragePrefix`    | `@daiso-tech/core/file-storage/plugins`    |
+| lock            | `withLockPrefix`           | `@daiso-tech/core/lock/plugins`            |
+| rate-limiter    | `withRateLimiterPrefix`    | `@daiso-tech/core/rate-limiter/plugins`    |
+| semaphore       | `withSemaphorePrefix`      | `@daiso-tech/core/semaphore/plugins`       |
+| shared-lock     | `withSharedLockPrefix`     | `@daiso-tech/core/shared-lock/plugins`     |
+| event-bus       | `withEventBusPrefix`       | `@daiso-tech/core/event-bus/plugins`       |
 
 ```ts
 import { withPlugin } from "@daiso-tech/core/middleware";
 import { withCachePrefix } from "@daiso-tech/core/cache/plugins";
 
-const adapter = withPlugin(new MemoryCacheAdapter(), withCachePrefix("tenant-42:"));
+const adapter = withPlugin(
+    new MemoryCacheAdapter(),
+    withCachePrefix("tenant-42:"),
+);
 
 // Keys are automatically prefixed:
 await adapter.add(context, "my-key", "value");

--- a/.changeset/with-prefix-plugins.md
+++ b/.changeset/with-prefix-plugins.md
@@ -2,16 +2,24 @@
 "@daiso-tech/core": minor
 ---
 
-Refactored the built-in namespacing system into opt-in `with*Prefix` plugins across all affected components. The `@daiso-tech/core/namespace` module (`INamespace`, `IKey`, `Namespace` class, `NoOpNamespace` class) has been removed. Key management is now simplified to plain strings, and prefixing is handled via middleware plugins when needed.
+## Architectural Shift: Composable `with*Prefix` Plugins
 
-### What changed
+The built-in namespacing system has been refactored into opt-in `with*Prefix` plugins across all affected components. The `@daiso-tech/core/namespace` module has been removed entirely. Key management is now simplified to plain strings, and prefixing is handled via middleware plugins when needed.
 
-**Removed `@daiso-tech/core/namespace` module** — The following are no longer available:
+### Motivation
 
-- `INamespace` contract — factory interface for creating namespaced keys
-- `IKey` interface — hierarchically-organized key with namespace awareness
-- `Namespace` class — configurable namespace with delimiter and root identifier support
-- `NoOpNamespace` class — namespace that passes keys through unchanged
+The previous namespace system (`INamespace`, `IKey`, `Namespace` class) added unnecessary complexity for what is fundamentally a string-prefixing concern. Every component had to carry namespace configuration through its settings, and keys were wrapped in `IKey` objects instead of plain strings. This made the API harder to use and increased bundle size for users who didn't need namespacing.
+
+The new approach removes the namespace abstraction entirely. Key prefixing is now an opt-in `PluginFn` applied directly to the adapter, keeping the core components simple and the API surface clean.
+
+### Breaking Changes
+
+**Removed `@daiso-tech/core/namespace` module:**
+
+- `INamespace` contract
+- `IKey` interface
+- `Namespace` class
+- `NoOpNamespace` class
 
 **Removed `namespace` setting** from component constructors:
 
@@ -22,42 +30,44 @@ Refactored the built-in namespacing system into opt-in `with*Prefix` plugins acr
 
 **Simplified key types** across all components:
 
-- Method parameters changed from `IKey` to `string`
-- `removeMany(keys: Iterable<string>)` → `removeMany(keys: Array<string>)`
+- All method parameters changed from `IKey` to `string`
+- `removeMany(keys: Iterable<string>)` changed to `removeMany(keys: Array<string>)`
 - Error classes (`KeyNotFoundCacheError`, `KeyExistsCacheError`, etc.) now accept `string` instead of `IKey`
 - `ILockState.key` changed from `IKey` to `string`
 
-### Replacement: `with*Prefix` plugins
+### New Plugin-Based Capabilities
 
 Key prefixing is now opt-in via middleware plugins. Available plugins:
 
-| Component       | Plugin                     |
-| --------------- | -------------------------- |
-| cache           | `withCachePrefix`          |
-| circuit-breaker | `withCircuitBreakerPrefix` |
-| file-storage    | `withFileStoragePrefix`    |
-| lock            | `withLockPrefix`           |
-| rate-limiter    | `withRateLimiterPrefix`    |
-| semaphore       | `withSemaphorePrefix`      |
-| shared-lock     | `withSharedLockPrefix`     |
-
-### Usage
+| Component       | Plugin                     | Import path                              |
+| --------------- | -------------------------- | ---------------------------------------- |
+| cache           | `withCachePrefix`          | `@daiso-tech/core/cache/plugins`         |
+| circuit-breaker | `withCircuitBreakerPrefix` | `@daiso-tech/core/circuit-breaker/plugins` |
+| file-storage    | `withFileStoragePrefix`    | `@daiso-tech/core/file-storage/plugins`  |
+| lock            | `withLockPrefix`           | `@daiso-tech/core/lock/plugins`          |
+| rate-limiter    | `withRateLimiterPrefix`    | `@daiso-tech/core/rate-limiter/plugins`  |
+| semaphore       | `withSemaphorePrefix`      | `@daiso-tech/core/semaphore/plugins`     |
+| shared-lock     | `withSharedLockPrefix`    | `@daiso-tech/core/shared-lock/plugins`   |
+| event-bus       | `withEventBusPrefix`       | `@daiso-tech/core/event-bus/plugins`     |
 
 ```ts
 import { withPlugin } from "@daiso-tech/core/middleware";
 import { withCachePrefix } from "@daiso-tech/core/cache/plugins";
 
-const adapter = new MemoryCacheAdapter();
-const prefixedAdapter = withPlugin(adapter, withCachePrefix("tenant-42:"));
+const adapter = withPlugin(new MemoryCacheAdapter(), withCachePrefix("tenant-42:"));
 
 // Keys are automatically prefixed:
-await prefixedAdapter.add(context, "my-key", "value");
+await adapter.add(context, "my-key", "value");
 // Internally calls adapter.add(context, "tenant-42:my-key", "value")
 ```
 
+### How the New Architecture Works
+
+Instead of passing a `Namespace` instance to the component constructor, prefixing is now applied at the adapter level. The `with*Prefix` plugin intercepts key-related method calls and prepends the configured prefix before forwarding to the underlying adapter. This keeps components adapter-agnostic and makes prefixing composable with other plugins.
+
 ### Migration
 
-**If you used `Namespace` directly** — replace with a `with*Prefix` plugin on the adapter:
+**If you used `Namespace` directly**, replace with a `with*Prefix` plugin on the adapter:
 
 ```diff
 -import { Cache, Namespace } from "@daiso-tech/core";
@@ -74,13 +84,6 @@ await prefixedAdapter.add(context, "my-key", "value");
 +const cache = new Cache({ adapter });
 ```
 
-**If you imported `INamespace` or `IKey` types** — update to use plain `string` instead.
+**If you imported `INamespace` or `IKey` types**, update to use plain `string` instead.
 
-**If you were using `NoOpNamespace`** — simply omit the `namespace` setting (it was the default).
-
-### Use cases
-
-- **Multi-tenant systems** — Prefix keys with a tenant identifier to isolate data
-- **Environment isolation** — Separate dev, staging, and production data
-- **Versioning** — Prefix keys with a schema version
-- **Module scoping** — Organize keys by feature to avoid collisions
+**If you were using `NoOpNamespace`**, simply omit the `namespace` setting (it was the default).


### PR DESCRIPTION
- Apply consistent section ordering: Motivation → Breaking Changes → New Features → Migration
- Add missing Motivation sections to all changesets
- Standardize heading hierarchy and terminology
- Fix with-prefix-plugins table (duplicated shared-lock row, missing event-bus row)
- Trim implementation details from cache-plugins (source paths, test notes)
- Add structured Breaking Changes and Migration sections to update-file-storage
- Remove colons from section headings for uniformity
- Add before/after code examples where applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Cache validation, locking, jittering, event-bus validation, and key prefixing are now opt-in adapter plugins.
  * Removed legacy database transaction-based adapter contracts and related wrapper types.
  * Cache write settings now use inline TTL values.
  * Replaced Node.js-specific file methods with portable byte and stream methods.
  * Removed built-in file-storage locking; use the file-storage lock plugin instead.

* **Migration**
  * Updated guidance and examples explain how to compose plugins and migrate custom adapters to the simplified contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->