### PR TITLE
enhacement/cache adapter update

### DIFF
--- a/src/cache/contracts/cache-adapter.contract.ts
+++ b/src/cache/contracts/cache-adapter.contract.ts
@@ -16,37 +16,37 @@ export type ICacheAdapter<TType = unknown> = {
     /**
      * Retrieves a value by key without removing it.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Cache key to retrieve
+     * @param context - Readable execution context for the operation
      * @returns The cached value, or null if not found or expired
      */
-    get(context: IReadableContext, key: string): Promise<TType | null>;
+    get(key: string, context: IReadableContext): Promise<TType | null>;
 
     /**
      * Retrieves a value by key and immediately removes it.
      * Useful for one-time-use values (tokens, temporary states, etc.).
      *
-     * @param context - Readable execution context for the operation
      * @param key - Cache key to retrieve and remove
+     * @param context - Readable execution context for the operation
      * @returns The cached value, or null if not found or expired
      */
-    getAndRemove(context: IReadableContext, key: string): Promise<TType | null>;
+    getAndRemove(key: string, context: IReadableContext): Promise<TType | null>;
 
     /**
      * Creates a new cache entry, but only if the key does not already exist.
      * Has no effect if the key already exists.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Cache key to add
      * @param value - Value to cache
      * @param ttl - Time-to-live duration for this entry. Pass `null` to cache without expiration.
+     * @param context - Readable execution context for the operation
      * @returns true if the entry was created, false if the key already existed
      */
     add(
-        context: IReadableContext,
         key: string,
         value: TType,
         ttl: TimeSpan | null,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
@@ -56,74 +56,77 @@ export type ICacheAdapter<TType = unknown> = {
      * @param key - The cache key to retrieve or add.
      * @param valueToAdd - The value to store if the key is not found.
      * @param ttl - Optional time-to-live for the cached item. If `null` is passed, the item will not expire.
+     * @param context - Readable execution context for the operation
      *
      * @returns The cached value if the key exists, or the newly added value.
      */
     getOrAdd(
-        context: IReadableContext,
         key: string,
         valueToAdd: TType,
         ttl: TimeSpan | null,
+        context: IReadableContext,
     ): Promise<TType>;
 
     /**
      * Creates a new cache entry or updates an existing one (upsert).
      * Also updates the TTL when overwriting an existing entry.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Cache key to set
      * @param value - Value to cache
      * @param ttl - Time-to-live duration for this entry. Pass `null` to cache without expiration.
+     * @param context - Readable execution context for the operation
      * @returns true if the entry was added, false if it was updated
      */
     put(
-        context: IReadableContext,
         key: string,
         value: TType,
         ttl: TimeSpan | null,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
      * Updates an existing cache entry without changing its TTL.
      * Has no effect if the key does not exist.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Cache key to update
      * @param value - New value to cache
+     * @param context - Readable execution context for the operation
      * @returns true if the entry was updated, false if the key did not exist
      */
     update(
-        context: IReadableContext,
         key: string,
         value: TType,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
      * Increments a numeric cache entry by a given amount.
      * Useful for counters, rates, and statistics.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Cache key to increment
      * @param value - Amount to increment by.
+     * @param context - Readable execution context for the operation
+     *
      * @returns true if the entry was incremented, false if the key did not exist
      * @throws {TypeError} If the cached value is not a number
      */
     increment(
-        context: IReadableContext,
         key: string,
         value: number,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
      * Removes multiple cache entries at once.
      *
-     * @param context - Readable execution context for the operation
      * @param keys - Array of cache keys to remove
+     * @param context - Readable execution context for the operation
+     *
      * @returns true if at least one key was removed, false if none existed
      */
     removeMany(
-        context: IReadableContext,
         keys: Array<string>,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
@@ -138,8 +141,8 @@ export type ICacheAdapter<TType = unknown> = {
      * Removes all cache entries whose keys start with a given prefix.
      * Useful for invalidating groups of related cache entries.
      *
-     * @param context - Readable execution context for the operation
      * @param prefix - Key prefix to match for removal
+     * @param context - Readable execution context for the operation
      */
-    removeByKeyPrefix(context: IReadableContext, prefix: string): Promise<void>;
+    removeByKeyPrefix(prefix: string, context: IReadableContext): Promise<void>;
 };

--- a/src/cache/implementations/adapters/kysely-cache-adapter/kysely-cache-adapter.ts
+++ b/src/cache/implementations/adapters/kysely-cache-adapter/kysely-cache-adapter.ts
@@ -218,7 +218,7 @@ export class KyselyCacheAdapter<TType = unknown>
         return trxFn(this.kysely);
     }
 
-    async get(_context: IReadableContext, key: string): Promise<TType | null> {
+    async get(key: string, _context: IReadableContext): Promise<TType | null> {
         const row = await this.kysely
             .selectFrom("cache")
             .where("cache.key", "=", key)
@@ -237,8 +237,8 @@ export class KyselyCacheAdapter<TType = unknown>
     }
 
     async getAndRemove(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<TType | null> {
         if (this.isMysql) {
             return await this._transaction(_context, async (trx) => {
@@ -286,10 +286,10 @@ export class KyselyCacheAdapter<TType = unknown>
     }
 
     async add(
-        _context: IReadableContext,
         key: string,
         value: TType,
         ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return await this._transaction(_context, async (trx) => {
             const existing = await trx
@@ -336,10 +336,10 @@ export class KyselyCacheAdapter<TType = unknown>
     }
 
     async getOrAdd(
-        _context: IReadableContext,
         key: string,
         valueToAdd: TType,
         ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<TType> {
         return await this._transaction(_context, async (trx) => {
             const existing = await trx
@@ -386,10 +386,10 @@ export class KyselyCacheAdapter<TType = unknown>
     }
 
     async put(
-        _context: IReadableContext,
         key: string,
         value: TType,
         ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return await this._transaction(_context, async (trx) => {
             const existing = await trx
@@ -435,9 +435,9 @@ export class KyselyCacheAdapter<TType = unknown>
     }
 
     async update(
-        _context: IReadableContext,
         key: string,
         value: TType,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const serializedValue = this.serde.serialize(value);
         const result = await this.kysely
@@ -456,9 +456,9 @@ export class KyselyCacheAdapter<TType = unknown>
     }
 
     async increment(
-        _context: IReadableContext,
         key: string,
         value: number,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return await this._transaction(_context, async (trx) => {
             const existing = await trx
@@ -498,8 +498,8 @@ export class KyselyCacheAdapter<TType = unknown>
     }
 
     async removeMany(
-        _context: IReadableContext,
         keys: Array<string>,
+        _context: IReadableContext,
     ): Promise<boolean> {
         if (keys.length === 0) {
             return false;
@@ -518,8 +518,8 @@ export class KyselyCacheAdapter<TType = unknown>
     }
 
     async removeByKeyPrefix(
-        _context: IReadableContext,
         prefix: string,
+        _context: IReadableContext,
     ): Promise<void> {
         await this.kysely
             .deleteFrom("cache")

--- a/src/cache/implementations/adapters/memory-cache-adapter/memory-cache-adapter.ts
+++ b/src/cache/implementations/adapters/memory-cache-adapter/memory-cache-adapter.ts
@@ -36,36 +36,36 @@ export class MemoryCacheAdapter<
      */
     constructor(private readonly map: Map<string, unknown> = new Map()) {}
 
-    get(context: IReadableContext, key: string): Promise<TType | null> {
-        return this._get(context, key);
+    get(key: string, context: IReadableContext): Promise<TType | null> {
+        return this._get(key, context);
     }
 
     add(
-        context: IReadableContext,
         key: string,
         value: TType,
         ttl: TimeSpan | null,
+        context: IReadableContext,
     ): Promise<boolean> {
-        return this._add(context, key, value, ttl);
+        return this._add(key, value, ttl, context);
     }
 
     async getOrAdd(
-        context: IReadableContext,
         key: string,
         valueToAdd: TType,
         ttl: TimeSpan | null,
+        context: IReadableContext,
     ): Promise<TType> {
-        const value = await this._get(context, key);
+        const value = await this._get(key, context);
         if (value === null) {
-            await this._add(context, key, valueToAdd, ttl);
+            await this._add(key, valueToAdd, ttl, context);
             return valueToAdd;
         }
         return value;
     }
 
     private _get(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<TType | null> {
         return Promise.resolve(
             this.map.get(key) ?? null,
@@ -73,19 +73,19 @@ export class MemoryCacheAdapter<
     }
 
     async getAndRemove(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<TType | null> {
-        const value = await this._get(context, key);
+        const value = await this._get(key, context);
         await this._remove(key);
         return value;
     }
 
     private _add(
-        _context: IReadableContext,
         key: string,
         value: TType,
         ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const hasNotKey = !this.map.has(key);
         if (hasNotKey) {
@@ -104,20 +104,20 @@ export class MemoryCacheAdapter<
     }
 
     async put(
-        context: IReadableContext,
         key: string,
         value: TType,
         ttl: TimeSpan | null,
+        context: IReadableContext,
     ): Promise<boolean> {
         const hasKey = await this._remove(key);
-        await this._add(context, key, value, ttl);
+        await this._add(key, value, ttl, context);
         return hasKey;
     }
 
     update(
-        _context: IReadableContext,
         key: string,
         value: TType,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const hasKey = this.map.has(key);
         if (hasKey) {
@@ -127,9 +127,9 @@ export class MemoryCacheAdapter<
     }
 
     async increment(
-        _context: IReadableContext,
         key: string,
         value: number,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const prevValue = this.map.get(key);
         const hasKey = prevValue !== undefined;
@@ -152,8 +152,8 @@ export class MemoryCacheAdapter<
     }
 
     removeMany(
-        _context: IReadableContext,
         keys: Array<string>,
+        _context: IReadableContext,
     ): Promise<boolean> {
         let deleteCount = 0;
         for (const key of keys) {
@@ -174,8 +174,8 @@ export class MemoryCacheAdapter<
     }
 
     removeByKeyPrefix(
-        _context: IReadableContext,
         prefix: string,
+        _context: IReadableContext,
     ): Promise<void> {
         for (const key of this.map.keys()) {
             if (key.startsWith(prefix)) {

--- a/src/cache/implementations/adapters/mongodb-cache-adapter/mongodb-cache-adapter.ts
+++ b/src/cache/implementations/adapters/mongodb-cache-adapter/mongodb-cache-adapter.ts
@@ -159,10 +159,10 @@ export class MongodbCacheAdapter<TType = unknown>
     }
 
     async getOrAdd(
-        _context: IReadableContext,
         key: string,
         valueToAdd: TType,
         ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<TType> {
         const hasExpirationQuery = {
             $ne: ["$expiration", null],
@@ -285,7 +285,7 @@ export class MongodbCacheAdapter<TType = unknown>
         return this.serde.deserialize(value);
     }
 
-    async get(_context: IReadableContext, key: string): Promise<TType | null> {
+    async get(key: string, _context: IReadableContext): Promise<TType | null> {
         const document = await this.collection.findOne(
             {
                 key,
@@ -302,8 +302,8 @@ export class MongodbCacheAdapter<TType = unknown>
     }
 
     async getAndRemove(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<TType | null> {
         const document = await this.collection.findOneAndDelete(
             {
@@ -333,10 +333,10 @@ export class MongodbCacheAdapter<TType = unknown>
     }
 
     async add(
-        _context: IReadableContext,
         key: string,
         value: TType,
         ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const hasExpirationQuery = {
             $ne: ["$expiration", null],
@@ -384,10 +384,10 @@ export class MongodbCacheAdapter<TType = unknown>
     }
 
     async put(
-        _context: IReadableContext,
         key: string,
         value: TType,
         ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const document = await this.collection.findOneAndUpdate(
             {
@@ -411,9 +411,9 @@ export class MongodbCacheAdapter<TType = unknown>
     }
 
     async update(
-        _context: IReadableContext,
         key: string,
         value: TType,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const updateResult = await this.collection.updateOne(
             MongodbCacheAdapter.filterUnexpiredKeys([key]),
@@ -430,9 +430,9 @@ export class MongodbCacheAdapter<TType = unknown>
     }
 
     async increment(
-        _context: IReadableContext,
         key: string,
         value: number,
+        _context: IReadableContext,
     ): Promise<boolean> {
         try {
             const updateResult = await this.collection.updateOne(
@@ -460,8 +460,8 @@ export class MongodbCacheAdapter<TType = unknown>
     }
 
     async removeMany(
-        _context: IReadableContext,
         keys: Array<string>,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const deleteResult = await this.collection.deleteMany(
             MongodbCacheAdapter.filterUnexpiredKeys(keys),
@@ -480,8 +480,8 @@ export class MongodbCacheAdapter<TType = unknown>
     }
 
     async removeByKeyPrefix(
-        _context: IReadableContext,
         prefix: string,
+        _context: IReadableContext,
     ): Promise<void> {
         const mongodbResult = await this.collection.deleteMany({
             key: {

--- a/src/cache/implementations/adapters/no-op-cache-adapter/no-op-cache-adapter.ts
+++ b/src/cache/implementations/adapters/no-op-cache-adapter/no-op-cache-adapter.ts
@@ -19,62 +19,62 @@ import { type TimeSpan } from "@/time-span/implementations/_module.js";
  */
 export class NoOpCacheAdapter<TType = unknown> implements ICacheAdapter<TType> {
     getOrAdd(
-        _context: IReadableContext,
         _key: string,
         valueToAdd: TType,
         _ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<TType> {
         return Promise.resolve(valueToAdd);
     }
 
-    get(_context: IReadableContext, _key: string): Promise<TType | null> {
+    get(_key: string, _context: IReadableContext): Promise<TType | null> {
         return Promise.resolve(null);
     }
 
     getAndRemove(
-        _context: IReadableContext,
         _key: string,
+        _context: IReadableContext,
     ): Promise<TType | null> {
         return Promise.resolve(null);
     }
 
     add(
-        _context: IReadableContext,
         _key: string,
         _value: TType,
         _ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     put(
-        _context: IReadableContext,
         _key: string,
         _value: TType,
         _ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     update(
-        _context: IReadableContext,
         _key: string,
         _value: TType,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     increment(
-        _context: IReadableContext,
         _key: string,
         _value: number,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     removeMany(
-        _context: IReadableContext,
         _keys: Array<string>,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
@@ -84,8 +84,8 @@ export class NoOpCacheAdapter<TType = unknown> implements ICacheAdapter<TType> {
     }
 
     removeByKeyPrefix(
-        _context: IReadableContext,
         _prefix: string,
+        _context: IReadableContext,
     ): Promise<void> {
         return Promise.resolve();
     }

--- a/src/cache/implementations/adapters/redis-cache-adapter/redis-cache-adapter.ts
+++ b/src/cache/implementations/adapters/redis-cache-adapter/redis-cache-adapter.ts
@@ -123,10 +123,10 @@ export class RedisCacheAdapter<
     }
 
     async getOrAdd(
-        _context: IReadableContext,
         key: string,
         valueToAdd: TType,
         ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<TType> {
         const serializedValue = this.serde.serialize(valueToAdd);
         const ttlInMs = ttl?.toMilliseconds() ?? -1;
@@ -157,7 +157,7 @@ export class RedisCacheAdapter<
         });
     }
 
-    async get(_context: IReadableContext, key: string): Promise<TType | null> {
+    async get(key: string, _context: IReadableContext): Promise<TType | null> {
         const value = await this.database.get(key);
         if (value === null) {
             return null;
@@ -166,8 +166,8 @@ export class RedisCacheAdapter<
     }
 
     async getAndRemove(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<TType | null> {
         const value = await this.database.getdel(key);
         if (value === null) {
@@ -177,10 +177,10 @@ export class RedisCacheAdapter<
     }
 
     async add(
-        _context: IReadableContext,
         key: string,
         value: TType,
         ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<boolean> {
         if (ttl === null) {
             const result = await this.database.set(
@@ -201,10 +201,10 @@ export class RedisCacheAdapter<
     }
 
     async put(
-        _context: IReadableContext,
         key: string,
         value: TType,
         ttl: TimeSpan | null,
+        _context: IReadableContext,
     ): Promise<boolean> {
         if (ttl === null) {
             const result = await this.database.set(
@@ -225,9 +225,9 @@ export class RedisCacheAdapter<
     }
 
     async update(
-        _context: IReadableContext,
         key: string,
         value: TType,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const result = await this.database.set(
             key,
@@ -238,9 +238,9 @@ export class RedisCacheAdapter<
     }
 
     async increment(
-        _context: IReadableContext,
         key: string,
         value: number,
+        _context: IReadableContext,
     ): Promise<boolean> {
         try {
             const redisResult = await this.database.daiso_cache_increment(
@@ -260,8 +260,8 @@ export class RedisCacheAdapter<
     }
 
     async removeMany(
-        _context: IReadableContext,
         keys: Array<string>,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const deleteResult = await this.database.del(...keys);
         return deleteResult > 0;
@@ -272,8 +272,8 @@ export class RedisCacheAdapter<
     }
 
     async removeByKeyPrefix(
-        _context: IReadableContext,
         prefix: string,
+        _context: IReadableContext,
     ): Promise<void> {
         for await (const _ of new ClearIterable(this.database, prefix)) {
             /* Empty */

--- a/src/cache/implementations/derivables/cache/cache.ts
+++ b/src/cache/implementations/derivables/cache/cache.ts
@@ -122,7 +122,7 @@ export class Cache<TType = unknown> implements ICache<TType> {
     }
 
     async get(key: string): Promise<TType | null> {
-        return await this.adapter.get(this.context, key);
+        return await this.adapter.get(key, this.context);
     }
 
     async getOrFail(key: string): Promise<TType> {
@@ -134,7 +134,7 @@ export class Cache<TType = unknown> implements ICache<TType> {
     }
 
     async getAndRemove(key: string): Promise<TType | null> {
-        return await this.adapter.getAndRemove(this.context, key);
+        return await this.adapter.getAndRemove(key, this.context);
     }
 
     async getOr(
@@ -156,10 +156,10 @@ export class Cache<TType = unknown> implements ICache<TType> {
         ttl: ITimeSpan | null = this.defaultTtl,
     ): Promise<TType> {
         return await this.adapter.getOrAdd(
-            this.context,
             key,
             valueToAdd,
             ttl === null ? null : TimeSpan.fromTimeSpan(ttl),
+            this.context,
         );
     }
 
@@ -169,10 +169,10 @@ export class Cache<TType = unknown> implements ICache<TType> {
         ttl: ITimeSpan | null = this.defaultTtl,
     ): Promise<boolean> {
         const hasAdded = await this.adapter.add(
-            this.context,
             key,
             value,
             ttl === null ? null : TimeSpan.fromTimeSpan(ttl),
+            this.context,
         );
 
         return hasAdded;
@@ -195,16 +195,16 @@ export class Cache<TType = unknown> implements ICache<TType> {
         ttl: ITimeSpan | null = this.defaultTtl,
     ): Promise<boolean> {
         const hasUpdated = await this.adapter.put(
-            this.context,
             key,
             value,
             ttl === null ? null : TimeSpan.fromTimeSpan(ttl),
+            this.context,
         );
         return hasUpdated;
     }
 
     async update(key: string, value: TType): Promise<boolean> {
-        const hasUpdated = await this.adapter.update(this.context, key, value);
+        const hasUpdated = await this.adapter.update(key, value, this.context);
 
         return hasUpdated;
     }
@@ -221,9 +221,9 @@ export class Cache<TType = unknown> implements ICache<TType> {
         value = 1 as Extract<TType, number>,
     ): Promise<boolean> {
         const hasUpdated = await this.adapter.increment(
-            this.context,
             key,
             value,
+            this.context,
         );
 
         return hasUpdated;
@@ -257,7 +257,7 @@ export class Cache<TType = unknown> implements ICache<TType> {
     }
 
     async remove(key: string): Promise<boolean> {
-        const hasRemoved = await this.adapter.removeMany(this.context, [key]);
+        const hasRemoved = await this.adapter.removeMany([key], this.context);
 
         return hasRemoved;
     }
@@ -275,13 +275,13 @@ export class Cache<TType = unknown> implements ICache<TType> {
             return true;
         }
         const hasRemovedAtLeastOne = await this.adapter.removeMany(
-            this.context,
             keys,
+            this.context,
         );
         return hasRemovedAtLeastOne;
     }
 
     async clear(): Promise<void> {
-        await this.adapter.removeByKeyPrefix(this.context, "");
+        await this.adapter.removeByKeyPrefix("", this.context);
     }
 }

--- a/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.test.ts
+++ b/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
+import { type ICacheAdapter } from "@/cache/contracts/cache-adapter.contract.js";
 import { NoOpCacheAdapter } from "@/cache/implementations/adapters/_module.js";
 import { withCacheJitter } from "@/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.js";
 import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
@@ -33,17 +34,16 @@ describe("function: withCacheJitter", () => {
             const ttl = TimeSpan.fromMinutes(1);
             const expectedMs = (1 - 0.2 * 0.5) * ttl.toMilliseconds();
 
-            await enhanced.add(context, "myKey", "value", ttl);
+            await enhanced.add("myKey", "value", ttl, context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(
-                context,
+            expect(spy).toHaveBeenCalledWith<Parameters<ICacheAdapter["add"]>>(
                 "myKey",
                 "value",
                 TimeSpan.fromMilliseconds(expectedMs),
+                context,
             );
         });
-
         test("Should not apply jitter when TTL is null", async () => {
             const adapter = new NoOpCacheAdapter<string>();
             const spy = vi.spyOn(adapter, "add");
@@ -54,11 +54,12 @@ describe("function: withCacheJitter", () => {
                 withCacheJitter({ _mathRandom: mathRandom }),
             );
 
-            await enhanced.add(context, "myKey", "value", null);
+            await enhanced.add("myKey", "value", null, context);
 
-            expect(spy).toHaveBeenCalledWith(context, "myKey", "value", null);
+            expect(spy).toHaveBeenCalledWith<Parameters<ICacheAdapter["add"]>>(
+                ...["myKey", "value", null, context],
+            );
         });
-
         test("Should use default jitter of 0.2 when not specified", async () => {
             const adapter = new NoOpCacheAdapter<string>();
             const spy = vi.spyOn(adapter, "add");
@@ -72,17 +73,16 @@ describe("function: withCacheJitter", () => {
             const ttl = TimeSpan.fromMinutes(1);
             const expectedMs = (1 - 0.2 * 0.5) * ttl.toMilliseconds();
 
-            await enhanced.add(context, "myKey", "value", ttl);
+            await enhanced.add("myKey", "value", ttl, context);
 
-            expect(spy).toHaveBeenCalledWith(
-                context,
+            expect(spy).toHaveBeenCalledWith<Parameters<ICacheAdapter["add"]>>(
                 "myKey",
                 "value",
                 TimeSpan.fromMilliseconds(expectedMs),
+                context,
             );
         });
     });
-
     describe("method: put", () => {
         test("Should apply jitter to TTL", async () => {
             const adapter = new NoOpCacheAdapter<string>();
@@ -100,17 +100,16 @@ describe("function: withCacheJitter", () => {
             const ttl = TimeSpan.fromMinutes(1);
             const expectedMs = (1 - 0.5 * 0.3) * ttl.toMilliseconds();
 
-            await enhanced.put(context, "myKey", "value", ttl);
+            await enhanced.put("myKey", "value", ttl, context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(
-                context,
+            expect(spy).toHaveBeenCalledWith<Parameters<ICacheAdapter["put"]>>(
                 "myKey",
                 "value",
                 TimeSpan.fromMilliseconds(expectedMs),
+                context,
             );
         });
-
         test("Should not apply jitter when TTL is null", async () => {
             const adapter = new NoOpCacheAdapter<string>();
             const spy = vi.spyOn(adapter, "put");
@@ -121,9 +120,14 @@ describe("function: withCacheJitter", () => {
                 withCacheJitter({ _mathRandom: mathRandom }),
             );
 
-            await enhanced.put(context, "myKey", "value", null);
+            await enhanced.put("myKey", "value", null, context);
 
-            expect(spy).toHaveBeenCalledWith(context, "myKey", "value", null);
+            expect(spy).toHaveBeenCalledWith<Parameters<ICacheAdapter["put"]>>(
+                "myKey",
+                "value",
+                null,
+                context,
+            );
         });
     });
 });

--- a/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.ts
+++ b/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.ts
@@ -66,22 +66,22 @@ export function withCacheJitter(
         enhance(
             adapter,
             "add",
-            ({ args: [context, key, value, ttl], next }) => {
-                return next([context, key, value, ttlWithJitter(ttl)]);
+            ({ args: [key, value, ttl, context], next }) => {
+                return next([key, value, ttlWithJitter(ttl), context]);
             },
         );
         enhance(
             adapter,
             "put",
-            ({ args: [context, key, value, ttl], next }) => {
-                return next([context, key, value, ttlWithJitter(ttl)]);
+            ({ args: [key, value, ttl, context], next }) => {
+                return next([key, value, ttlWithJitter(ttl), context]);
             },
         );
         enhance(
             adapter,
             "getOrAdd",
-            ({ args: [context, key, value, ttl], next }) => {
-                return next([context, key, value, ttlWithJitter(ttl)]);
+            ({ args: [key, value, ttl, context], next }) => {
+                return next([key, value, ttlWithJitter(ttl), context]);
             },
         );
     };

--- a/src/cache/implementations/plugins/with-cache-prefix/with-cache-prefix.test.ts
+++ b/src/cache/implementations/plugins/with-cache-prefix/with-cache-prefix.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
+import { type ICacheAdapter } from "@/cache/contracts/cache-adapter.contract.js";
 import { NoOpCacheAdapter } from "@/cache/implementations/adapters/_module.js";
 import { withCachePrefix } from "@/cache/implementations/plugins/with-cache-prefix/with-cache-prefix.js";
 import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
@@ -17,112 +18,141 @@ describe("function: withCachePrefix", () => {
         vi.clearAllMocks();
     });
 
-    test("Should prefix keys for add", async () => {
-        const adapter = new NoOpCacheAdapter<string>();
-        const spy = vi.spyOn(adapter, "add");
+    describe("method: add", () => {
+        test("Should prefix keys", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "add");
 
-        const enhanced = withPlugin(adapter, withCachePrefix(prefix));
+            const enhanced = withPlugin(adapter, withCachePrefix(prefix));
 
-        await enhanced.add(context, "myKey", "value", TimeSpan.fromMinutes(5));
+            await enhanced.add(
+                "myKey",
+                "value",
+                TimeSpan.fromMinutes(5),
+                context,
+            );
 
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(
-            context,
-            `${prefix}myKey`,
-            "value",
-            TimeSpan.fromMinutes(5),
-        );
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith<Parameters<ICacheAdapter["add"]>>(
+                `${prefix}myKey`,
+                "value",
+                TimeSpan.fromMinutes(5),
+                context,
+            );
+        });
     });
+    describe("method: get", () => {
+        test("Should prefix keys", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "get");
 
-    test("Should prefix keys for get", async () => {
-        const adapter = new NoOpCacheAdapter<string>();
-        const spy = vi.spyOn(adapter, "get");
+            const enhanced = withPlugin(adapter, withCachePrefix(prefix));
 
-        const enhanced = withPlugin(adapter, withCachePrefix(prefix));
+            await enhanced.get("myKey", context);
 
-        await enhanced.get(context, "myKey");
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith<Parameters<ICacheAdapter["get"]>>(
+                `${prefix}myKey`,
+                context,
+            );
+        });
     });
+    describe("method: getAndRemove", () => {
+        test("Should prefix keys", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "getAndRemove");
 
-    test("Should prefix keys for getAndRemove", async () => {
-        const adapter = new NoOpCacheAdapter<string>();
-        const spy = vi.spyOn(adapter, "getAndRemove");
+            const enhanced = withPlugin(adapter, withCachePrefix(prefix));
 
-        const enhanced = withPlugin(adapter, withCachePrefix(prefix));
+            await enhanced.getAndRemove("myKey", context);
 
-        await enhanced.getAndRemove(context, "myKey");
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ICacheAdapter["getAndRemove"]>
+            >(`${prefix}myKey`, context);
+        });
     });
+    describe("method: increment", () => {
+        test("Should prefix keys", async () => {
+            const adapter = new NoOpCacheAdapter<number>();
+            const spy = vi.spyOn(adapter, "increment");
 
-    test("Should prefix keys for increment", async () => {
-        const adapter = new NoOpCacheAdapter<number>();
-        const spy = vi.spyOn(adapter, "increment");
+            const enhanced = withPlugin(adapter, withCachePrefix(prefix));
 
-        const enhanced = withPlugin(adapter, withCachePrefix(prefix));
+            await enhanced.increment("myKey", 5, context);
 
-        await enhanced.increment(context, "myKey", 5);
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, 5);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ICacheAdapter["increment"]>
+            >(`${prefix}myKey`, 5, context);
+        });
     });
+    describe("method: put", () => {
+        test("Should prefix keys", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "put");
 
-    test("Should prefix keys for put", async () => {
-        const adapter = new NoOpCacheAdapter<string>();
-        const spy = vi.spyOn(adapter, "put");
+            const enhanced = withPlugin(adapter, withCachePrefix(prefix));
 
-        const enhanced = withPlugin(adapter, withCachePrefix(prefix));
+            await enhanced.put(
+                "myKey",
+                "value",
+                TimeSpan.fromMinutes(5),
+                context,
+            );
 
-        await enhanced.put(context, "myKey", "value", TimeSpan.fromMinutes(5));
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(
-            context,
-            `${prefix}myKey`,
-            "value",
-            TimeSpan.fromMinutes(5),
-        );
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith<Parameters<ICacheAdapter["put"]>>(
+                `${prefix}myKey`,
+                "value",
+                TimeSpan.fromMinutes(5),
+                context,
+            );
+        });
     });
+    describe("method: removeByKeyPrefix", () => {
+        test("Should prefix keys", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "removeByKeyPrefix");
 
-    test("Should prefix keys for removeByKeyPrefix", async () => {
-        const adapter = new NoOpCacheAdapter<string>();
-        const spy = vi.spyOn(adapter, "removeByKeyPrefix");
+            const enhanced = withPlugin(adapter, withCachePrefix(prefix));
 
-        const enhanced = withPlugin(adapter, withCachePrefix(prefix));
+            await enhanced.removeByKeyPrefix("myKey", context);
 
-        await enhanced.removeByKeyPrefix(context, "myKey");
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ICacheAdapter["removeByKeyPrefix"]>
+            >(`${prefix}myKey`, context);
+        });
     });
+    describe("method: removeMany", () => {
+        test("Should prefix keys", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "removeMany");
 
-    test("Should prefix keys for removeMany", async () => {
-        const adapter = new NoOpCacheAdapter<string>();
-        const spy = vi.spyOn(adapter, "removeMany");
+            const enhanced = withPlugin(adapter, withCachePrefix(prefix));
 
-        const enhanced = withPlugin(adapter, withCachePrefix(prefix));
+            await enhanced.removeMany(["key1", "key2"], context);
 
-        await enhanced.removeMany(context, ["key1", "key2"]);
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, [
-            `${prefix}key1`,
-            `${prefix}key2`,
-        ]);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ICacheAdapter["removeMany"]>
+            >([`${prefix}key1`, `${prefix}key2`], context);
+        });
     });
+    describe("method: update", () => {
+        test("Should prefix keys", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "update");
 
-    test("Should prefix keys for update", async () => {
-        const adapter = new NoOpCacheAdapter<string>();
-        const spy = vi.spyOn(adapter, "update");
+            const enhanced = withPlugin(adapter, withCachePrefix(prefix));
 
-        const enhanced = withPlugin(adapter, withCachePrefix(prefix));
+            await enhanced.update("myKey", "newValue", context);
 
-        await enhanced.update(context, "myKey", "newValue");
-
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, "newValue");
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ICacheAdapter["update"]>
+            >(`${prefix}myKey`, "newValue", context);
+        });
     });
 });

--- a/src/cache/implementations/plugins/with-cache-prefix/with-cache-prefix.ts
+++ b/src/cache/implementations/plugins/with-cache-prefix/with-cache-prefix.ts
@@ -24,48 +24,36 @@ export function withCachePrefix(prefix: string): PluginFn<ICacheAdapter> {
         return prefix + key;
     }
     return (adapter, enhance) => {
-        enhance(adapter, "add", ({ args: [context, key, ...rest], next }) => {
-            return next([context, withPrefix(key), ...rest]);
+        enhance(adapter, "add", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
         });
-        enhance(adapter, "get", ({ args: [context, key], next }) => {
-            return next([context, withPrefix(key)]);
+        enhance(adapter, "get", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
         });
-        enhance(adapter, "getAndRemove", ({ args: [context, key], next }) => {
-            return next([context, withPrefix(key)]);
+        enhance(adapter, "getAndRemove", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
         });
-        enhance(
-            adapter,
-            "increment",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
-            },
-        );
-        enhance(adapter, "put", ({ args: [context, key, ...rest], next }) => {
-            return next([context, withPrefix(key), ...rest]);
+        enhance(adapter, "increment", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
+        });
+        enhance(adapter, "put", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
         });
         enhance(
             adapter,
             "removeByKeyPrefix",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
+            ({ args: [key, ...rest], next }) => {
+                return next([withPrefix(key), ...rest]);
             },
         );
-        enhance(adapter, "removeMany", ({ args: [context, keys], next }) => {
-            return next([context, keys.map(withPrefix)]);
+        enhance(adapter, "removeMany", ({ args: [keys, ...rest], next }) => {
+            return next([keys.map(withPrefix), ...rest]);
         });
-        enhance(
-            adapter,
-            "update",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
-            },
-        );
-        enhance(
-            adapter,
-            "getOrAdd",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
-            },
-        );
+        enhance(adapter, "update", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
+        });
+        enhance(adapter, "getOrAdd", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
+        });
     };
 }

--- a/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.test.ts
+++ b/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 
+import { type ICacheAdapter } from "@/cache/contracts/cache-adapter.contract.js";
 import { NoOpCacheAdapter } from "@/cache/implementations/adapters/_module.js";
 import { withCacheSchema } from "@/cache/implementations/plugins/with-cache-schema/with-cache-schema.js";
 import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
@@ -25,21 +26,20 @@ describe("function: withCacheSchema", () => {
             );
 
             await enhanced.add(
-                context,
                 "myKey",
                 "validValue",
                 TimeSpan.fromMinutes(5),
+                context,
             );
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(
-                context,
+            expect(spy).toHaveBeenCalledWith<Parameters<ICacheAdapter["add"]>>(
                 "myKey",
                 "validValue",
                 TimeSpan.fromMinutes(5),
+                context,
             );
         });
-
         test("Should throw when input validation fails", async () => {
             const adapter = new NoOpCacheAdapter<string>();
             const enhanced = withPlugin(
@@ -49,183 +49,13 @@ describe("function: withCacheSchema", () => {
 
             await expect(
                 enhanced.add(
-                    context,
                     "myKey",
                     "invalidValue",
                     TimeSpan.fromMinutes(5),
-                ),
-            ).rejects.toThrow();
-        });
-    });
-
-    describe("method: put", () => {
-        test("Should validate input", async () => {
-            const adapter = new NoOpCacheAdapter<string>();
-            const spy = vi.spyOn(adapter, "put");
-            const enhanced = withPlugin(
-                adapter,
-                withCacheSchema({ schema: passingSchema }),
-            );
-
-            await enhanced.put(
-                context,
-                "myKey",
-                "validValue",
-                TimeSpan.fromMinutes(5),
-            );
-
-            expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(
-                context,
-                "myKey",
-                "validValue",
-                TimeSpan.fromMinutes(5),
-            );
-        });
-
-        test("Should throw when input validation fails", async () => {
-            const adapter = new NoOpCacheAdapter<string>();
-            const enhanced = withPlugin(
-                adapter,
-                withCacheSchema({ schema: failingSchema }),
-            );
-
-            await expect(
-                enhanced.put(
                     context,
-                    "myKey",
-                    "invalidValue",
-                    TimeSpan.fromMinutes(5),
                 ),
             ).rejects.toThrow();
         });
-    });
-
-    describe("method: update", () => {
-        test("Should validate input", async () => {
-            const adapter = new NoOpCacheAdapter<string>();
-            const spy = vi.spyOn(adapter, "update");
-            const enhanced = withPlugin(
-                adapter,
-                withCacheSchema({ schema: passingSchema }),
-            );
-
-            await enhanced.update(context, "myKey", "validValue");
-
-            expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, "myKey", "validValue");
-        });
-
-        test("Should throw when input validation fails", async () => {
-            const adapter = new NoOpCacheAdapter<string>();
-            const enhanced = withPlugin(
-                adapter,
-                withCacheSchema({ schema: failingSchema }),
-            );
-
-            await expect(
-                enhanced.update(context, "myKey", "invalidValue"),
-            ).rejects.toThrow();
-        });
-    });
-
-    describe("method: get", () => {
-        test("Should validate output", async () => {
-            const adapter = new NoOpCacheAdapter<string>();
-            vi.spyOn(adapter, "get").mockResolvedValue("storedValue");
-            const enhanced = withPlugin(
-                adapter,
-                withCacheSchema({ schema: passingSchema }),
-            );
-
-            const result = await enhanced.get(context, "myKey");
-
-            expect(result).toBe("storedValue");
-        });
-
-        test("Should throw when output validation fails", async () => {
-            const adapter = new NoOpCacheAdapter<string>();
-            vi.spyOn(adapter, "get").mockResolvedValue("invalidValue");
-            const enhanced = withPlugin(
-                adapter,
-                withCacheSchema({ schema: failingSchema }),
-            );
-
-            await expect(enhanced.get(context, "myKey")).rejects.toThrow();
-        });
-
-        test("Should pass null through without validation when key is not found", async () => {
-            const adapter = new NoOpCacheAdapter<string>();
-            vi.spyOn(adapter, "get").mockResolvedValue(null);
-            const enhanced = withPlugin(
-                adapter,
-                withCacheSchema({ schema: passingSchema }),
-            );
-
-            const result = await enhanced.get(context, "myKey");
-
-            expect(result).toBeNull();
-        });
-    });
-
-    describe("method: getAndRemove", () => {
-        test("Should validate output", async () => {
-            const adapter = new NoOpCacheAdapter<string>();
-            vi.spyOn(adapter, "getAndRemove").mockResolvedValue("storedValue");
-            const enhanced = withPlugin(
-                adapter,
-                withCacheSchema({ schema: passingSchema }),
-            );
-
-            const result = await enhanced.getAndRemove(context, "myKey");
-
-            expect(result).toBe("storedValue");
-        });
-
-        test("Should throw when output validation fails", async () => {
-            const adapter = new NoOpCacheAdapter<string>();
-            vi.spyOn(adapter, "getAndRemove").mockResolvedValue("invalidValue");
-            const enhanced = withPlugin(
-                adapter,
-                withCacheSchema({ schema: failingSchema }),
-            );
-
-            await expect(
-                enhanced.getAndRemove(context, "myKey"),
-            ).rejects.toThrow();
-        });
-
-        test("Should pass null through without validation when key is not found", async () => {
-            const adapter = new NoOpCacheAdapter<string>();
-            vi.spyOn(adapter, "getAndRemove").mockResolvedValue(null);
-            const enhanced = withPlugin(
-                adapter,
-                withCacheSchema({ schema: passingSchema }),
-            );
-
-            const result = await enhanced.getAndRemove(context, "myKey");
-
-            expect(result).toBeNull();
-        });
-    });
-
-    describe("options", () => {
-        test("Should skip output validation when shouldValidateOutput is false", async () => {
-            const adapter = new NoOpCacheAdapter<string>();
-            vi.spyOn(adapter, "get").mockResolvedValue("someValue");
-            const enhanced = withPlugin(
-                adapter,
-                withCacheSchema({
-                    schema: failingSchema,
-                    shouldValidateOutput: false,
-                }),
-            );
-
-            const result = await enhanced.get(context, "myKey");
-
-            expect(result).toBe("someValue");
-        });
-
         test("Should still validate input when shouldValidateOutput is false", async () => {
             const adapter = new NoOpCacheAdapter<string>();
             const spy = vi.spyOn(adapter, "add");
@@ -238,13 +68,222 @@ describe("function: withCacheSchema", () => {
             );
 
             await enhanced.add(
-                context,
                 "myKey",
                 "validValue",
                 TimeSpan.fromMinutes(5),
+                context,
             );
 
             expect(spy).toHaveBeenCalledOnce();
+        });
+    });
+    describe("method: put", () => {
+        test("Should validate input", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "put");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: passingSchema }),
+            );
+
+            await enhanced.put(
+                "myKey",
+                "validValue",
+                TimeSpan.fromMinutes(5),
+                context,
+            );
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith<Parameters<ICacheAdapter["put"]>>(
+                "myKey",
+                "validValue",
+                TimeSpan.fromMinutes(5),
+                context,
+            );
+        });
+        test("Should throw when input validation fails", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: failingSchema }),
+            );
+
+            await expect(
+                enhanced.put(
+                    "myKey",
+                    "invalidValue",
+                    TimeSpan.fromMinutes(5),
+                    context,
+                ),
+            ).rejects.toThrow();
+        });
+        test("Should still validate input when shouldValidateOutput is false", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "put");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({
+                    schema: passingSchema,
+                    shouldValidateOutput: false,
+                }),
+            );
+
+            await enhanced.put(
+                "myKey",
+                "validValue",
+                TimeSpan.fromMinutes(5),
+                context,
+            );
+
+            expect(spy).toHaveBeenCalledOnce();
+        });
+    });
+    describe("method: update", () => {
+        test("Should validate input", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "update");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: passingSchema }),
+            );
+
+            await enhanced.update("myKey", "validValue", context);
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ICacheAdapter["update"]>
+            >("myKey", "validValue", context);
+        });
+        test("Should throw when input validation fails", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: failingSchema }),
+            );
+
+            await expect(
+                enhanced.update("myKey", "invalidValue", context),
+            ).rejects.toThrow();
+        });
+        test("Should still validate input when shouldValidateOutput is false", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            const spy = vi.spyOn(adapter, "update");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({
+                    schema: passingSchema,
+                    shouldValidateOutput: false,
+                }),
+            );
+
+            await enhanced.update("myKey", "validValue", context);
+
+            expect(spy).toHaveBeenCalledOnce();
+        });
+    });
+    describe("method: get", () => {
+        test("Should validate output", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            vi.spyOn(adapter, "get").mockResolvedValue("storedValue");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: passingSchema }),
+            );
+
+            const result = await enhanced.get("myKey", context);
+
+            expect(result).toBe("storedValue");
+        });
+        test("Should throw when output validation fails", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            vi.spyOn(adapter, "get").mockResolvedValue("invalidValue");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: failingSchema }),
+            );
+
+            await expect(enhanced.get("myKey", context)).rejects.toThrow();
+        });
+        test("Should pass null through without validation when key is not found", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            vi.spyOn(adapter, "get").mockResolvedValue(null);
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: passingSchema }),
+            );
+
+            const result = await enhanced.get("myKey", context);
+
+            expect(result).toBeNull();
+        });
+        test("Should skip output validation when shouldValidateOutput is false", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            vi.spyOn(adapter, "get").mockResolvedValue("someValue");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({
+                    schema: failingSchema,
+                    shouldValidateOutput: false,
+                }),
+            );
+
+            const result = await enhanced.get("myKey", context);
+
+            expect(result).toBe("someValue");
+        });
+    });
+
+    describe("method: getAndRemove", () => {
+        test("Should validate output", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            vi.spyOn(adapter, "getAndRemove").mockResolvedValue("storedValue");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: passingSchema }),
+            );
+
+            const result = await enhanced.getAndRemove("myKey", context);
+
+            expect(result).toBe("storedValue");
+        });
+        test("Should throw when output validation fails", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            vi.spyOn(adapter, "getAndRemove").mockResolvedValue("invalidValue");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: failingSchema }),
+            );
+
+            await expect(
+                enhanced.getAndRemove("myKey", context),
+            ).rejects.toThrow();
+        });
+        test("Should pass null through without validation when key is not found", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            vi.spyOn(adapter, "getAndRemove").mockResolvedValue(null);
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({ schema: passingSchema }),
+            );
+
+            const result = await enhanced.getAndRemove("myKey", context);
+
+            expect(result).toBeNull();
+        });
+        test("Should skip output validation when shouldValidateOutput is false", async () => {
+            const adapter = new NoOpCacheAdapter<string>();
+            vi.spyOn(adapter, "getAndRemove").mockResolvedValue("someValue");
+            const enhanced = withPlugin(
+                adapter,
+                withCacheSchema({
+                    schema: failingSchema,
+                    shouldValidateOutput: false,
+                }),
+            );
+
+            const result = await enhanced.getAndRemove("myKey", context);
+
+            expect(result).toBe("someValue");
         });
     });
 });

--- a/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.ts
+++ b/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.ts
@@ -79,33 +79,33 @@ export function withCacheSchema(
         enhance(
             adapter,
             "add",
-            async ({ args: [context, key, value, ttl], next }) => {
-                return next([context, key, await validate(schema, value), ttl]);
+            async ({ args: [key, value, ...rest], next }) => {
+                return next([key, await validate(schema, value), ...rest]);
             },
         );
         enhance(
             adapter,
             "put",
-            async ({ args: [context, key, value, ttl], next }) => {
-                return next([context, key, await validate(schema, value), ttl]);
+            async ({ args: [key, value, ...rest], next }) => {
+                return next([key, await validate(schema, value), ...rest]);
             },
         );
         enhance(
             adapter,
             "update",
-            async ({ args: [context, key, value], next }) => {
-                return next([context, key, await validate(schema, value)]);
+            async ({ args: [key, value, ...rest], next }) => {
+                return next([key, await validate(schema, value), ...rest]);
             },
         );
         enhance(
             adapter,
             "getOrAdd",
-            async ({ args: [context, key, valueToAdd, ttl], next }) => {
+            async ({ args: [key, valueToAdd, ttl, ...rest], next }) => {
                 const valueToReturn = await next([
-                    context,
                     key,
                     await validate(schema, valueToAdd),
                     ttl,
+                    ...rest,
                 ]);
                 return await validate(schema, valueToReturn);
             },

--- a/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.test.ts
+++ b/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.test.ts
@@ -38,10 +38,10 @@ describe("function: withCacheWriteLock", () => {
 
             console.log("1.");
             await enhanced.add(
-                context,
                 "myKey",
                 "value",
                 TimeSpan.fromMinutes(5),
+                context,
             );
             console.log("2.");
 
@@ -65,10 +65,10 @@ describe("function: withCacheWriteLock", () => {
             );
 
             await enhanced.put(
-                context,
                 "myKey",
                 "value",
                 TimeSpan.fromMinutes(5),
+                context,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -90,7 +90,7 @@ describe("function: withCacheWriteLock", () => {
                 withCacheWriteLock({ lockFactory }),
             );
 
-            await enhanced.update(context, "myKey", "newValue");
+            await enhanced.update("myKey", "newValue", context);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -111,7 +111,7 @@ describe("function: withCacheWriteLock", () => {
                 withCacheWriteLock({ lockFactory }),
             );
 
-            await enhanced.increment(context, "myKey", 5);
+            await enhanced.increment("myKey", 5, context);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -132,7 +132,7 @@ describe("function: withCacheWriteLock", () => {
                 withCacheWriteLock({ lockFactory }),
             );
 
-            await enhanced.getAndRemove(context, "myKey");
+            await enhanced.getAndRemove("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -149,7 +149,7 @@ describe("function: withCacheWriteLock", () => {
                 withCacheWriteLock({ lockFactory }),
             );
 
-            const result = await enhanced.getAndRemove(context, "myKey");
+            const result = await enhanced.getAndRemove("myKey", context);
 
             expect(result).toBe("storedValue");
         });
@@ -168,7 +168,7 @@ describe("function: withCacheWriteLock", () => {
                 withCacheWriteLock({ lockFactory }),
             );
 
-            await enhanced.removeMany(context, ["key1", "key2", "key3"]);
+            await enhanced.removeMany(["key1", "key2", "key3"], context);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledWith("key1");
@@ -189,12 +189,10 @@ describe("function: withCacheWriteLock", () => {
                 withCacheWriteLock({ lockFactory }),
             );
 
-            await enhanced.removeMany(context, [
-                "key1",
-                "key2",
-                "key1",
-                "key3",
-            ]);
+            await enhanced.removeMany(
+                ["key1", "key2", "key1", "key3"],
+                context,
+            );
 
             expect(spy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledTimes(3);
@@ -214,7 +212,7 @@ describe("function: withCacheWriteLock", () => {
                 withCacheWriteLock({ lockFactory }),
             );
 
-            const result = await enhanced.removeMany(context, ["key1", "key2"]);
+            const result = await enhanced.removeMany(["key1", "key2"], context);
 
             expect(result).toBe(true);
         });
@@ -237,16 +235,16 @@ describe("function: withCacheWriteLock", () => {
             );
 
             await enhanced.add(
-                context,
                 "myKey",
                 "value",
                 TimeSpan.fromMinutes(5),
+                context,
             );
             expect(createSpy).toHaveBeenCalledWith("myKey");
             expect(runSpy).toHaveBeenCalledTimes(1);
 
             vi.clearAllMocks();
-            await enhanced.get(context, "myKey");
+            await enhanced.get("myKey", context);
             expect(createSpy).not.toHaveBeenCalled();
             expect(runSpy).not.toHaveBeenCalled();
             expect(getSpy).toHaveBeenCalledOnce();

--- a/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.ts
+++ b/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.ts
@@ -93,19 +93,15 @@ export function withCacheWriteLock(
                 "getAndRemove" satisfies WithCacheWriteLockMethods,
             )
         ) {
-            enhance(
-                adapter,
-                "getAndRemove",
-                ({ args: [_context, key], next }) => {
-                    return lockFactory.create(key).runOrFail(() => {
-                        return next();
-                    });
-                },
-            );
+            enhance(adapter, "getAndRemove", ({ args: [key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
         }
 
         if (onlyMethods.includes("add" satisfies WithCacheWriteLockMethods)) {
-            enhance(adapter, "add", ({ args: [_context, key], next }) => {
+            enhance(adapter, "add", ({ args: [key], next }) => {
                 return lockFactory.create(key).runOrFail(() => {
                     return next();
                 });
@@ -113,7 +109,7 @@ export function withCacheWriteLock(
         }
 
         if (onlyMethods.includes("put" satisfies WithCacheWriteLockMethods)) {
-            enhance(adapter, "put", ({ args: [_context, key], next }) => {
+            enhance(adapter, "put", ({ args: [key], next }) => {
                 return lockFactory.create(key).runOrFail(() => {
                     return next();
                 });
@@ -123,7 +119,7 @@ export function withCacheWriteLock(
         if (
             onlyMethods.includes("update" satisfies WithCacheWriteLockMethods)
         ) {
-            enhance(adapter, "update", ({ args: [_context, key], next }) => {
+            enhance(adapter, "update", ({ args: [key], next }) => {
                 return lockFactory.create(key).runOrFail(() => {
                     return next();
                 });
@@ -135,7 +131,7 @@ export function withCacheWriteLock(
                 "increment" satisfies WithCacheWriteLockMethods,
             )
         ) {
-            enhance(adapter, "increment", ({ args: [_context, key], next }) => {
+            enhance(adapter, "increment", ({ args: [key], next }) => {
                 return lockFactory.create(key).runOrFail(() => {
                     return next();
                 });
@@ -147,32 +143,24 @@ export function withCacheWriteLock(
                 "removeMany" satisfies WithCacheWriteLockMethods,
             )
         ) {
-            enhance(
-                adapter,
-                "removeMany",
-                ({ args: [_context, keys], next }) => {
-                    let fn = () => next();
-                    for (const key of [...new Set(keys)].reverse()) {
-                        const prevFn = fn;
-                        fn = () => lockFactory.create(key).runOrFail(prevFn);
-                    }
-                    return fn();
-                },
-            );
+            enhance(adapter, "removeMany", ({ args: [keys], next }) => {
+                let fn = () => next();
+                for (const key of [...new Set(keys)].reverse()) {
+                    const prevFn = fn;
+                    fn = () => lockFactory.create(key).runOrFail(prevFn);
+                }
+                return fn();
+            });
         }
 
         if (
             onlyMethods.includes("getOrAdd" satisfies WithCacheWriteLockMethods)
         ) {
-            enhance(
-                adapter,
-                "getOrAdd",
-                async ({ args: [_context, key], next }) => {
-                    return lockFactory.create(key).runOrFail(async () => {
-                        return next();
-                    });
-                },
-            );
+            enhance(adapter, "getOrAdd", async ({ args: [key], next }) => {
+                return lockFactory.create(key).runOrFail(async () => {
+                    return next();
+                });
+            });
         }
     };
 }

--- a/src/cache/implementations/test-utilities/cache-adapter.test-suite.ts
+++ b/src/cache/implementations/test-utilities/cache-adapter.test-suite.ts
@@ -120,39 +120,39 @@ export function cacheAdapterTestSuite(
     describe("ICacheAdapter tests:", () => {
         describe("method: get", () => {
             test("Should return the value when key exists", async () => {
-                await adapter.add(context, "a", 1, null);
+                await adapter.add("a", 1, null, context);
                 await delayWithBuffer(TTL.divide(4));
-                expect(await adapter.get(context, "a")).toBe(1);
+                expect(await adapter.get("a", context)).toBe(1);
             });
             test("Should return null when keys doesnt exists", async () => {
-                expect(await adapter.get(context, "a")).toBeNull();
+                expect(await adapter.get("a", context)).toBeNull();
             });
             test("Should return null when key is experied", async () => {
-                await adapter.add(context, "a", 1, TTL);
+                await adapter.add("a", 1, TTL, context);
                 await delayWithBuffer(TTL);
-                expect(await adapter.get(context, "a")).toBeNull();
+                expect(await adapter.get("a", context)).toBeNull();
             });
         });
         describe("method: getAndRemove", () => {
             test("Should return value when key exists", async () => {
-                await adapter.add(context, "a", 1, null);
+                await adapter.add("a", 1, null, context);
                 await delayWithBuffer(TTL.divide(4));
-                expect(await adapter.getAndRemove(context, "a")).toBe(1);
+                expect(await adapter.getAndRemove("a", context)).toBe(1);
             });
             test("Should return null when key doesnt exists", async () => {
-                expect(await adapter.getAndRemove(context, "a")).toBeNull();
+                expect(await adapter.getAndRemove("a", context)).toBeNull();
             });
             test("Should return null when key is expired", async () => {
-                await adapter.add(context, "a", 1, TTL);
+                await adapter.add("a", 1, TTL, context);
                 await delayWithBuffer(TTL);
-                expect(await adapter.getAndRemove(context, "a")).toBeNull();
+                expect(await adapter.getAndRemove("a", context)).toBeNull();
             });
             test("Should persist removal when key exists", async () => {
-                await adapter.add(context, "a", 1, null);
+                await adapter.add("a", 1, null, context);
                 await delayWithBuffer(TTL.divide(4));
-                await adapter.getAndRemove(context, "a");
+                await adapter.getAndRemove("a", context);
                 await delayWithBuffer(TTL.divide(4));
-                expect(await adapter.get(context, "a")).toBeNull();
+                expect(await adapter.get("a", context)).toBeNull();
             });
         });
         describe("method: getOrAdd", () => {
@@ -161,10 +161,10 @@ export function cacheAdapterTestSuite(
 
                 const valueToAdd = -1;
                 const result = await adapter.getOrAdd(
-                    context,
                     key,
                     valueToAdd,
                     null,
+                    context,
                 );
 
                 expect(result).toBe(valueToAdd);
@@ -173,49 +173,49 @@ export function cacheAdapterTestSuite(
                 const key = "a";
 
                 const valueToAdd = -1;
-                await adapter.getOrAdd(context, key, valueToAdd, null);
+                await adapter.getOrAdd(key, valueToAdd, null, context);
 
-                const result = await adapter.get(context, key);
+                const result = await adapter.get(key, context);
                 expect(result).toBe(valueToAdd);
             });
             test("Should return value to add when key is expired", async () => {
                 const key = "a";
-                await adapter.add(context, key, 1, TTL);
+                await adapter.add(key, 1, TTL, context);
                 await delayWithBuffer(TTL);
 
                 const valueToAdd = -1;
                 const result = await adapter.getOrAdd(
-                    context,
                     key,
                     valueToAdd,
                     null,
+                    context,
                 );
 
                 expect(result).toBe(valueToAdd);
             });
             test("Should persist value when key is expired", async () => {
                 const key = "a";
-                await adapter.add(context, key, 1, TTL);
+                await adapter.add(key, 1, TTL, context);
                 await delayWithBuffer(TTL);
 
                 const valueToAdd = -1;
-                await adapter.getOrAdd(context, key, valueToAdd, null);
+                await adapter.getOrAdd(key, valueToAdd, null, context);
 
-                const result = await adapter.get(context, key);
+                const result = await adapter.get(key, context);
                 expect(result).toBe(valueToAdd);
             });
             test("Should return value when key exists", async () => {
                 const key = "a";
 
                 const value = 1;
-                await adapter.add(context, key, value, null);
+                await adapter.add(key, value, null, context);
 
                 const valueToAdd = -1;
                 const result = await adapter.getOrAdd(
-                    context,
                     key,
                     valueToAdd,
                     null,
+                    context,
                 );
 
                 expect(result).toBe(value);
@@ -224,12 +224,12 @@ export function cacheAdapterTestSuite(
                 const key = "a";
 
                 const value = 1;
-                await adapter.add(context, key, value, null);
+                await adapter.add(key, value, null, context);
 
                 const valueToAdd = -1;
-                await adapter.getOrAdd(context, key, valueToAdd, null);
+                await adapter.getOrAdd(key, valueToAdd, null, context);
 
-                const result = await adapter.get(context, key);
+                const result = await adapter.get(key, context);
                 expect(result).toBe(value);
             });
             test("Should return value when key is unexpired", async () => {
@@ -237,14 +237,14 @@ export function cacheAdapterTestSuite(
                 const longTtl = TimeSpan.fromMinutes(5);
 
                 const value = 1;
-                await adapter.add(context, key, value, longTtl);
+                await adapter.add(key, value, longTtl, context);
 
                 const valueToAdd = -1;
                 const result = await adapter.getOrAdd(
-                    context,
                     key,
                     valueToAdd,
                     null,
+                    context,
                 );
 
                 expect(result).toBe(value);
@@ -254,232 +254,230 @@ export function cacheAdapterTestSuite(
                 const longTtl = TimeSpan.fromMinutes(5);
 
                 const value = 1;
-                await adapter.add(context, key, value, longTtl);
+                await adapter.add(key, value, longTtl, context);
 
                 const valueToAdd = -1;
-                await adapter.getOrAdd(context, key, valueToAdd, null);
+                await adapter.getOrAdd(key, valueToAdd, null, context);
 
-                const result = await adapter.get(context, key);
+                const result = await adapter.get(key, context);
                 expect(result).toBe(value);
             });
         });
         describe("method: add", () => {
             test("Should return true when key doesnt exists", async () => {
-                const result = await adapter.add(context, "a", 1, null);
+                const result = await adapter.add("a", 1, null, context);
                 await delayWithBuffer(TTL.divide(4));
                 expect(result).toBe(true);
             });
             test("Should return true when key is expired", async () => {
-                await adapter.add(context, "a", 1, TTL);
+                await adapter.add("a", 1, TTL, context);
                 await delayWithBuffer(TTL);
-                expect(await adapter.add(context, "a", 1, null)).toBe(true);
+                expect(await adapter.add("a", 1, null, context)).toBe(true);
             });
             test("Should persist values when key doesnt exist", async () => {
-                await adapter.add(context, "a", 1, null);
+                await adapter.add("a", 1, null, context);
                 await delayWithBuffer(TTL.divide(4));
-                expect(await adapter.get(context, "a")).toBe(1);
+                expect(await adapter.get("a", context)).toBe(1);
             });
             test("Should persist values when key is expired", async () => {
-                await adapter.add(context, "a", -1, TTL);
+                await adapter.add("a", -1, TTL, context);
                 await delayWithBuffer(TTL);
-                await adapter.add(context, "a", 1, null);
-                expect(await adapter.get(context, "a")).toBe(1);
+                await adapter.add("a", 1, null, context);
+                expect(await adapter.get("a", context)).toBe(1);
             });
             test("Should return false when key exists", async () => {
-                await adapter.add(context, "a", 1, null);
+                await adapter.add("a", 1, null, context);
                 await delayWithBuffer(TTL.divide(4));
-                expect(await adapter.add(context, "a", 1, null)).toBe(false);
+                expect(await adapter.add("a", 1, null, context)).toBe(false);
             });
             test("Should not persist value when key exist", async () => {
-                await adapter.add(context, "a", 1, null);
+                await adapter.add("a", 1, null, context);
                 await delayWithBuffer(TTL.divide(4));
-                await adapter.add(context, "a", 2, null);
+                await adapter.add("a", 2, null, context);
                 await delayWithBuffer(TTL.divide(4));
-                expect(await adapter.get(context, "a")).toBe(1);
+                expect(await adapter.get("a", context)).toBe(1);
             });
         });
         describe("method: put", () => {
             test("Should return true when key exists", async () => {
-                await adapter.add(context, "a", 1, null);
+                await adapter.add("a", 1, null, context);
                 await delayWithBuffer(TTL.divide(4));
-                expect(await adapter.put(context, "a", -1, null)).toBe(true);
+                expect(await adapter.put("a", -1, null, context)).toBe(true);
             });
             test("Should persist value when key exist", async () => {
-                await adapter.add(context, "a", 1, null);
+                await adapter.add("a", 1, null, context);
                 await delayWithBuffer(TTL.divide(4));
-                await adapter.put(context, "a", -1, null);
+                await adapter.put("a", -1, null, context);
                 await delayWithBuffer(TTL.divide(4));
-                expect(await adapter.get(context, "a")).toBe(-1);
+                expect(await adapter.get("a", context)).toBe(-1);
             });
             test("Should return false when key doesnt exists", async () => {
-                expect(await adapter.put(context, "a", -1, null)).toBe(false);
+                expect(await adapter.put("a", -1, null, context)).toBe(false);
             });
             test("Should return false when key is expired", async () => {
-                await adapter.add(context, "a", 1, TTL);
+                await adapter.add("a", 1, TTL, context);
                 await delayWithBuffer(TTL);
-                expect(await adapter.put(context, "a", -1, null)).toBe(false);
+                expect(await adapter.put("a", -1, null, context)).toBe(false);
             });
             test("Should persist values when key doesnt exist", async () => {
-                await adapter.put(context, "a", -1, null);
+                await adapter.put("a", -1, null, context);
                 await delayWithBuffer(TTL.divide(4));
-                expect(await adapter.get(context, "a")).toBe(-1);
+                expect(await adapter.get("a", context)).toBe(-1);
             });
             test("Should persist values when key is expired", async () => {
-                await adapter.add(context, "a", 1, TTL);
+                await adapter.add("a", 1, TTL, context);
                 await delayWithBuffer(TTL);
-                await adapter.put(context, "a", -1, null);
+                await adapter.put("a", -1, null, context);
                 await delayWithBuffer(TTL.divide(4));
-                expect(await adapter.get(context, "a")).toBe(-1);
+                expect(await adapter.get("a", context)).toBe(-1);
             });
             test("Should replace the ttl value", async () => {
                 const ttlA = TimeSpan.fromMilliseconds(100);
-                await adapter.add(context, "a", 1, ttlA);
+                await adapter.add("a", 1, ttlA, context);
                 await delayWithBuffer(TTL.divide(4));
                 const ttlB = TimeSpan.fromMilliseconds(50);
-                await adapter.put(context, "a", -1, ttlB);
+                await adapter.put("a", -1, ttlB, context);
                 await delayWithBuffer(ttlB);
-                expect(await adapter.get(context, "a")).toBeNull();
+                expect(await adapter.get("a", context)).toBeNull();
             });
         });
         describe("method: update", () => {
             test("Should return true when key exists", async () => {
-                await adapter.add(context, "a", 1, null);
+                await adapter.add("a", 1, null, context);
                 await delayWithBuffer(TTL.divide(4));
-                expect(await adapter.update(context, "a", -1)).toBe(true);
+                expect(await adapter.update("a", -1, context)).toBe(true);
             });
             test("Should persist value when key exist", async () => {
-                await adapter.add(context, "a", 1, null);
+                await adapter.add("a", 1, null, context);
                 await delayWithBuffer(TTL.divide(4));
-                await adapter.update(context, "a", -1);
+                await adapter.update("a", -1, context);
                 await delayWithBuffer(TTL.divide(4));
-                expect(await adapter.get(context, "a")).toBe(-1);
+                expect(await adapter.get("a", context)).toBe(-1);
             });
             test("Should return false when key doesnt exists", async () => {
-                expect(await adapter.update(context, "a", -1)).toBe(false);
+                expect(await adapter.update("a", -1, context)).toBe(false);
             });
             test("Should return false when key is expired", async () => {
-                await adapter.add(context, "a", 1, TTL);
+                await adapter.add("a", 1, TTL, context);
                 await delayWithBuffer(TTL);
-                expect(await adapter.update(context, "a", -1)).toBe(false);
+                expect(await adapter.update("a", -1, context)).toBe(false);
             });
             test("Should not persist value when key doesnt exist", async () => {
-                await adapter.update(context, "a", -1);
+                await adapter.update("a", -1, context);
                 await delayWithBuffer(TTL.divide(4));
-                expect(await adapter.get(context, "a")).toBeNull();
+                expect(await adapter.get("a", context)).toBeNull();
             });
             test("Should not persist value when key is expired", async () => {
-                await adapter.add(context, "a", 1, TTL);
+                await adapter.add("a", 1, TTL, context);
                 await delayWithBuffer(TTL);
-                await adapter.update(context, "a", -1);
-                expect(await adapter.get(context, "a")).toBeNull();
+                await adapter.update("a", -1, context);
+                expect(await adapter.get("a", context)).toBeNull();
             });
         });
         describe("method: increment", () => {
             test("Should return true when key exists", async () => {
-                await adapter.add(context, "a", 1, null);
+                await adapter.add("a", 1, null, context);
                 await delayWithBuffer(TTL.divide(4));
-                expect(await adapter.increment(context, "a", 1)).toBe(true);
+                expect(await adapter.increment("a", 1, context)).toBe(true);
             });
             test("Should persist increment when key exists", async () => {
-                await adapter.add(context, "a", 1, null);
+                await adapter.add("a", 1, null, context);
                 await delayWithBuffer(TTL.divide(4));
-                await adapter.increment(context, "a", 1);
+                await adapter.increment("a", 1, context);
                 await delayWithBuffer(TTL.divide(4));
-                expect(await adapter.get(context, "a")).toBe(2);
+                expect(await adapter.get("a", context)).toBe(2);
             });
             test("Should return false when key doesnt exists", async () => {
-                expect(await adapter.increment(context, "a", 1)).toBe(false);
+                expect(await adapter.increment("a", 1, context)).toBe(false);
             });
             test("Should return false when key is expired", async () => {
-                await adapter.add(context, "a", 1, TTL);
+                await adapter.add("a", 1, TTL, context);
                 await delayWithBuffer(TTL);
-                expect(await adapter.increment(context, "a", 1)).toBe(false);
+                expect(await adapter.increment("a", 1, context)).toBe(false);
             });
             test("Should not persist increment when key doesnt exists", async () => {
-                await adapter.increment(context, "a", 1);
+                await adapter.increment("a", 1, context);
                 await delayWithBuffer(TTL.divide(4));
-                expect(await adapter.get(context, "a")).toBeNull();
+                expect(await adapter.get("a", context)).toBeNull();
             });
             test("Should not persist increment when key is expired", async () => {
-                await adapter.add(context, "a", 1, TTL);
+                await adapter.add("a", 1, TTL, context);
                 await delayWithBuffer(TTL);
-                await adapter.increment(context, "a", 1);
-                expect(await adapter.get(context, "a")).toBeNull();
+                await adapter.increment("a", 1, context);
+                expect(await adapter.get("a", context)).toBeNull();
             });
             test("Should throw TypeError when value is not number type", async () => {
-                await adapter.add(context, "a", "str", null);
+                await adapter.add("a", "str", null, context);
                 await delayWithBuffer(TTL.divide(4));
                 await expect(
-                    adapter.increment(context, "a", 1),
+                    adapter.increment("a", 1, context),
                 ).rejects.toBeInstanceOf(TypeError);
             });
         });
         describe("method: removeMany", () => {
             test("Should return false when all keys does not exists", async () => {
-                const result = await adapter.removeMany(context, [
-                    "a",
-                    "b",
-                    "c",
-                ]);
+                const result = await adapter.removeMany(
+                    ["a", "b", "c"],
+                    context,
+                );
 
                 expect(result).toBe(false);
             });
             test("Should return true when one key exists", async () => {
-                await adapter.add(context, "a", 1, null);
+                await adapter.add("a", 1, null, context);
                 await delayWithBuffer(TTL.divide(4));
 
-                const result = await adapter.removeMany(context, [
-                    "a",
-                    "b",
-                    "c",
-                ]);
+                const result = await adapter.removeMany(
+                    ["a", "b", "c"],
+                    context,
+                );
 
                 expect(result).toBe(true);
             });
             test("Should persist removal of the keys that exists", async () => {
-                await adapter.add(context, "a", 1, null);
-                await adapter.add(context, "b", 2, null);
-                await adapter.add(context, "c", 3, null);
+                await adapter.add("a", 1, null, context);
+                await adapter.add("b", 2, null, context);
+                await adapter.add("c", 3, null, context);
                 await delayWithBuffer(TTL.divide(4));
 
-                await adapter.removeMany(context, ["a", "b"]);
+                await adapter.removeMany(["a", "b"], context);
                 await delayWithBuffer(TTL.divide(4));
 
                 const result = [
-                    await adapter.get(context, "a"),
-                    await adapter.get(context, "b"),
-                    await adapter.get(context, "c"),
+                    await adapter.get("a", context),
+                    await adapter.get("b", context),
+                    await adapter.get("c", context),
                 ];
                 expect(result).toEqual([null, null, 3]);
             });
         });
         describe("method: removeAll", () => {
             test("Should remove all keys", async () => {
-                await adapter.add(context, "cache/a", 1, null);
-                await adapter.add(context, "cache/b", 2, null);
-                await adapter.add(context, "c", 3, null);
+                await adapter.add("cache/a", 1, null, context);
+                await adapter.add("cache/b", 2, null, context);
+                await adapter.add("c", 3, null, context);
                 await delayWithBuffer(TTL.divide(4));
                 await adapter.removeAll(context);
                 await delayWithBuffer(TTL.divide(4));
                 expect([
-                    await adapter.get(context, "cache/a"),
-                    await adapter.get(context, "cache/b"),
-                    await adapter.get(context, "c"),
+                    await adapter.get("cache/a", context),
+                    await adapter.get("cache/b", context),
+                    await adapter.get("c", context),
                 ]).toEqual([null, null, null]);
             });
         });
         describe("method: removeByKeyPrefix", () => {
             test(`Should remove all keys that start with prefix "cache"`, async () => {
-                await adapter.add(context, "cache/a", 1, null);
-                await adapter.add(context, "cache/b", 2, null);
-                await adapter.add(context, "c", 3, null);
+                await adapter.add("cache/a", 1, null, context);
+                await adapter.add("cache/b", 2, null, context);
+                await adapter.add("c", 3, null, context);
                 await delayWithBuffer(TTL.divide(4));
-                await adapter.removeByKeyPrefix(context, "cache");
+                await adapter.removeByKeyPrefix("cache", context);
                 await delayWithBuffer(TTL.divide(4));
                 const result = [
-                    await adapter.get(context, "cache/a"),
-                    await adapter.get(context, "cache/b"),
-                    await adapter.get(context, "c"),
+                    await adapter.get("cache/a", context),
+                    await adapter.get("cache/b", context),
+                    await adapter.get("c", context),
                 ];
                 expect(result).toEqual([null, null, 3]);
             });


### PR DESCRIPTION
- **refactor(cache): move context parameter to last position in ICacheAdapter methods**
- **refactor(no-op-cache-adapter): move context parameter to last position**
- **refactor(memory-cache-adapter): move context parameter to last position**
- **refactor(redis-cache-adapter): move context parameter to last position**
- **refactor(kysely-cache-adapter): move context parameter to last position**
- **refactor(mongodb-cache-adapter): move context parameter to last position**
- **refactor(with-cache-jitter): move context parameter to last position**
- **refactor(with-cache-prefix): move context parameter to last position**
- **refactor(with-cache-schema): move context parameter to last position**
- **refactor(with-cache-write-lock): move context parameter to last position**
- **refactor(cache-adapter-test-suite): move context parameter to last position**
- **refactor(cache): move context parameter to last position in adapter calls**
- **test(with-cache-jitter): move context parameter to last position**
- **test(with-cache-prefix): move context parameter to last position**
- **test(with-cache-schema): move context parameter to last position**
- **test(with-cache-write-lock): move context parameter to last position**
