### PR TITLE
enhacement/shared lock update

### DIFF
--- a/src/shared-lock/contracts/shared-lock-adapter.contract.ts
+++ b/src/shared-lock/contracts/shared-lock-adapter.contract.ts
@@ -116,32 +116,34 @@ export type ISharedLockAdapter = {
      * Attempts to acquire a writer lock for the specified key.
      * Succeeds only if no non-expired writer lock exists and no non-expired reader slots are held.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the shared lock
      * @param lockId - Unique identifier for this acquirer (becomes the owner)
      * @param ttl - Time-to-live duration or null for indefinite locks
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise resolving to true if the writer lock was successfully acquired, false if already held by another owner
      */
     acquireWriter(
-        context: IReadableContext,
         key: string,
         lockId: string,
         ttl: TimeSpan | null,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
      * Releases a writer lock if owned by the specified lockId.
      * Ownership verification prevents accidental release of locks held by others.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the shared lock
      * @param lockId - Unique identifier of the lock owner
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise resolving to true if the writer lock was successfully released, false if not owned by lockId or doesn't exist
      */
     releaseWriter(
-        context: IReadableContext,
         key: string,
         lockId: string,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
@@ -149,30 +151,32 @@ export type ISharedLockAdapter = {
      * Used for emergency lock release or administrative cleanup.
      * Bypasses ownership verification for situations where the owner is unavailable.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the shared lock
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise resolving to true if the writer lock existed and was released, false if the lock is already expired
      */
     forceReleaseWriter(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
      * Refreshes (extends) the time-to-live of an existing writer lock.
      * Only succeeds if all conditions are met: ownership matches, lock hasn't expired, and it's expirable.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the shared lock
      * @param lockId - Unique identifier of the lock owner
      * @param ttl - New time-to-live duration to set
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise resolving to true if refresh succeeded, false if the lock is unexpirable, expired, or not owned by lockId
      */
     refreshWriter(
-        context: IReadableContext,
         key: string,
         lockId: string,
         ttl: TimeSpan,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
@@ -180,6 +184,7 @@ export type ISharedLockAdapter = {
      * Succeeds only if no non-expired writer lock is held and the current number of acquired reader slots has not reached the limit.
      *
      * @param settings - Settings containing the context, key, lockId, limit, and ttl for the acquisition
+     *
      * @returns Promise resolving to true if the reader slot was successfully acquired, false if the slot limit has been reached
      */
     acquireReader(settings: SharedLockAcquireSettings): Promise<boolean>;
@@ -188,15 +193,16 @@ export type ISharedLockAdapter = {
      * Releases a specific reader slot if it is currently acquired.
      * Only the holder of the slot (identified by slotId) can release it.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the shared lock
      * @param slotId - Unique identifier of the reader slot to release
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise resolving to true if the reader slot was successfully released, false if the slot doesn't exist or is already released
      */
     releaseReader(
-        context: IReadableContext,
         key: string,
         slotId: string,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
@@ -204,51 +210,55 @@ export type ISharedLockAdapter = {
      * Used for emergency cleanup or administrative operations.
      * Bypasses ownership verification for situations where individual slot holders are unavailable.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the shared lock
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise resolving to true if reader slots existed and were released, false if no reader slots are acquired
      */
     forceReleaseAllReaders(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
      * Refreshes (extends) the time-to-live of an existing reader slot.
      * Only succeeds if all conditions are met: the slot exists, hasn't expired, and is expirable.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the shared lock
      * @param slotId - Unique identifier of the reader slot to refresh
      * @param ttl - New time-to-live duration to set
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise resolving to true if refresh succeeded, false if the slot is unexpirable, expired, or doesn't exist
      */
     refreshReader(
-        context: IReadableContext,
         key: string,
         slotId: string,
         ttl: TimeSpan,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
      * Forcibly releases both the writer lock and all reader slots regardless of ownership.
      * Used for complete emergency cleanup of the shared lock.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the shared lock
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise resolving to true if the shared lock existed and was fully released, false if the shared lock doesn't exist
      */
-    forceRelease(context: IReadableContext, key: string): Promise<boolean>;
+    forceRelease(key: string, context: IReadableContext): Promise<boolean>;
 
     /**
      * Retrieves the current state of a shared lock.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the shared lock
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise resolving to the non-expired shared lock state if it exists; otherwise null for missing or expired shared locks
      */
     getState(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<ISharedLockAdapterState | null>;
 };

--- a/src/shared-lock/implementations/adapters/kysely-shared-lock-adapter/kysely-shared-lock-adapter.ts
+++ b/src/shared-lock/implementations/adapters/kysely-shared-lock-adapter/kysely-shared-lock-adapter.ts
@@ -364,10 +364,10 @@ export class KyselySharedLockAdapter
     }
 
     async acquireWriter(
-        _context: IReadableContext,
         key: string,
         lockId: string,
         ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return await this._transaction(async (trx) => {
             // Check if a non-expired writer lock exists held by a different owner
@@ -435,9 +435,9 @@ export class KyselySharedLockAdapter
     }
 
     async releaseWriter(
-        _context: IReadableContext,
         key: string,
         lockId: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         if (this.isMysql) {
             return await this._transaction(async (trx) => {
@@ -493,8 +493,8 @@ export class KyselySharedLockAdapter
     }
 
     async forceReleaseWriter(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         if (this.isMysql) {
             return await this._transaction(async (trx) => {
@@ -547,10 +547,10 @@ export class KyselySharedLockAdapter
     }
 
     async refreshWriter(
-        _context: IReadableContext,
         key: string,
         lockId: string,
         ttl: TimeSpan,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const expiration = ttl.toEndDate().getTime();
         const result = await this.kysely
@@ -703,9 +703,9 @@ export class KyselySharedLockAdapter
     }
 
     async releaseReader(
-        _context: IReadableContext,
         key: string,
         slotId: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         if (this.isMysql) {
             return await this._transaction(async (trx) => {
@@ -761,8 +761,8 @@ export class KyselySharedLockAdapter
     }
 
     async forceReleaseAllReaders(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         if (this.isMysql) {
             return await this._transaction(async (trx) => {
@@ -815,10 +815,10 @@ export class KyselySharedLockAdapter
     }
 
     async refreshReader(
-        _context: IReadableContext,
         key: string,
         slotId: string,
         ttl: TimeSpan,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const expiration = ttl.toEndDate().getTime();
         const result = await this.kysely
@@ -944,8 +944,8 @@ export class KyselySharedLockAdapter
     }
 
     async forceRelease(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const writerReleased = await this.deleteNonExpiredWriter(key);
         const readerReleased = await this.deleteNonExpiredReaderSlots(key);
@@ -1031,8 +1031,8 @@ export class KyselySharedLockAdapter
     }
 
     async getState(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<ISharedLockAdapterState | null> {
         const [writer, reader] = await Promise.all([
             this.getWriterState(key),

--- a/src/shared-lock/implementations/adapters/memory-shared-lock-adapter/memory-shared-lock-adapter.test.ts
+++ b/src/shared-lock/implementations/adapters/memory-shared-lock-adapter/memory-shared-lock-adapter.test.ts
@@ -29,19 +29,19 @@ describe("class: MemorySharedLockAdapter", () => {
     });
     describe("method: deInit", () => {
         test("Should clear map", async () => {
-            await adapter.acquireWriter(noOpContext, "a", "1", null);
+            await adapter.acquireWriter("a", "1", null, noOpContext);
             await adapter.acquireWriter(
-                noOpContext,
                 "a",
                 "2",
                 TimeSpan.fromMilliseconds(100),
-            );
-            await adapter.acquireWriter(noOpContext, "b", "1", null);
-            await adapter.acquireWriter(
                 noOpContext,
+            );
+            await adapter.acquireWriter("b", "1", null, noOpContext);
+            await adapter.acquireWriter(
                 "b",
                 "2",
                 TimeSpan.fromMilliseconds(100),
+                noOpContext,
             );
 
             await adapter.acquireReader({

--- a/src/shared-lock/implementations/adapters/memory-shared-lock-adapter/memory-shared-lock-adapter.ts
+++ b/src/shared-lock/implementations/adapters/memory-shared-lock-adapter/memory-shared-lock-adapter.ts
@@ -115,10 +115,10 @@ export class MemorySharedLockAdapter
     }
 
     async acquireWriter(
-        _context: IReadableContext,
         key: string,
         lockId: string,
         ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const sharedLock = this.map.get(key);
         const readerSemaphore = sharedLock?.readerSemaphore ?? null;
@@ -160,9 +160,9 @@ export class MemorySharedLockAdapter
     }
 
     async releaseWriter(
-        _context: IReadableContext,
         key: string,
         lockId: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const sharedLock = this.map.get(key);
         const readerSemaphore = sharedLock?.readerSemaphore ?? null;
@@ -190,9 +190,9 @@ export class MemorySharedLockAdapter
         return Promise.resolve(true);
     }
 
-    async forceReleaseWriter(
-        _context: IReadableContext,
+    private async _forceReleaseWriter(
         key: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const sharedLock = this.map.get(key);
         const readerSemaphore = sharedLock?.readerSemaphore ?? null;
@@ -218,11 +218,18 @@ export class MemorySharedLockAdapter
         return Promise.resolve(true);
     }
 
+    forceReleaseWriter(
+        key: string,
+        context: IReadableContext,
+    ): Promise<boolean> {
+        return this._forceReleaseWriter(key, context);
+    }
+
     async refreshWriter(
-        _context: IReadableContext,
         key: string,
         lockId: string,
         ttl: TimeSpan,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const sharedLock = this.map.get(key);
         const readerSemaphore = sharedLock?.readerSemaphore ?? null;
@@ -313,9 +320,9 @@ export class MemorySharedLockAdapter
     }
 
     async releaseReader(
-        _context: IReadableContext,
         key: string,
         lockId: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const sharedLock = this.map.get(key);
         const writerLock = sharedLock?.writerLock ?? null;
@@ -354,9 +361,9 @@ export class MemorySharedLockAdapter
         return Promise.resolve(true);
     }
 
-    async forceReleaseAllReaders(
-        _context: IReadableContext,
+    private async _forceReleaseAllReaders(
         key: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const sharedLock = this.map.get(key);
         const writerLock = sharedLock?.writerLock ?? null;
@@ -381,11 +388,18 @@ export class MemorySharedLockAdapter
         return Promise.resolve(hasSlots);
     }
 
+    forceReleaseAllReaders(
+        key: string,
+        context: IReadableContext,
+    ): Promise<boolean> {
+        return this._forceReleaseAllReaders(key, context);
+    }
+
     async refreshReader(
-        _context: IReadableContext,
         key: string,
         lockId: string,
         ttl: TimeSpan,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const sharedLock = this.map.get(key);
         const writerLock = sharedLock?.writerLock ?? null;
@@ -431,14 +445,14 @@ export class MemorySharedLockAdapter
     }
 
     async forceRelease(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<boolean> {
-        const hasReleasedAllReaders = await this.forceReleaseAllReaders(
-            context,
+        const hasReleasedAllReaders = await this._forceReleaseAllReaders(
             key,
+            context,
         );
-        const hasReleasedWriter = await this.forceReleaseWriter(context, key);
+        const hasReleasedWriter = await this._forceReleaseWriter(key, context);
         return hasReleasedAllReaders || hasReleasedWriter;
     }
 
@@ -535,8 +549,8 @@ export class MemorySharedLockAdapter
     }
 
     async getState(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<ISharedLockAdapterState | null> {
         const sharedLock = this.map.get(key);
 

--- a/src/shared-lock/implementations/adapters/mongodb-shared-lock-adapter/mongodb-shared-lock-adapter.test.ts
+++ b/src/shared-lock/implementations/adapters/mongodb-shared-lock-adapter/mongodb-shared-lock-adapter.test.ts
@@ -115,7 +115,7 @@ describe("class: MongodbSharedLockAdapter", () => {
             const lockId = "1";
             const ttl = null;
 
-            await adapter.acquireWriter(noOpContext, key, lockId, ttl);
+            await adapter.acquireWriter(key, lockId, ttl, noOpContext);
 
             const doc = await collection.findOne({
                 key,
@@ -143,7 +143,7 @@ describe("class: MongodbSharedLockAdapter", () => {
             const ttl = TimeSpan.fromMinutes(5);
             const expiration = ttl.toEndDate();
 
-            await adapter.acquireWriter(noOpContext, key, lockId, ttl);
+            await adapter.acquireWriter(key, lockId, ttl, noOpContext);
 
             const doc = await collection.findOne({
                 key,
@@ -419,8 +419,8 @@ describe("class: MongodbSharedLockAdapter", () => {
                 limit,
             });
 
-            await adapter.releaseReader(noOpContext, key, lockId1);
-            await adapter.releaseReader(noOpContext, key, lockId2);
+            await adapter.releaseReader(key, lockId1, noOpContext);
+            await adapter.releaseReader(key, lockId2, noOpContext);
 
             const doc = await collection.findOne({ key });
             expect(doc?.expiration?.getTime()).toBeLessThan(Date.now());

--- a/src/shared-lock/implementations/adapters/mongodb-shared-lock-adapter/mongodb-shared-lock-adapter.ts
+++ b/src/shared-lock/implementations/adapters/mongodb-shared-lock-adapter/mongodb-shared-lock-adapter.ts
@@ -268,10 +268,10 @@ export class MongodbSharedLockAdapter
     }
 
     async acquireWriter(
-        _context: IReadableContext,
         key: string,
         lockId: string,
         ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const expiration = ttl?.toEndDate() ?? null;
         const isExpiredQuery = {
@@ -365,9 +365,9 @@ export class MongodbSharedLockAdapter
     }
 
     async releaseWriter(
-        _context: IReadableContext,
         key: string,
         lockId: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const isWriterActive = {
             writer: {
@@ -427,8 +427,8 @@ export class MongodbSharedLockAdapter
     }
 
     async forceReleaseWriter(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const sharedLock = await this.collection.findOneAndDelete(
             {
@@ -469,10 +469,10 @@ export class MongodbSharedLockAdapter
     }
 
     async refreshWriter(
-        _context: IReadableContext,
         key: string,
         lockId: string,
         ttl: TimeSpan,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const isUnexpiredQuery = {
             $and: [
@@ -753,9 +753,9 @@ export class MongodbSharedLockAdapter
     }
 
     async releaseReader(
-        _context: IReadableContext,
         key: string,
         slotId: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const sharedLock = await this.collection.findOneAndUpdate(
             {
@@ -819,8 +819,8 @@ export class MongodbSharedLockAdapter
     }
 
     async forceReleaseAllReaders(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const sharedLock = await this.collection.findOneAndDelete(
             {
@@ -861,10 +861,10 @@ export class MongodbSharedLockAdapter
     }
 
     async refreshReader(
-        _context: IReadableContext,
         key: string,
         slotId: string,
         ttl: TimeSpan,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const isExpireableQuery = {
             $ne: ["$$slot.expiration", null],
@@ -944,8 +944,8 @@ export class MongodbSharedLockAdapter
     }
 
     async forceRelease(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const sharedLock = await this.collection.findOneAndDelete({
             key,
@@ -1046,8 +1046,8 @@ export class MongodbSharedLockAdapter
     }
 
     async getState(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<ISharedLockAdapterState | null> {
         const sharedLock = await this.collection.findOne(
             { key },

--- a/src/shared-lock/implementations/adapters/no-op-shared-lock-adapter/no-op-shared-lock-adapter.ts
+++ b/src/shared-lock/implementations/adapters/no-op-shared-lock-adapter/no-op-shared-lock-adapter.ts
@@ -20,34 +20,34 @@ import { type TimeSpan } from "@/time-span/implementations/_module.js";
  */
 export class NoOpSharedLockAdapter implements ISharedLockAdapter {
     acquireWriter(
-        _context: IReadableContext,
         _key: string,
         _lockId: string,
         _ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     releaseWriter(
-        _context: IReadableContext,
         _key: string,
         _lockId: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     forceReleaseWriter(
-        _context: IReadableContext,
         _key: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     refreshWriter(
-        _context: IReadableContext,
         _key: string,
         _lockId: string,
         _ttl: TimeSpan,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
@@ -57,36 +57,36 @@ export class NoOpSharedLockAdapter implements ISharedLockAdapter {
     }
 
     releaseReader(
-        _context: IReadableContext,
         _key: string,
         _lockId: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     forceReleaseAllReaders(
-        _context: IReadableContext,
         _key: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     refreshReader(
-        _context: IReadableContext,
         _key: string,
         _lockId: string,
         _ttl: TimeSpan,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
-    forceRelease(_context: IReadableContext, _key: string): Promise<boolean> {
+    forceRelease(_key: string, _context: IReadableContext): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     getState(
-        _context: IReadableContext,
         _key: string,
+        _context: IReadableContext,
     ): Promise<ISharedLockAdapterState | null> {
         return Promise.resolve(null);
     }

--- a/src/shared-lock/implementations/adapters/redis-shared-lock-adapter/redis-shared-lock-adapter.ts
+++ b/src/shared-lock/implementations/adapters/redis-shared-lock-adapter/redis-shared-lock-adapter.ts
@@ -732,10 +732,10 @@ export class RedisSharedLockAdapter implements ISharedLockAdapter {
     }
 
     async acquireWriter(
-        _context: IReadableContext,
         key: string,
         lockId: string,
         ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const result = await this.database.daiso_shared_lock_acquire_writer(
             key,
@@ -746,9 +746,9 @@ export class RedisSharedLockAdapter implements ISharedLockAdapter {
     }
 
     async releaseWriter(
-        _context: IReadableContext,
         key: string,
         lockId: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const result = await this.database.daiso_shared_lock_release_writer(
             key,
@@ -758,10 +758,10 @@ export class RedisSharedLockAdapter implements ISharedLockAdapter {
     }
 
     async refreshWriter(
-        _context: IReadableContext,
         key: string,
         lockId: string,
         ttl: TimeSpan,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const result = await this.database.daiso_shared_lock_refresh_writer(
             key,
@@ -772,8 +772,8 @@ export class RedisSharedLockAdapter implements ISharedLockAdapter {
     }
 
     async forceReleaseWriter(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const result =
             await this.database.daiso_shared_lock_force_release_writer(key);
@@ -793,9 +793,9 @@ export class RedisSharedLockAdapter implements ISharedLockAdapter {
     }
 
     async releaseReader(
-        _context: IReadableContext,
         key: string,
         lockId: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const result = await this.database.daiso_shared_lock_release_reader(
             key,
@@ -806,10 +806,10 @@ export class RedisSharedLockAdapter implements ISharedLockAdapter {
     }
 
     async refreshReader(
-        _context: IReadableContext,
         key: string,
         lockId: string,
         ttl: TimeSpan,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const result = await this.database.daiso_shared_lock_refresh_reader(
             key,
@@ -821,8 +821,8 @@ export class RedisSharedLockAdapter implements ISharedLockAdapter {
     }
 
     async forceReleaseAllReaders(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const result =
             await this.database.daiso_shared_lock_force_release_all_readers(
@@ -833,8 +833,8 @@ export class RedisSharedLockAdapter implements ISharedLockAdapter {
     }
 
     async forceRelease(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const result = await this.database.daiso_shared_lock_force_release(
             key,
@@ -844,8 +844,8 @@ export class RedisSharedLockAdapter implements ISharedLockAdapter {
     }
 
     async getState(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<ISharedLockAdapterState | null> {
         const json = JSON.parse(
             await this.database.daiso_shared_lock_get_state(key, Date.now()),

--- a/src/shared-lock/implementations/derivables/shared-lock-factory/shared-lock.ts
+++ b/src/shared-lock/implementations/derivables/shared-lock-factory/shared-lock.ts
@@ -124,7 +124,7 @@ export class SharedLock implements ISharedLock {
     async acquireReader(): Promise<boolean> {
         return await this.adapter.acquireReader({
             context: this.context,
-            key: this._key.toString(),
+            key: this._key,
             lockId: this.lockId,
             limit: this.limit,
             ttl: this._ttl,
@@ -140,9 +140,9 @@ export class SharedLock implements ISharedLock {
 
     async releaseReader(): Promise<boolean> {
         return await this.adapter.releaseReader(
-            this.context,
-            this._key.toString(),
+            this._key,
             this.lockId,
+            this.context,
         );
     }
 
@@ -158,8 +158,8 @@ export class SharedLock implements ISharedLock {
 
     async forceReleaseAllReaders(): Promise<boolean> {
         return await this.adapter.forceReleaseAllReaders(
+            this._key,
             this.context,
-            this._key.toString(),
         );
     }
 
@@ -167,10 +167,10 @@ export class SharedLock implements ISharedLock {
         ttl: ITimeSpan = this.defaultRefreshTime,
     ): Promise<boolean> {
         const hasRefreshed = await this.adapter.refreshReader(
-            this.context,
-            this._key.toString(),
+            this._key,
             this.lockId,
             TimeSpan.fromTimeSpan(ttl),
+            this.context,
         );
         if (hasRefreshed) {
             this._ttl = TimeSpan.fromTimeSpan(ttl);
@@ -201,10 +201,10 @@ export class SharedLock implements ISharedLock {
 
     async acquireWriter(): Promise<boolean> {
         return await this.adapter.acquireWriter(
-            this.context,
-            this._key.toString(),
+            this._key,
             this.lockId,
             this._ttl,
+            this.context,
         );
     }
 
@@ -217,9 +217,9 @@ export class SharedLock implements ISharedLock {
 
     async releaseWriter(): Promise<boolean> {
         return await this.adapter.releaseWriter(
-            this.context,
-            this._key.toString(),
+            this._key,
             this.lockId,
+            this.context,
         );
     }
 
@@ -231,20 +231,17 @@ export class SharedLock implements ISharedLock {
     }
 
     async forceReleaseWriter(): Promise<boolean> {
-        return await this.adapter.forceReleaseWriter(
-            this.context,
-            this._key.toString(),
-        );
+        return await this.adapter.forceReleaseWriter(this._key, this.context);
     }
 
     async refreshWriter(
         ttl: ITimeSpan = this.defaultRefreshTime,
     ): Promise<boolean> {
         const hasRefreshed = await this.adapter.refreshWriter(
-            this.context,
-            this._key.toString(),
+            this._key,
             this.lockId,
             TimeSpan.fromTimeSpan(ttl),
+            this.context,
         );
         if (hasRefreshed) {
             this._ttl = TimeSpan.fromTimeSpan(ttl);
@@ -272,10 +269,7 @@ export class SharedLock implements ISharedLock {
     }
 
     async forceRelease(): Promise<boolean> {
-        return await this.adapter.forceRelease(
-            this.context,
-            this._key.toString(),
-        );
+        return await this.adapter.forceRelease(this._key, this.context);
     }
 
     private extractWriterState(
@@ -352,10 +346,7 @@ export class SharedLock implements ISharedLock {
     }
 
     async getState(): Promise<ISharedLockState> {
-        const state = await this.adapter.getState(
-            this.context,
-            this._key.toString(),
-        );
+        const state = await this.adapter.getState(this._key, this.context);
         if (state === null) {
             return {
                 type: SHARED_LOCK_STATE.EXPIRED,

--- a/src/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.test.ts
+++ b/src/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.test.ts
@@ -4,6 +4,7 @@ import { Context } from "@/execution-context/implementations/derivables/executio
 import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enhance-factory.js";
 import { useFactory } from "@/middleware/implementations/use-factory/_module.js";
 import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
+import { type ISharedLockAdapter } from "@/shared-lock/contracts/_module.js";
 import { NoOpSharedLockAdapter } from "@/shared-lock/implementations/adapters/_module.js";
 import { withSharedLockPrefix } from "@/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.js";
 import { TimeSpan } from "@/time-span/implementations/_module.js";
@@ -24,10 +25,12 @@ describe("function: withSharedLockPrefix", () => {
 
             const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
-            await enhanced.forceRelease(context, "myKey");
+            await enhanced.forceRelease("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISharedLockAdapter["forceRelease"]>
+            >(`${prefix}myKey`, context);
         });
     });
 
@@ -38,10 +41,12 @@ describe("function: withSharedLockPrefix", () => {
 
             const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
-            await enhanced.getState(context, "myKey");
+            await enhanced.getState("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISharedLockAdapter["getState"]>
+            >(`${prefix}myKey`, context);
         });
     });
 
@@ -53,19 +58,16 @@ describe("function: withSharedLockPrefix", () => {
             const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
             await enhanced.acquireWriter(
-                context,
                 "myKey",
                 "lockId",
                 TimeSpan.fromSeconds(30),
+                context,
             );
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(
-                context,
-                `${prefix}myKey`,
-                "lockId",
-                TimeSpan.fromSeconds(30),
-            );
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISharedLockAdapter["acquireWriter"]>
+            >(`${prefix}myKey`, "lockId", TimeSpan.fromSeconds(30), context);
         });
     });
 
@@ -76,10 +78,12 @@ describe("function: withSharedLockPrefix", () => {
 
             const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
-            await enhanced.forceReleaseWriter(context, "myKey");
+            await enhanced.forceReleaseWriter("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISharedLockAdapter["forceReleaseWriter"]>
+            >(`${prefix}myKey`, context);
         });
     });
 
@@ -91,19 +95,16 @@ describe("function: withSharedLockPrefix", () => {
             const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
             await enhanced.refreshWriter(
-                context,
                 "myKey",
                 "lockId",
                 TimeSpan.fromSeconds(30),
+                context,
             );
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(
-                context,
-                `${prefix}myKey`,
-                "lockId",
-                TimeSpan.fromSeconds(30),
-            );
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISharedLockAdapter["refreshWriter"]>
+            >(`${prefix}myKey`, "lockId", TimeSpan.fromSeconds(30), context);
         });
     });
 
@@ -114,14 +115,12 @@ describe("function: withSharedLockPrefix", () => {
 
             const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
-            await enhanced.releaseWriter(context, "myKey", "lockId");
+            await enhanced.releaseWriter("myKey", "lockId", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(
-                context,
-                `${prefix}myKey`,
-                "lockId",
-            );
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISharedLockAdapter["releaseWriter"]>
+            >(`${prefix}myKey`, "lockId", context);
         });
     });
 
@@ -141,7 +140,9 @@ describe("function: withSharedLockPrefix", () => {
             });
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith({
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISharedLockAdapter["acquireReader"]>
+            >({
                 context,
                 key: `${prefix}myKey`,
                 lockId: "lock1",
@@ -158,10 +159,12 @@ describe("function: withSharedLockPrefix", () => {
 
             const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
-            await enhanced.forceReleaseAllReaders(context, "myKey");
+            await enhanced.forceReleaseAllReaders("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISharedLockAdapter["forceReleaseAllReaders"]>
+            >(`${prefix}myKey`, context);
         });
     });
 
@@ -173,19 +176,16 @@ describe("function: withSharedLockPrefix", () => {
             const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
             await enhanced.refreshReader(
-                context,
                 "myKey",
                 "lockId",
                 TimeSpan.fromSeconds(30),
+                context,
             );
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(
-                context,
-                `${prefix}myKey`,
-                "lockId",
-                TimeSpan.fromSeconds(30),
-            );
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISharedLockAdapter["refreshReader"]>
+            >(`${prefix}myKey`, "lockId", TimeSpan.fromSeconds(30), context);
         });
     });
 
@@ -196,14 +196,12 @@ describe("function: withSharedLockPrefix", () => {
 
             const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
-            await enhanced.releaseReader(context, "myKey", "lockId");
+            await enhanced.releaseReader("myKey", "lockId", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(
-                context,
-                `${prefix}myKey`,
-                "lockId",
-            );
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISharedLockAdapter["releaseReader"]>
+            >(`${prefix}myKey`, "lockId", context);
         });
     });
 });

--- a/src/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.ts
+++ b/src/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.ts
@@ -26,49 +26,36 @@ export function withSharedLockPrefix(
         return prefix + key;
     }
     return (adapter, enhance) => {
-        enhance(adapter, "forceRelease", ({ args: [context, key], next }) => {
-            return next([context, withPrefix(key)]);
+        enhance(adapter, "forceRelease", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
         });
-        enhance(adapter, "getState", ({ args: [context, key], next }) => {
-            return next([context, withPrefix(key)]);
+        enhance(adapter, "getState", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
         });
 
-        enhance(
-            adapter,
-            "acquireWriter",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
-            },
-        );
+        enhance(adapter, "acquireWriter", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
+        });
         enhance(
             adapter,
             "forceReleaseWriter",
-            ({ args: [context, key], next }) => {
-                return next([context, withPrefix(key)]);
+            ({ args: [key, ...rest], next }) => {
+                return next([withPrefix(key), ...rest]);
             },
         );
-        enhance(
-            adapter,
-            "refreshWriter",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
-            },
-        );
-        enhance(
-            adapter,
-            "releaseWriter",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
-            },
-        );
+        enhance(adapter, "refreshWriter", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
+        });
+        enhance(adapter, "releaseWriter", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
+        });
 
         enhance(
             adapter,
             "acquireReader",
-            ({ args: [{ context, key, ...rest }], next }) => {
+            ({ args: [{ key, ...rest }], next }) => {
                 return next([
                     {
-                        context,
                         key: withPrefix(key),
                         ...rest,
                     },
@@ -78,23 +65,15 @@ export function withSharedLockPrefix(
         enhance(
             adapter,
             "forceReleaseAllReaders",
-            ({ args: [context, key], next }) => {
-                return next([context, withPrefix(key)]);
+            ({ args: [key, ...rest], next }) => {
+                return next([withPrefix(key), ...rest]);
             },
         );
-        enhance(
-            adapter,
-            "refreshReader",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
-            },
-        );
-        enhance(
-            adapter,
-            "releaseReader",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
-            },
-        );
+        enhance(adapter, "refreshReader", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
+        });
+        enhance(adapter, "releaseReader", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
+        });
     };
 }

--- a/src/shared-lock/implementations/test-utilities/shared-lock-adapter.test-suite.ts
+++ b/src/shared-lock/implementations/test-utilities/shared-lock-adapter.test-suite.ts
@@ -122,10 +122,10 @@ export function sharedLockAdapterTestSuite(
                 const ttl = null;
 
                 const result = await adapter.acquireWriter(
-                    context,
                     key,
                     sharedLockId,
                     ttl,
+                    context,
                 );
 
                 expect(result).toBe(true);
@@ -135,14 +135,14 @@ export function sharedLockAdapterTestSuite(
                 const sharedLockId = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
 
-                await adapter.acquireWriter(context, key, sharedLockId, ttl);
+                await adapter.acquireWriter(key, sharedLockId, ttl, context);
                 await delayWithBuffer(ttl);
 
                 const result = await adapter.acquireWriter(
-                    context,
                     key,
                     sharedLockId,
                     null,
+                    context,
                 );
                 expect(result).toBe(true);
             });
@@ -151,12 +151,12 @@ export function sharedLockAdapterTestSuite(
                 const sharedLockId = "b";
                 const ttl = null;
 
-                await adapter.acquireWriter(context, key, sharedLockId, ttl);
+                await adapter.acquireWriter(key, sharedLockId, ttl, context);
                 const result = await adapter.acquireWriter(
-                    context,
                     key,
                     sharedLockId,
                     ttl,
+                    context,
                 );
 
                 expect(result).toBe(true);
@@ -166,12 +166,12 @@ export function sharedLockAdapterTestSuite(
                 const sharedLockId = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
 
-                await adapter.acquireWriter(context, key, sharedLockId, ttl);
+                await adapter.acquireWriter(key, sharedLockId, ttl, context);
                 const result = await adapter.acquireWriter(
-                    context,
                     key,
                     sharedLockId,
                     ttl,
+                    context,
                 );
 
                 expect(result).toBe(true);
@@ -181,13 +181,13 @@ export function sharedLockAdapterTestSuite(
                 const sharedLockId1 = "b";
                 const ttl = null;
 
-                await adapter.acquireWriter(context, key, sharedLockId1, ttl);
+                await adapter.acquireWriter(key, sharedLockId1, ttl, context);
                 const sharedLockId2 = "c";
                 const result = await adapter.acquireWriter(
-                    context,
                     key,
                     sharedLockId2,
                     ttl,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -197,13 +197,13 @@ export function sharedLockAdapterTestSuite(
                 const sharedLockId1 = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
 
-                await adapter.acquireWriter(context, key, sharedLockId1, ttl);
+                await adapter.acquireWriter(key, sharedLockId1, ttl, context);
                 const sharedLockId2 = "c";
                 const result = await adapter.acquireWriter(
-                    context,
                     key,
                     sharedLockId2,
                     ttl,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -215,18 +215,18 @@ export function sharedLockAdapterTestSuite(
                 const ttl = null;
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
                 });
 
                 const result = await adapter.acquireWriter(
-                    context,
                     key,
                     lockId,
                     ttl,
+                    context,
                 );
                 expect(result).toBe(false);
             });
@@ -237,16 +237,16 @@ export function sharedLockAdapterTestSuite(
                 const ttl = null;
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
                 });
 
-                await adapter.acquireWriter(context, key, lockId, ttl);
+                await adapter.acquireWriter(key, lockId, ttl, context);
 
-                const state = await adapter.getState(context, key);
+                const state = await adapter.getState(key, context);
 
                 expect({
                     ...state,
@@ -273,9 +273,9 @@ export function sharedLockAdapterTestSuite(
                 const sharedLockId = "b";
 
                 const result = await adapter.releaseWriter(
-                    context,
                     key,
                     sharedLockId,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -284,13 +284,13 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId1 = "b";
                 const ttl = null;
-                await adapter.acquireWriter(context, key, sharedLockId1, ttl);
+                await adapter.acquireWriter(key, sharedLockId1, ttl, context);
 
                 const sharedLockId2 = "c";
                 const result = await adapter.releaseWriter(
-                    context,
                     key,
                     sharedLockId2,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -299,13 +299,13 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId1 = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
-                await adapter.acquireWriter(context, key, sharedLockId1, ttl);
+                await adapter.acquireWriter(key, sharedLockId1, ttl, context);
 
                 const sharedLockId2 = "c";
                 const result = await adapter.releaseWriter(
-                    context,
                     key,
                     sharedLockId2,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -314,14 +314,14 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId1 = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
-                await adapter.acquireWriter(context, key, sharedLockId1, ttl);
+                await adapter.acquireWriter(key, sharedLockId1, ttl, context);
                 await delayWithBuffer(ttl);
 
                 const sharedLockId2 = "c";
                 const result = await adapter.releaseWriter(
-                    context,
                     key,
                     sharedLockId2,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -330,13 +330,13 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
-                await adapter.acquireWriter(context, key, sharedLockId, ttl);
+                await adapter.acquireWriter(key, sharedLockId, ttl, context);
                 await delayWithBuffer(ttl);
 
                 const result = await adapter.releaseWriter(
-                    context,
                     key,
                     sharedLockId,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -345,12 +345,12 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId = "b";
                 const ttl = null;
-                await adapter.acquireWriter(context, key, sharedLockId, ttl);
+                await adapter.acquireWriter(key, sharedLockId, ttl, context);
 
                 const result = await adapter.releaseWriter(
-                    context,
                     key,
                     sharedLockId,
+                    context,
                 );
 
                 expect(result).toBe(true);
@@ -359,12 +359,12 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
-                await adapter.acquireWriter(context, key, sharedLockId, ttl);
+                await adapter.acquireWriter(key, sharedLockId, ttl, context);
 
                 const result = await adapter.releaseWriter(
-                    context,
                     key,
                     sharedLockId,
+                    context,
                 );
 
                 expect(result).toBe(true);
@@ -373,15 +373,15 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId1 = "b";
                 const ttl = null;
-                await adapter.acquireWriter(context, key, sharedLockId1, ttl);
+                await adapter.acquireWriter(key, sharedLockId1, ttl, context);
                 const sharedLockId2 = "c";
 
-                await adapter.releaseWriter(context, key, sharedLockId2);
+                await adapter.releaseWriter(key, sharedLockId2, context);
                 const result = await adapter.acquireWriter(
-                    context,
                     key,
                     sharedLockId2,
                     ttl,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -390,15 +390,15 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId1 = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
-                await adapter.acquireWriter(context, key, sharedLockId1, ttl);
+                await adapter.acquireWriter(key, sharedLockId1, ttl, context);
 
                 const sharedLockId2 = "c";
-                await adapter.releaseWriter(context, key, sharedLockId2);
+                await adapter.releaseWriter(key, sharedLockId2, context);
                 const result = await adapter.acquireWriter(
-                    context,
                     key,
                     sharedLockId2,
                     ttl,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -407,15 +407,15 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId1 = "b";
                 const ttl = null;
-                await adapter.acquireWriter(context, key, sharedLockId1, ttl);
-                await adapter.releaseWriter(context, key, sharedLockId1);
+                await adapter.acquireWriter(key, sharedLockId1, ttl, context);
+                await adapter.releaseWriter(key, sharedLockId1, context);
 
                 const sharedLockId2 = "c";
                 const result = await adapter.acquireWriter(
-                    context,
                     key,
                     sharedLockId2,
                     ttl,
+                    context,
                 );
 
                 expect(result).toBe(true);
@@ -424,15 +424,15 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId1 = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
-                await adapter.acquireWriter(context, key, sharedLockId1, ttl);
-                await adapter.releaseWriter(context, key, sharedLockId1);
+                await adapter.acquireWriter(key, sharedLockId1, ttl, context);
+                await adapter.releaseWriter(key, sharedLockId1, context);
 
                 const sharedLockId2 = "c";
                 const result = await adapter.acquireWriter(
-                    context,
                     key,
                     sharedLockId2,
                     ttl,
+                    context,
                 );
 
                 expect(result).toBe(true);
@@ -444,17 +444,17 @@ export function sharedLockAdapterTestSuite(
                 const ttl = TimeSpan.fromSeconds(10);
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
                 });
 
                 const result = await adapter.releaseWriter(
-                    context,
                     key,
                     lockId,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -466,16 +466,16 @@ export function sharedLockAdapterTestSuite(
                 const ttl = null;
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
                 });
 
-                await adapter.releaseWriter(context, key, lockId);
+                await adapter.releaseWriter(key, lockId, context);
 
-                const state = await adapter.getState(context, key);
+                const state = await adapter.getState(key, context);
 
                 expect({
                     ...state,
@@ -500,7 +500,7 @@ export function sharedLockAdapterTestSuite(
             test("Should return false when key doesnt exists", async () => {
                 const key = "a";
 
-                const result = await adapter.forceReleaseWriter(context, key);
+                const result = await adapter.forceReleaseWriter(key, context);
 
                 expect(result).toBe(false);
             });
@@ -509,10 +509,10 @@ export function sharedLockAdapterTestSuite(
                 const sharedLockId = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
 
-                await adapter.acquireWriter(context, key, sharedLockId, ttl);
+                await adapter.acquireWriter(key, sharedLockId, ttl, context);
                 await delayWithBuffer(ttl);
 
-                const result = await adapter.forceReleaseWriter(context, key);
+                const result = await adapter.forceReleaseWriter(key, context);
 
                 expect(result).toBe(false);
             });
@@ -521,9 +521,9 @@ export function sharedLockAdapterTestSuite(
                 const sharedLockId = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
 
-                await adapter.acquireWriter(context, key, sharedLockId, ttl);
+                await adapter.acquireWriter(key, sharedLockId, ttl, context);
 
-                const result = await adapter.forceReleaseWriter(context, key);
+                const result = await adapter.forceReleaseWriter(key, context);
 
                 expect(result).toBe(true);
             });
@@ -532,9 +532,9 @@ export function sharedLockAdapterTestSuite(
                 const sharedLockId = "b";
                 const ttl = null;
 
-                await adapter.acquireWriter(context, key, sharedLockId, ttl);
+                await adapter.acquireWriter(key, sharedLockId, ttl, context);
 
-                const result = await adapter.forceReleaseWriter(context, key);
+                const result = await adapter.forceReleaseWriter(key, context);
 
                 expect(result).toBe(true);
             });
@@ -542,16 +542,16 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId1 = "b";
                 const ttl = null;
-                await adapter.acquireWriter(context, key, sharedLockId1, ttl);
+                await adapter.acquireWriter(key, sharedLockId1, ttl, context);
 
-                await adapter.forceReleaseWriter(context, key);
+                await adapter.forceReleaseWriter(key, context);
 
                 const sharedLockId2 = "c";
                 const result = await adapter.acquireWriter(
-                    context,
                     key,
                     sharedLockId2,
                     ttl,
+                    context,
                 );
                 expect(result).toBe(true);
             });
@@ -562,14 +562,14 @@ export function sharedLockAdapterTestSuite(
                 const ttl = TimeSpan.fromSeconds(10);
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
                 });
 
-                const result = await adapter.forceReleaseWriter(context, key);
+                const result = await adapter.forceReleaseWriter(key, context);
 
                 expect(result).toBe(false);
             });
@@ -580,16 +580,16 @@ export function sharedLockAdapterTestSuite(
                 const ttl = null;
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
                 });
 
-                await adapter.forceReleaseWriter(context, key);
+                await adapter.forceReleaseWriter(key, context);
 
-                const state = await adapter.getState(context, key);
+                const state = await adapter.getState(key, context);
 
                 expect({
                     ...state,
@@ -617,10 +617,10 @@ export function sharedLockAdapterTestSuite(
 
                 const newTtl = TimeSpan.fromMinutes(1);
                 const result = await adapter.refreshWriter(
-                    context,
                     key,
                     sharedLockId,
                     newTtl,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -629,15 +629,15 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId1 = "b";
                 const ttl = null;
-                await adapter.acquireWriter(context, key, sharedLockId1, ttl);
+                await adapter.acquireWriter(key, sharedLockId1, ttl, context);
 
                 const newTtl = TimeSpan.fromMinutes(1);
                 const sharedLockId2 = "c";
                 const result = await adapter.refreshWriter(
-                    context,
                     key,
                     sharedLockId2,
                     newTtl,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -646,15 +646,15 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId1 = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
-                await adapter.acquireWriter(context, key, sharedLockId1, ttl);
+                await adapter.acquireWriter(key, sharedLockId1, ttl, context);
 
                 const newTtl = TimeSpan.fromMinutes(1);
                 const sharedLockId2 = "c";
                 const result = await adapter.refreshWriter(
-                    context,
                     key,
                     sharedLockId2,
                     newTtl,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -663,16 +663,16 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId1 = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
-                await adapter.acquireWriter(context, key, sharedLockId1, ttl);
+                await adapter.acquireWriter(key, sharedLockId1, ttl, context);
                 await delayWithBuffer(ttl);
 
                 const newTtl = TimeSpan.fromMinutes(1);
                 const sharedLockId2 = "c";
                 const result = await adapter.refreshWriter(
-                    context,
                     key,
                     sharedLockId2,
                     newTtl,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -681,15 +681,15 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
-                await adapter.acquireWriter(context, key, sharedLockId, ttl);
+                await adapter.acquireWriter(key, sharedLockId, ttl, context);
                 await delayWithBuffer(ttl);
 
                 const newTtl = TimeSpan.fromMinutes(1);
                 const result = await adapter.refreshWriter(
-                    context,
                     key,
                     sharedLockId,
                     newTtl,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -698,14 +698,14 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId = "b";
                 const ttl = null;
-                await adapter.acquireWriter(context, key, sharedLockId, ttl);
+                await adapter.acquireWriter(key, sharedLockId, ttl, context);
 
                 const newTtl = TimeSpan.fromMinutes(1);
                 const result = await adapter.refreshWriter(
-                    context,
                     key,
                     sharedLockId,
                     newTtl,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -714,14 +714,14 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
-                await adapter.acquireWriter(context, key, sharedLockId, ttl);
+                await adapter.acquireWriter(key, sharedLockId, ttl, context);
 
                 const newTtl = TimeSpan.fromMinutes(1);
                 const result = await adapter.refreshWriter(
-                    context,
                     key,
                     sharedLockId,
                     newTtl,
+                    context,
                 );
 
                 expect(result).toBe(true);
@@ -730,22 +730,22 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId1 = "1";
                 const ttl = null;
-                await adapter.acquireWriter(context, key, sharedLockId1, ttl);
+                await adapter.acquireWriter(key, sharedLockId1, ttl, context);
 
                 const newTtl = TimeSpan.fromMilliseconds(50);
                 await adapter.refreshWriter(
-                    context,
                     key,
                     sharedLockId1,
                     newTtl,
+                    context,
                 );
                 await delayWithBuffer(newTtl);
                 const sharedLockId2 = "2";
                 const result = await adapter.acquireWriter(
-                    context,
                     key,
                     sharedLockId2,
                     ttl,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -754,32 +754,32 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId1 = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
-                await adapter.acquireWriter(context, key, sharedLockId1, ttl);
+                await adapter.acquireWriter(key, sharedLockId1, ttl, context);
 
                 const newTtl = TimeSpan.fromMilliseconds(100);
                 await adapter.refreshWriter(
-                    context,
                     key,
                     sharedLockId1,
                     newTtl,
+                    context,
                 );
                 await delayWithBuffer(newTtl.divide(2));
 
                 const sharedLockId2 = "c";
                 const result1 = await adapter.acquireWriter(
-                    context,
                     key,
                     sharedLockId2,
                     ttl,
+                    context,
                 );
                 expect(result1).toBe(false);
 
                 await delayWithBuffer(newTtl.divide(2));
                 const result2 = await adapter.acquireWriter(
-                    context,
                     key,
                     sharedLockId2,
                     ttl,
+                    context,
                 );
                 expect(result2).toBe(true);
             });
@@ -790,8 +790,8 @@ export function sharedLockAdapterTestSuite(
                 const ttl = TimeSpan.fromSeconds(10);
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
@@ -799,10 +799,10 @@ export function sharedLockAdapterTestSuite(
 
                 const newTtl = TimeSpan.fromSeconds(20);
                 const result = await adapter.refreshWriter(
-                    context,
                     key,
                     lockId,
                     newTtl,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -814,17 +814,17 @@ export function sharedLockAdapterTestSuite(
                 const ttl = null;
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
                 });
 
                 const newTtl = TimeSpan.fromSeconds(20);
-                await adapter.refreshWriter(context, key, lockId, newTtl);
+                await adapter.refreshWriter(key, lockId, newTtl, context);
 
-                const state = await adapter.getState(context, key);
+                const state = await adapter.getState(key, context);
 
                 expect({
                     ...state,
@@ -853,8 +853,8 @@ export function sharedLockAdapterTestSuite(
                 const ttl = null;
 
                 const result = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
@@ -869,8 +869,8 @@ export function sharedLockAdapterTestSuite(
                 const ttl = TimeSpan.fromMilliseconds(50);
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
@@ -878,8 +878,8 @@ export function sharedLockAdapterTestSuite(
                 await delayWithBuffer(ttl);
 
                 const result = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
@@ -894,16 +894,16 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId1 = "1";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     limit,
                     ttl,
                 });
                 const lockId2 = "2";
                 const result = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId2,
                     limit,
                     ttl,
@@ -918,24 +918,24 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId1 = "1";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     limit,
                     ttl,
                 });
                 const lockId2 = "2";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId2,
                     limit,
                     ttl,
                 });
                 const lockId3 = "3";
                 const result = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId3,
                     limit,
                     ttl,
@@ -950,8 +950,8 @@ export function sharedLockAdapterTestSuite(
                 const lockId1 = "1";
                 const ttl1 = null;
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     limit,
                     ttl: ttl1,
@@ -959,8 +959,8 @@ export function sharedLockAdapterTestSuite(
                 const lockId2 = "2";
                 const ttl2 = TimeSpan.fromMilliseconds(50);
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId2,
                     limit,
                     ttl: ttl2,
@@ -970,8 +970,8 @@ export function sharedLockAdapterTestSuite(
                 const lockId3 = "3";
                 const ttl3 = null;
                 const result = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId3,
                     limit,
                     ttl: ttl3,
@@ -986,15 +986,15 @@ export function sharedLockAdapterTestSuite(
                 const ttl = null;
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
                 });
                 const result = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
@@ -1009,15 +1009,15 @@ export function sharedLockAdapterTestSuite(
                 const ttl = TimeSpan.fromMilliseconds(50);
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
                 });
                 const result = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
@@ -1032,15 +1032,15 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId1 = "1";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     limit,
                     ttl,
                 });
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     limit,
                     ttl,
@@ -1048,8 +1048,8 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId2 = "2";
                 const result = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId2,
                     limit,
                     ttl,
@@ -1064,15 +1064,15 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId1 = "1";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     limit,
                     ttl,
                 });
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     limit,
                     ttl,
@@ -1080,8 +1080,8 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId2 = "2";
                 const result = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId2,
                     limit,
                     ttl,
@@ -1096,8 +1096,8 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId1 = "1";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     limit,
                     ttl,
@@ -1105,20 +1105,20 @@ export function sharedLockAdapterTestSuite(
                 const lockId2 = "2";
                 const newLimit = 3;
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId2,
                     limit: newLimit,
                     ttl,
                 });
                 const lockId3 = "3";
 
-                const result1 = await adapter.getState(context, key);
+                const result1 = await adapter.getState(key, context);
                 expect(result1?.reader?.limit).toBe(limit);
 
                 const result2 = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId3,
                     limit: newLimit,
                     ttl,
@@ -1129,12 +1129,12 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const lockId = "1";
                 const ttl = null;
-                await adapter.acquireWriter(context, key, lockId, ttl);
+                await adapter.acquireWriter(key, lockId, ttl, context);
 
                 const limit = 3;
                 const result = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     ttl,
                     limit,
@@ -1146,18 +1146,18 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const lockId = "1";
                 const ttl = null;
-                await adapter.acquireWriter(context, key, lockId, ttl);
+                await adapter.acquireWriter(key, lockId, ttl, context);
 
                 const limit = 3;
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     ttl,
                     limit,
                 });
 
-                const state = await adapter.getState(context, key);
+                const state = await adapter.getState(key, context);
 
                 expect(state).toEqual({
                     writer: {
@@ -1175,8 +1175,8 @@ export function sharedLockAdapterTestSuite(
                 const limit = 2;
                 const ttl = null;
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
@@ -1184,9 +1184,9 @@ export function sharedLockAdapterTestSuite(
 
                 const noneExistingKey = "c";
                 const result = await adapter.releaseReader(
-                    context,
                     noneExistingKey,
                     lockId,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -1198,8 +1198,8 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId = "1";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     ttl,
                     limit,
@@ -1207,9 +1207,9 @@ export function sharedLockAdapterTestSuite(
 
                 const noneExistingLockId = "2";
                 const result = await adapter.releaseReader(
-                    context,
                     key,
                     noneExistingLockId,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -1221,8 +1221,8 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId = "1";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     ttl,
                     limit,
@@ -1230,9 +1230,9 @@ export function sharedLockAdapterTestSuite(
                 await delayWithBuffer(ttl);
 
                 const result = await adapter.releaseReader(
-                    context,
                     key,
                     lockId,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -1244,16 +1244,16 @@ export function sharedLockAdapterTestSuite(
                 const limit = 2;
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     ttl,
                     limit,
                 });
                 const result = await adapter.releaseReader(
-                    context,
                     key,
                     lockId,
+                    context,
                 );
 
                 expect(result).toBe(true);
@@ -1265,16 +1265,16 @@ export function sharedLockAdapterTestSuite(
                 const limit = 2;
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     ttl,
                     limit,
                 });
                 const result = await adapter.releaseReader(
-                    context,
                     key,
                     lockId,
+                    context,
                 );
 
                 expect(result).toBe(true);
@@ -1286,40 +1286,40 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId1 = "1";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     limit,
                     ttl,
                 });
                 const lockId2 = "2";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId2,
                     limit,
                     ttl,
                 });
-                await adapter.releaseReader(context, key, lockId1);
-                await adapter.releaseReader(context, key, lockId2);
+                await adapter.releaseReader(key, lockId1, context);
+                await adapter.releaseReader(key, lockId2, context);
 
                 const newLimit = 3;
                 const lockId3 = "3";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId3,
                     limit: newLimit,
                     ttl,
                 });
 
-                const result1 = await adapter.getState(context, key);
+                const result1 = await adapter.getState(key, context);
                 expect(result1?.reader?.limit).toBe(newLimit);
 
                 const lockId4 = "4";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId4,
                     limit: newLimit,
                     ttl,
@@ -1327,8 +1327,8 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId5 = "5";
                 const result2 = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId5,
                     limit: newLimit,
                     ttl,
@@ -1337,8 +1337,8 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId6 = "6";
                 const result3 = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId6,
                     limit,
                     ttl,
@@ -1352,31 +1352,31 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId1 = "1";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     limit,
                     ttl,
                 });
                 const lockId2 = "2";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId2,
                     limit,
                     ttl,
                 });
-                await adapter.releaseReader(context, key, lockId1);
+                await adapter.releaseReader(key, lockId1, context);
 
-                const result1 = await adapter.getState(context, key);
+                const result1 = await adapter.getState(key, context);
                 expect(result1?.reader?.acquiredSlots.size).toBe(1);
 
-                await adapter.releaseReader(context, key, lockId2);
+                await adapter.releaseReader(key, lockId2, context);
 
                 const lockId3 = "3";
                 const result2 = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId3,
                     limit,
                     ttl,
@@ -1385,8 +1385,8 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId4 = "4";
                 const result3 = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId4,
                     limit,
                     ttl,
@@ -1397,12 +1397,12 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const lockId = "1";
                 const ttl = null;
-                await adapter.acquireWriter(context, key, lockId, ttl);
+                await adapter.acquireWriter(key, lockId, ttl, context);
 
                 const result = await adapter.releaseReader(
-                    context,
                     key,
                     lockId,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -1411,11 +1411,11 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const lockId = "1";
                 const ttl = null;
-                await adapter.acquireWriter(context, key, lockId, ttl);
+                await adapter.acquireWriter(key, lockId, ttl, context);
 
-                await adapter.releaseReader(context, key, lockId);
+                await adapter.releaseReader(key, lockId, context);
 
-                const state = await adapter.getState(context, key);
+                const state = await adapter.getState(key, context);
 
                 expect(state).toEqual({
                     writer: {
@@ -1433,8 +1433,8 @@ export function sharedLockAdapterTestSuite(
                 const limit = 2;
                 const ttl = null;
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
@@ -1442,8 +1442,8 @@ export function sharedLockAdapterTestSuite(
 
                 const noneExistingKey = "c";
                 const result = await adapter.forceReleaseAllReaders(
-                    context,
                     noneExistingKey,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -1455,8 +1455,8 @@ export function sharedLockAdapterTestSuite(
                 const lockId = "1";
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
@@ -1464,8 +1464,8 @@ export function sharedLockAdapterTestSuite(
                 await delayWithBuffer(ttl);
 
                 const result = await adapter.forceReleaseAllReaders(
-                    context,
                     key,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -1477,26 +1477,26 @@ export function sharedLockAdapterTestSuite(
                 const limit = 2;
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     limit,
                     ttl,
                 });
                 const lockId2 = "2";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId2,
                     limit,
                     ttl,
                 });
-                await adapter.releaseReader(context, key, lockId1);
-                await adapter.releaseReader(context, key, lockId2);
+                await adapter.releaseReader(key, lockId1, context);
+                await adapter.releaseReader(key, lockId2, context);
 
                 const result = await adapter.forceReleaseAllReaders(
-                    context,
                     key,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -1508,16 +1508,16 @@ export function sharedLockAdapterTestSuite(
                 const lockId = "1";
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
                 });
 
                 const result = await adapter.forceReleaseAllReaders(
-                    context,
                     key,
+                    context,
                 );
 
                 expect(result).toBe(true);
@@ -1528,8 +1528,8 @@ export function sharedLockAdapterTestSuite(
                 const lockId1 = "1";
                 const ttl1 = null;
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     limit,
                     ttl: ttl1,
@@ -1537,20 +1537,20 @@ export function sharedLockAdapterTestSuite(
                 const lockId2 = "2";
                 const ttl2 = TimeSpan.fromMilliseconds(50);
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId2,
                     limit,
                     ttl: ttl2,
                 });
 
-                await adapter.forceReleaseAllReaders(context, key);
+                await adapter.forceReleaseAllReaders(key, context);
 
                 const lockId3 = "3";
                 const ttl3 = null;
                 const result1 = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId3,
                     limit,
                     ttl: ttl3,
@@ -1559,8 +1559,8 @@ export function sharedLockAdapterTestSuite(
                 const lockId4 = "4";
                 const ttl4 = null;
                 const result2 = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId4,
                     limit,
                     ttl: ttl4,
@@ -1574,39 +1574,39 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId1 = "1";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     limit,
                     ttl,
                 });
                 const lockId2 = "2";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId2,
                     limit,
                     ttl,
                 });
-                await adapter.forceReleaseAllReaders(context, key);
+                await adapter.forceReleaseAllReaders(key, context);
 
                 const newLimit = 3;
                 const lockId3 = "3";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId3,
                     limit: newLimit,
                     ttl,
                 });
 
-                const result1 = await adapter.getState(context, key);
+                const result1 = await adapter.getState(key, context);
                 expect(result1?.reader?.limit).toBe(newLimit);
 
                 const lockId4 = "4";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId4,
                     limit: newLimit,
                     ttl,
@@ -1614,8 +1614,8 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId5 = "5";
                 const result2 = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId5,
                     limit: newLimit,
                     ttl,
@@ -1624,8 +1624,8 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId6 = "6";
                 const result3 = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId6,
                     limit,
                     ttl,
@@ -1636,11 +1636,11 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const lockId = "1";
                 const ttl = null;
-                await adapter.acquireWriter(context, key, lockId, ttl);
+                await adapter.acquireWriter(key, lockId, ttl, context);
 
                 const result = await adapter.forceReleaseAllReaders(
-                    context,
                     key,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -1649,11 +1649,11 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const lockId = "1";
                 const ttl = null;
-                await adapter.acquireWriter(context, key, lockId, ttl);
+                await adapter.acquireWriter(key, lockId, ttl, context);
 
-                await adapter.forceReleaseAllReaders(context, key);
+                await adapter.forceReleaseAllReaders(key, context);
 
-                const state = await adapter.getState(context, key);
+                const state = await adapter.getState(key, context);
 
                 expect(state).toEqual({
                     writer: {
@@ -1671,8 +1671,8 @@ export function sharedLockAdapterTestSuite(
                 const limit = 2;
                 const ttl = null;
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
@@ -1681,10 +1681,10 @@ export function sharedLockAdapterTestSuite(
                 const newTtl = TimeSpan.fromMilliseconds(100);
                 const noneExistingKey = "c";
                 const result = await adapter.refreshReader(
-                    context,
                     noneExistingKey,
                     lockId,
                     newTtl,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -1696,8 +1696,8 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId = "b";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     ttl,
                     limit,
@@ -1706,10 +1706,10 @@ export function sharedLockAdapterTestSuite(
                 const noneExistingLockId = "c";
                 const newTtl = TimeSpan.fromMilliseconds(100);
                 const result = await adapter.refreshReader(
-                    context,
                     key,
                     noneExistingLockId,
                     newTtl,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -1720,8 +1720,8 @@ export function sharedLockAdapterTestSuite(
                 const limit = 2;
                 const ttl = TimeSpan.fromMilliseconds(50);
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
@@ -1730,10 +1730,10 @@ export function sharedLockAdapterTestSuite(
 
                 const newTtl = TimeSpan.fromMilliseconds(100);
                 const result = await adapter.refreshReader(
-                    context,
                     key,
                     lockId,
                     newTtl,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -1745,18 +1745,18 @@ export function sharedLockAdapterTestSuite(
                 const limit = 2;
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     ttl,
                     limit,
                 });
                 const newTtl = TimeSpan.fromMilliseconds(100);
                 const result = await adapter.refreshReader(
-                    context,
                     key,
                     lockId,
                     newTtl,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -1768,18 +1768,18 @@ export function sharedLockAdapterTestSuite(
                 const limit = 2;
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     ttl,
                     limit,
                 });
                 const newTtl = TimeSpan.fromMilliseconds(100);
                 const result = await adapter.refreshReader(
-                    context,
                     key,
                     lockId,
                     newTtl,
+                    context,
                 );
 
                 expect(result).toBe(true);
@@ -1791,8 +1791,8 @@ export function sharedLockAdapterTestSuite(
                 const ttl1 = null;
                 const lockId1 = "1";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     ttl: ttl1,
                     limit,
@@ -1801,21 +1801,21 @@ export function sharedLockAdapterTestSuite(
                 const ttl2 = null;
                 const lockId2 = "2";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId2,
                     ttl: ttl2,
                     limit,
                 });
 
                 const newTtl = TimeSpan.fromMilliseconds(100);
-                await adapter.refreshReader(context, key, lockId2, newTtl);
+                await adapter.refreshReader(key, lockId2, newTtl, context);
                 await delayWithBuffer(newTtl);
 
                 const lockId3 = "3";
                 const result1 = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId3,
                     ttl: ttl2,
                     limit,
@@ -1829,8 +1829,8 @@ export function sharedLockAdapterTestSuite(
                 const ttl1 = null;
                 const lockId1 = "1";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     ttl: ttl1,
                     limit,
@@ -1839,21 +1839,21 @@ export function sharedLockAdapterTestSuite(
                 const ttl2 = TimeSpan.fromMilliseconds(50);
                 const lockId2 = "2";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId2,
                     ttl: ttl2,
                     limit,
                 });
 
                 const newTtl = TimeSpan.fromMilliseconds(100);
-                await adapter.refreshReader(context, key, lockId2, newTtl);
+                await adapter.refreshReader(key, lockId2, newTtl, context);
                 await delayWithBuffer(newTtl.divide(2));
 
                 const lockId3 = "3";
                 const result1 = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId3,
                     ttl: ttl2,
                     limit,
@@ -1862,8 +1862,8 @@ export function sharedLockAdapterTestSuite(
 
                 await delayWithBuffer(newTtl.divide(2));
                 const result2 = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId3,
                     ttl: ttl2,
                     limit,
@@ -1874,14 +1874,14 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const lockId = "1";
                 const ttl = null;
-                await adapter.acquireWriter(context, key, lockId, ttl);
+                await adapter.acquireWriter(key, lockId, ttl, context);
 
                 const newTtl = TimeSpan.fromSeconds(20);
                 const result = await adapter.refreshReader(
-                    context,
                     key,
                     lockId,
                     newTtl,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -1890,12 +1890,12 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const lockId = "1";
                 const ttl = null;
-                await adapter.acquireWriter(context, key, lockId, ttl);
+                await adapter.acquireWriter(key, lockId, ttl, context);
 
                 const newTtl = TimeSpan.fromSeconds(20);
-                await adapter.refreshReader(context, key, lockId, newTtl);
+                await adapter.refreshReader(key, lockId, newTtl, context);
 
-                const state = await adapter.getState(context, key);
+                const state = await adapter.getState(key, context);
 
                 expect(state).toEqual({
                     writer: {
@@ -1910,7 +1910,7 @@ export function sharedLockAdapterTestSuite(
             test("Should return false when key doesnt exists", async () => {
                 const key = "a";
 
-                const result = await adapter.forceRelease(context, key);
+                const result = await adapter.forceRelease(key, context);
 
                 expect(result).toBe(false);
             });
@@ -1919,10 +1919,10 @@ export function sharedLockAdapterTestSuite(
                 const sharedLockId = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
 
-                await adapter.acquireWriter(context, key, sharedLockId, ttl);
+                await adapter.acquireWriter(key, sharedLockId, ttl, context);
                 await delayWithBuffer(ttl);
 
-                const result = await adapter.forceRelease(context, key);
+                const result = await adapter.forceRelease(key, context);
 
                 expect(result).toBe(false);
             });
@@ -1931,9 +1931,9 @@ export function sharedLockAdapterTestSuite(
                 const sharedLockId = "b";
                 const ttl = TimeSpan.fromMilliseconds(50);
 
-                await adapter.acquireWriter(context, key, sharedLockId, ttl);
+                await adapter.acquireWriter(key, sharedLockId, ttl, context);
 
-                const result = await adapter.forceRelease(context, key);
+                const result = await adapter.forceRelease(key, context);
 
                 expect(result).toBe(true);
             });
@@ -1942,9 +1942,9 @@ export function sharedLockAdapterTestSuite(
                 const sharedLockId = "b";
                 const ttl = null;
 
-                await adapter.acquireWriter(context, key, sharedLockId, ttl);
+                await adapter.acquireWriter(key, sharedLockId, ttl, context);
 
-                const result = await adapter.forceRelease(context, key);
+                const result = await adapter.forceRelease(key, context);
 
                 expect(result).toBe(true);
             });
@@ -1952,16 +1952,16 @@ export function sharedLockAdapterTestSuite(
                 const key = "a";
                 const sharedLockId1 = "b";
                 const ttl = null;
-                await adapter.acquireWriter(context, key, sharedLockId1, ttl);
+                await adapter.acquireWriter(key, sharedLockId1, ttl, context);
 
-                await adapter.forceRelease(context, key);
+                await adapter.forceRelease(key, context);
 
                 const sharedLockId2 = "c";
                 const result = await adapter.acquireWriter(
-                    context,
                     key,
                     sharedLockId2,
                     ttl,
+                    context,
                 );
                 expect(result).toBe(true);
             });
@@ -1972,15 +1972,15 @@ export function sharedLockAdapterTestSuite(
                 const lockId = "1";
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
                 });
                 await delayWithBuffer(ttl);
 
-                const result = await adapter.forceRelease(context, key);
+                const result = await adapter.forceRelease(key, context);
 
                 expect(result).toBe(false);
             });
@@ -1991,24 +1991,24 @@ export function sharedLockAdapterTestSuite(
                 const limit = 2;
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     limit,
                     ttl,
                 });
                 const lockId2 = "2";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId2,
                     limit,
                     ttl,
                 });
-                await adapter.releaseReader(context, key, lockId1);
-                await adapter.releaseReader(context, key, lockId2);
+                await adapter.releaseReader(key, lockId1, context);
+                await adapter.releaseReader(key, lockId2, context);
 
-                const result = await adapter.forceRelease(context, key);
+                const result = await adapter.forceRelease(key, context);
 
                 expect(result).toBe(false);
             });
@@ -2019,14 +2019,14 @@ export function sharedLockAdapterTestSuite(
                 const lockId = "1";
 
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId,
                     limit,
                     ttl,
                 });
 
-                const result = await adapter.forceRelease(context, key);
+                const result = await adapter.forceRelease(key, context);
 
                 expect(result).toBe(true);
             });
@@ -2036,8 +2036,8 @@ export function sharedLockAdapterTestSuite(
                 const lockId1 = "1";
                 const ttl1 = null;
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     limit,
                     ttl: ttl1,
@@ -2045,20 +2045,20 @@ export function sharedLockAdapterTestSuite(
                 const lockId2 = "2";
                 const ttl2 = TimeSpan.fromMilliseconds(50);
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId2,
                     limit,
                     ttl: ttl2,
                 });
 
-                await adapter.forceRelease(context, key);
+                await adapter.forceRelease(key, context);
 
                 const lockId3 = "3";
                 const ttl3 = null;
                 const result1 = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId3,
                     limit,
                     ttl: ttl3,
@@ -2067,8 +2067,8 @@ export function sharedLockAdapterTestSuite(
                 const lockId4 = "4";
                 const ttl4 = null;
                 const result2 = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId4,
                     limit,
                     ttl: ttl4,
@@ -2082,39 +2082,39 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId1 = "1";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId1,
                     limit,
                     ttl,
                 });
                 const lockId2 = "2";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId2,
                     limit,
                     ttl,
                 });
-                await adapter.forceRelease(context, key);
+                await adapter.forceRelease(key, context);
 
                 const newLimit = 3;
                 const lockId3 = "3";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId3,
                     limit: newLimit,
                     ttl,
                 });
 
-                const result1 = await adapter.getState(context, key);
+                const result1 = await adapter.getState(key, context);
                 expect(result1?.reader?.limit).toBe(newLimit);
 
                 const lockId4 = "4";
                 await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId4,
                     limit: newLimit,
                     ttl,
@@ -2122,8 +2122,8 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId5 = "5";
                 const result2 = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId5,
                     limit: newLimit,
                     ttl,
@@ -2132,8 +2132,8 @@ export function sharedLockAdapterTestSuite(
 
                 const lockId6 = "6";
                 const result3 = await adapter.acquireReader({
-                    context,
                     key,
+                    context,
                     lockId: lockId6,
                     limit,
                     ttl,
@@ -2145,7 +2145,7 @@ export function sharedLockAdapterTestSuite(
             test("Should return null when key doesnt exists", async () => {
                 const key = "a";
 
-                const sharedLockData = await adapter.getState(context, key);
+                const sharedLockData = await adapter.getState(key, context);
 
                 expect(sharedLockData).toBeNull();
             });
@@ -2155,14 +2155,14 @@ export function sharedLockAdapterTestSuite(
                     const sharedLockId = "b";
                     const ttl = TimeSpan.fromMilliseconds(50);
                     await adapter.acquireWriter(
-                        context,
                         key,
                         sharedLockId,
                         ttl,
+                        context,
                     );
                     await delayWithBuffer(ttl);
 
-                    const sharedLockData = await adapter.getState(context, key);
+                    const sharedLockData = await adapter.getState(key, context);
 
                     expect(sharedLockData).toBeNull();
                 });
@@ -2171,15 +2171,15 @@ export function sharedLockAdapterTestSuite(
                     const ttl = null;
                     const sharedLockId = "1";
                     await adapter.acquireWriter(
-                        context,
                         key,
                         sharedLockId,
                         ttl,
+                        context,
                     );
 
-                    await adapter.forceReleaseWriter(context, key);
+                    await adapter.forceReleaseWriter(key, context);
 
-                    const sharedLockData = await adapter.getState(context, key);
+                    const sharedLockData = await adapter.getState(key, context);
 
                     expect(sharedLockData).toBeNull();
                 });
@@ -2188,15 +2188,15 @@ export function sharedLockAdapterTestSuite(
                     const ttl = null;
                     const sharedLockId = "1";
                     await adapter.acquireWriter(
-                        context,
                         key,
                         sharedLockId,
                         ttl,
+                        context,
                     );
 
-                    await adapter.forceRelease(context, key);
+                    await adapter.forceRelease(key, context);
 
-                    const sharedLockData = await adapter.getState(context, key);
+                    const sharedLockData = await adapter.getState(key, context);
 
                     expect(sharedLockData).toBeNull();
                 });
@@ -2205,15 +2205,15 @@ export function sharedLockAdapterTestSuite(
                     const ttl = null;
                     const sharedLockId = "1";
                     await adapter.acquireWriter(
-                        context,
                         key,
                         sharedLockId,
                         ttl,
+                        context,
                     );
 
-                    await adapter.releaseWriter(context, key, sharedLockId);
+                    await adapter.releaseWriter(key, sharedLockId, context);
 
-                    const sharedLockData = await adapter.getState(context, key);
+                    const sharedLockData = await adapter.getState(key, context);
 
                     expect(sharedLockData).toBeNull();
                 });
@@ -2222,13 +2222,13 @@ export function sharedLockAdapterTestSuite(
                     const ttl = null;
                     const sharedLockId = "1";
                     await adapter.acquireWriter(
-                        context,
                         key,
                         sharedLockId,
                         ttl,
+                        context,
                     );
 
-                    const state = await adapter.getState(context, key);
+                    const state = await adapter.getState(key, context);
 
                     expect(state).toEqual({
                         reader: null,
@@ -2248,16 +2248,16 @@ export function sharedLockAdapterTestSuite(
                         vi.useFakeTimers();
                         expiration = ttl.toEndDate();
                         await adapter.acquireWriter(
-                            context,
                             key,
                             sharedLockId,
                             ttl,
+                            context,
                         );
                     } finally {
                         vi.useRealTimers();
                     }
 
-                    const state = await adapter.getState(context, key);
+                    const state = await adapter.getState(key, context);
 
                     expect(state).toEqual({
                         reader: null,
@@ -2284,13 +2284,13 @@ export function sharedLockAdapterTestSuite(
                     const keyB = "a";
                     const sharedLockId = "2";
                     await adapter.acquireWriter(
-                        context,
                         keyB,
                         sharedLockId,
                         ttl,
+                        context,
                     );
 
-                    const state = await adapter.getState(context, keyB);
+                    const state = await adapter.getState(keyB, context);
 
                     expect({
                         ...state,
@@ -2326,7 +2326,7 @@ export function sharedLockAdapterTestSuite(
                     });
                     await delayWithBuffer(ttl);
 
-                    const result = await adapter.getState(context, key);
+                    const result = await adapter.getState(key, context);
 
                     expect(result).toBeNull();
                 });
@@ -2354,9 +2354,9 @@ export function sharedLockAdapterTestSuite(
                         ttl: ttl2,
                     });
 
-                    await adapter.forceReleaseAllReaders(context, key);
+                    await adapter.forceReleaseAllReaders(key, context);
 
-                    const result = await adapter.getState(context, key);
+                    const result = await adapter.getState(key, context);
 
                     expect(result).toBeNull();
                 });
@@ -2384,9 +2384,9 @@ export function sharedLockAdapterTestSuite(
                         ttl: ttl2,
                     });
 
-                    await adapter.forceRelease(context, key);
+                    await adapter.forceRelease(key, context);
 
-                    const result = await adapter.getState(context, key);
+                    const result = await adapter.getState(key, context);
 
                     expect(result).toBeNull();
                 });
@@ -2414,10 +2414,10 @@ export function sharedLockAdapterTestSuite(
                         ttl: ttl2,
                     });
 
-                    await adapter.releaseReader(context, key, lockId1);
-                    await adapter.releaseReader(context, key, lockId2);
+                    await adapter.releaseReader(key, lockId1, context);
+                    await adapter.releaseReader(key, lockId2, context);
 
-                    const result = await adapter.getState(context, key);
+                    const result = await adapter.getState(key, context);
 
                     expect(result).toBeNull();
                 });
@@ -2435,7 +2435,7 @@ export function sharedLockAdapterTestSuite(
                         ttl,
                     });
 
-                    const state = await adapter.getState(context, key);
+                    const state = await adapter.getState(key, context);
 
                     expect(state?.reader?.limit).toBe(limit);
                 });
@@ -2463,7 +2463,7 @@ export function sharedLockAdapterTestSuite(
                         ttl: ttl2,
                     });
 
-                    const state = await adapter.getState(context, key);
+                    const state = await adapter.getState(key, context);
 
                     expect(state?.reader?.acquiredSlots.size).toBe(2);
                 });
@@ -2481,7 +2481,7 @@ export function sharedLockAdapterTestSuite(
                         ttl,
                     });
 
-                    const state = await adapter.getState(context, key);
+                    const state = await adapter.getState(key, context);
 
                     expect({
                         ...state,
@@ -2522,7 +2522,7 @@ export function sharedLockAdapterTestSuite(
                         vi.useRealTimers();
                     }
 
-                    const state = await adapter.getState(context, key);
+                    const state = await adapter.getState(key, context);
 
                     expect({
                         ...state,
@@ -2548,10 +2548,10 @@ export function sharedLockAdapterTestSuite(
                     const keyB = "a";
                     const sharedLockId = "2";
                     await adapter.acquireWriter(
-                        context,
                         keyB,
                         sharedLockId,
                         ttl,
+                        context,
                     );
 
                     const keyA = "a";
@@ -2565,7 +2565,7 @@ export function sharedLockAdapterTestSuite(
                         ttl,
                     });
 
-                    const state = await adapter.getState(context, keyB);
+                    const state = await adapter.getState(keyB, context);
 
                     expect(state).toEqual({
                         writer: {


### PR DESCRIPTION
- **refactor(shared-lock): reorder context parameter to last position in contract**
- **refactor(shared-lock): reorder context parameter in memory adapter**
- **refactor(shared-lock): reorder context parameter in no-op adapter**
- **refactor(shared-lock): reorder context parameter in kysely adapter**
- **refactor(shared-lock): reorder context parameter in mongodb adapter**
- **refactor(shared-lock): reorder context parameter in redis adapter**
- **refactor(shared-lock): reorder context parameter in prefix plugin**
- **refactor(shared-lock): reorder context parameter in shared-lock factory**
- **test(shared-lock): update adapter test suite for context reorder**
- **test(shared-lock): update memory adapter tests for context reorder**
- **test(shared-lock): update mongodb adapter tests for context reorder**
- **test(shared-lock): update prefix plugin tests for context reorder**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Shared-lock adapter methods now place the lock key and related identifiers before the context parameter.
  * Update integrations and custom adapters to use the new calling convention.

* **Bug Fixes**
  * In-memory locks and reader slots now correctly handle expired entries during release operations.

* **Tests**
  * Updated adapter, prefixing, expiration, and lifecycle coverage for the revised method signatures and expiration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->