### PR TITLE
enhacement/file storage

### DIFF
--- a/src/file-storage/contracts/file-storage-adapter.contract.ts
+++ b/src/file-storage/contracts/file-storage-adapter.contract.ts
@@ -75,13 +75,14 @@ export type IFileUrlAdapter = {
      * Generates a public, permanently-accessible URL for a file.
      * Returns null if the file does not exist or public access is not supported by the adapter.
      *
-     * @param context - Readable execution context for the operation
      * @param key - The file identifier/path
+     * @param context - Readable execution context for the operation
+     *
      * @returns The public URL or null if unavailable
      */
     getPublicUrl(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<string | null>;
 
     /**
@@ -90,15 +91,16 @@ export type IFileUrlAdapter = {
      * Returns null when the adapter verifies that the file does not exist.
      * Some backends may return a signed URL that fails when accessed if existence checks are disabled.
      *
-     * @param context - Readable execution context for the operation
      * @param key - The file identifier/path
      * @param settings - Configuration for the signed URL (expiration, content type, disposition)
+     * @param context - Readable execution context for the operation
+     *
      * @returns The signed download URL, or null when the adapter verifies the file is unavailable
      */
     getSignedDownloadUrl(
-        context: IReadableContext,
         key: string,
         settings: FileAdapterSignedDownloadUrlSettings,
+        context: IReadableContext,
     ): Promise<string | null>;
 
     /**
@@ -106,16 +108,17 @@ export type IFileUrlAdapter = {
      * The URL expires after the configured duration and becomes invalid.
      * Throws if URL generation fails (storage system misconfiguration).
      *
-     * @param context - Readable execution context for the operation
      * @param key - The file identifier/path where upload will be stored
      * @param settings - Configuration for the signed URL (expiration, expected content type)
+     * @param context - Readable execution context for the operation
+     *
      * @returns The signed upload URL (must always return a valid URL)
      * @throws Error if signed URL generation fails
      */
     getSignedUploadUrl(
-        context: IReadableContext,
         key: string,
         settings: FileAdapterSignedUploadUrlSettings,
+        context: IReadableContext,
     ): Promise<string>;
 };
 
@@ -316,24 +319,26 @@ export type IFileStorageAdapter = {
     /**
      * Checks whether a file exists at the given key.
      *
-     * @param context - Readable execution context for the operation
      * @param key - The file identifier/path to check
+     * @param context - Readable execution context for the operation
+     *
      * @returns True if file exists, false otherwise
      */
-    exists(context: IReadableContext, key: string): Promise<boolean>;
+    exists(key: string, context: IReadableContext): Promise<boolean>;
 
     /**
      * Retrieves file content as an async stream of byte chunks.
      * Memory-efficient for large files - content is streamed rather than loaded entirely.
      * Returns null if the file does not exist.
      *
-     * @param context - Readable execution context for the operation
      * @param key - The file identifier/path
+     * @param context - Readable execution context for the operation
+     *
      * @returns Async iterable of Uint8Array chunks, or null if file not found
      */
     getStream(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<FileAdapterStream | null>;
 
     /**
@@ -341,13 +346,14 @@ export type IFileStorageAdapter = {
      * The entire file must fit in memory - use getStream for large files.
      * Returns null if the file does not exist.
      *
-     * @param context - Readable execution context for the operation
      * @param key - The file identifier/path
+     * @param context - Readable execution context for the operation
+     *
      * @returns Complete file bytes as Uint8Array, or null if file not found
      */
     getBytes(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<Uint8Array | null>;
 
     /**
@@ -355,13 +361,14 @@ export type IFileStorageAdapter = {
      * Returns null if the file does not exist.
      * Useful for cache validation and file information endpoints.
      *
-     * @param context - Readable execution context for the operation
      * @param key - The file identifier/path
+     * @param context - Readable execution context for the operation
+     *
      * @returns File metadata object, or null if file not found
      */
     getMetaData(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<FileAdapterMetadata | null>;
 
     /**
@@ -369,15 +376,16 @@ export type IFileStorageAdapter = {
      * Fails if key already exists (use put for upsert or update for existing files).
      * Content is loaded entirely in memory - use addStream for large files.
      *
-     * @param context - Readable execution context for the operation
      * @param key - The file identifier/path where file will be created
      * @param content - File content with HTTP headers configuration
+     * @param context - Readable execution context for the operation
+     *
      * @returns True if file was created, false if key already exists
      */
     add(
-        context: IReadableContext,
         key: string,
         content: WritableFileAdapterContent,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
@@ -385,15 +393,16 @@ export type IFileStorageAdapter = {
      * Fails if key already exists (use putStream for upsert or updateStream for existing files).
      * Content is streamed - efficient for large files or continuous data sources.
      *
-     * @param context - Readable execution context for the operation
      * @param key - The file identifier/path where file will be created
      * @param stream - File content stream with HTTP headers configuration
+     * @param context - Readable execution context for the operation
+     *
      * @returns True if file was created, false if key already exists
      */
     addStream(
-        context: IReadableContext,
         key: string,
         stream: WritableFileAdapterStream,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
@@ -401,15 +410,16 @@ export type IFileStorageAdapter = {
      * Fails if key doesn't exist (use put for upsert or add for new files).
      * Content is loaded entirely in memory - use updateStream for large files.
      *
-     * @param context - Readable execution context for the operation
      * @param key - The file identifier/path to update
      * @param content - New file content with HTTP headers configuration
+     * @param context - Readable execution context for the operation
+     *
      * @returns True if file was updated, false if key doesn't exist
      */
     update(
-        context: IReadableContext,
         key: string,
         content: WritableFileAdapterContent,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
@@ -417,15 +427,16 @@ export type IFileStorageAdapter = {
      * Fails if key doesn't exist (use putStream for upsert or addStream for new files).
      * Content is streamed - efficient for large files or continuous data sources.
      *
-     * @param context - Readable execution context for the operation
      * @param key - The file identifier/path to update
      * @param stream - New file content stream with HTTP headers configuration
+     * @param context - Readable execution context for the operation
+     *
      * @returns True if file was updated, false if key doesn't exist
      */
     updateStream(
-        context: IReadableContext,
         key: string,
         stream: WritableFileAdapterStream,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
@@ -433,15 +444,16 @@ export type IFileStorageAdapter = {
      * Always succeeds: creates file if doesn't exist, overwrites if exists.
      * Content is loaded entirely in memory - use putStream for large files.
      *
-     * @param context - Readable execution context for the operation
      * @param key - The file identifier/path to create or update
      * @param content - File content with HTTP headers configuration
+     * @param context - Readable execution context for the operation
+     *
      * @returns True if file was updated (already existed), false if newly created
      */
     put(
-        context: IReadableContext,
         key: string,
         content: WritableFileAdapterContent,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
@@ -449,45 +461,48 @@ export type IFileStorageAdapter = {
      * Always succeeds: creates file if doesn't exist, overwrites if exists.
      * Content is streamed - efficient for large files or continuous data sources.
      *
-     * @param context - Readable execution context for the operation
      * @param key - The file identifier/path to create or update
      * @param stream - File content stream with HTTP headers configuration
+     * @param context - Readable execution context for the operation
+     *
      * @returns True if file was updated (already existed), false if newly created
      */
     putStream(
-        context: IReadableContext,
         key: string,
         stream: WritableFileAdapterStream,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
      * Copies source file to destination path if destination doesn't exist.
      * Destination is left unchanged if source not found or destination already exists.
      *
-     * @param context - Readable execution context for the operation
      * @param source - Source file identifier/path to copy from
      * @param destination - Destination file identifier/path to copy to
+     * @param context - Readable execution context for the operation
+     *
      * @returns `FileWriteEnum` indicating: SUCCESS (copied), NOT_FOUND (source missing), or KEY_EXISTS (destination exists)
      */
     copy(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<FileWriteEnum>;
 
     /**
      * Copies source file to destination path, overwriting destination if it exists.
      * Returns false if source doesn't exist; destination remains unchanged.
      *
-     * @param context - Readable execution context for the operation
      * @param source - Source file identifier/path to copy from
      * @param destination - Destination file identifier/path to copy to (will be overwritten)
+     * @param context - Readable execution context for the operation
+     *
      * @returns True if source was found and copied, false if source doesn't exist
      */
     copyAndReplace(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
@@ -495,15 +510,16 @@ export type IFileStorageAdapter = {
      * Destination is left unchanged if source not found or destination already exists.
      * Effectively deletes the source file after successful copy.
      *
-     * @param context - Readable execution context for the operation
      * @param source - Source file identifier/path to move from
      * @param destination - Destination file identifier/path to move to
+     * @param context - Readable execution context for the operation
+     *
      * @returns `FileWriteEnum` indicating: SUCCESS (moved), NOT_FOUND (source missing), or KEY_EXISTS (destination exists)
      */
     move(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<FileWriteEnum>;
 
     /**
@@ -511,27 +527,29 @@ export type IFileStorageAdapter = {
      * Returns false if source doesn't exist; destination remains unchanged.
      * Effectively deletes the source file after successful copy.
      *
-     * @param context - Readable execution context for the operation
      * @param source - Source file identifier/path to move from
      * @param destination - Destination file identifier/path to move to (will be overwritten)
+     * @param context - Readable execution context for the operation
+     *
      * @returns True if source was found and moved, false if source doesn't exist
      */
     moveAndReplace(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
      * Removes multiple specific files by key.
      *
-     * @param context - Readable execution context for the operation
      * @param keys - Array of file identifiers/paths to delete
+     * @param context - Readable execution context for the operation
+     *
      * @returns True if at least one key was deleted, false if no keys were found
      */
     removeMany(
-        context: IReadableContext,
         keys: Array<string>,
+        context: IReadableContext,
     ): Promise<boolean>;
 
     /**
@@ -539,11 +557,12 @@ export type IFileStorageAdapter = {
      * Useful for batch deletion by directory or namespace.
      * Silently succeeds if no keys match the prefix.
      *
-     * @param context - Readable execution context for the operation
      * @param prefix - Key prefix to match (e.g., "uploads/2024-01/" for all January uploads)
+     * @param context - Readable execution context for the operation
+     *
      * @returns Void (always succeeds)
      */
-    removeByPrefix(context: IReadableContext, prefix: string): Promise<void>;
+    removeByPrefix(prefix: string, context: IReadableContext): Promise<void>;
 };
 
 /**

--- a/src/file-storage/implementations/adapters/fs-file-storage-adapter/fs-file-storage-adapter.test.ts
+++ b/src/file-storage/implementations/adapters/fs-file-storage-adapter/fs-file-storage-adapter.test.ts
@@ -40,8 +40,8 @@ describe("class: FsFileStorageAdapter", () => {
             const noneExistingKey = "a";
 
             const result = await adapter_.getMetaData(
-                noOpContext,
                 noneExistingKey,
+                noOpContext,
             );
 
             expect(result).toBeNull();
@@ -51,16 +51,20 @@ describe("class: FsFileStorageAdapter", () => {
 
             const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
             const contentType = "text/plain";
-            await adapter_.add(noOpContext, key, {
-                data,
-                cacheControl: null,
-                contentDisposition: null,
-                contentEncoding: null,
-                contentLanguage: null,
-                contentType,
-                fileSizeInBytes: data.length,
-            });
-            const result = await adapter_.getMetaData(noOpContext, key);
+            await adapter_.add(
+                key,
+                {
+                    data,
+                    cacheControl: null,
+                    contentDisposition: null,
+                    contentEncoding: null,
+                    contentLanguage: null,
+                    contentType,
+                    fileSizeInBytes: data.length,
+                },
+                noOpContext,
+            );
+            const result = await adapter_.getMetaData(key, noOpContext);
 
             expect(result).toEqual({
                 etag: expect.any(String) as string,
@@ -74,16 +78,20 @@ describe("class: FsFileStorageAdapter", () => {
 
             const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
             const contentType = "application/json";
-            await adapter_.add(noOpContext, key, {
-                data,
-                cacheControl: null,
-                contentDisposition: null,
-                contentEncoding: null,
-                contentLanguage: null,
-                contentType,
-                fileSizeInBytes: data.length,
-            });
-            const result = await adapter_.getMetaData(noOpContext, key);
+            await adapter_.add(
+                key,
+                {
+                    data,
+                    cacheControl: null,
+                    contentDisposition: null,
+                    contentEncoding: null,
+                    contentLanguage: null,
+                    contentType,
+                    fileSizeInBytes: data.length,
+                },
+                noOpContext,
+            );
+            const result = await adapter_.getMetaData(key, noOpContext);
 
             expect(result).toEqual({
                 etag: expect.any(String) as string,
@@ -97,16 +105,20 @@ describe("class: FsFileStorageAdapter", () => {
 
             const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
             const contentType = "application/json";
-            await adapter_.add(noOpContext, key, {
-                data,
-                cacheControl: null,
-                contentDisposition: null,
-                contentEncoding: null,
-                contentLanguage: null,
-                contentType,
-                fileSizeInBytes: data.length,
-            });
-            const result = await adapter_.getMetaData(noOpContext, key);
+            await adapter_.add(
+                key,
+                {
+                    data,
+                    cacheControl: null,
+                    contentDisposition: null,
+                    contentEncoding: null,
+                    contentLanguage: null,
+                    contentType,
+                    fileSizeInBytes: data.length,
+                },
+                noOpContext,
+            );
+            const result = await adapter_.getMetaData(key, noOpContext);
 
             expect(result).toEqual({
                 etag: expect.any(String) as string,

--- a/src/file-storage/implementations/adapters/fs-file-storage-adapter/fs-file-storage-adapter.ts
+++ b/src/file-storage/implementations/adapters/fs-file-storage-adapter/fs-file-storage-adapter.ts
@@ -145,14 +145,14 @@ export class FsFileStorageAdapter
         return join(this.location, this.codec.encode(key));
     }
 
-    async exists(_context: IReadableContext, key: string): Promise<boolean> {
+    async exists(key: string, _context: IReadableContext): Promise<boolean> {
         const normalizeKey = this.normalizeKey(key);
         return FsFileStorageAdapter.isFileFound(normalizeKey);
     }
 
     async getStream(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<FileAdapterStream | null> {
         const normalizeKey = this.normalizeKey(key);
         if (!(await FsFileStorageAdapter.isFileFound(normalizeKey))) {
@@ -162,8 +162,8 @@ export class FsFileStorageAdapter
     }
 
     async getBytes(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<Uint8Array | null> {
         try {
             const normalizeKey = this.normalizeKey(key);
@@ -178,8 +178,8 @@ export class FsFileStorageAdapter
     }
 
     async getMetaData(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<FileAdapterMetadata | null> {
         try {
             const normalizeKey = this.normalizeKey(key);
@@ -203,9 +203,9 @@ export class FsFileStorageAdapter
     }
 
     async add(
-        _context: IReadableContext,
         key: string,
         content: WritableFileAdapterContent,
+        _context: IReadableContext,
     ): Promise<boolean> {
         try {
             const normalizeKey = this.normalizeKey(key);
@@ -222,9 +222,9 @@ export class FsFileStorageAdapter
     }
 
     async addStream(
-        _context: IReadableContext,
         key: string,
         stream: WritableFileAdapterStream,
+        _context: IReadableContext,
     ): Promise<boolean> {
         try {
             const normalizeKey = this.normalizeKey(key);
@@ -242,9 +242,9 @@ export class FsFileStorageAdapter
     }
 
     async update(
-        _context: IReadableContext,
         key: string,
         content: WritableFileAdapterContent,
+        _context: IReadableContext,
     ): Promise<boolean> {
         try {
             const normalizeKey = this.normalizeKey(key);
@@ -262,9 +262,9 @@ export class FsFileStorageAdapter
     }
 
     async updateStream(
-        _context: IReadableContext,
         key: string,
         stream: WritableFileAdapterStream,
+        _context: IReadableContext,
     ): Promise<boolean> {
         try {
             const normalizeKey = this.normalizeKey(key);
@@ -282,9 +282,9 @@ export class FsFileStorageAdapter
     }
 
     async put(
-        _context: IReadableContext,
         key: string,
         content: WritableFileAdapterContent,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const normalizeKey = this.normalizeKey(key);
         const isFound = await FsFileStorageAdapter.isFileFound(normalizeKey);
@@ -293,9 +293,9 @@ export class FsFileStorageAdapter
     }
 
     async putStream(
-        _context: IReadableContext,
         key: string,
         stream: WritableFileAdapterStream,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const normalizeKey = this.normalizeKey(key);
         const isFound = await FsFileStorageAdapter.isFileFound(normalizeKey);
@@ -305,9 +305,9 @@ export class FsFileStorageAdapter
     }
 
     private async _copy(
-        _context: IReadableContext,
         source: string,
         destination: string,
+        _context: IReadableContext,
     ): Promise<FileWriteEnum> {
         try {
             const normalizeSource = this.normalizeKey(source);
@@ -332,17 +332,17 @@ export class FsFileStorageAdapter
     }
 
     async copy(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<FileWriteEnum> {
-        return this._copy(context, source, destination);
+        return this._copy(source, destination, context);
     }
 
     private async _copyAndReplace(
-        _context: IReadableContext,
         source: string,
         destination: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         try {
             const normalizeSource = this.normalizeKey(source);
@@ -359,11 +359,11 @@ export class FsFileStorageAdapter
     }
 
     async copyAndReplace(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<boolean> {
-        return this._copyAndReplace(context, source, destination);
+        return this._copyAndReplace(source, destination, context);
     }
 
     private async _removeMany(
@@ -397,11 +397,11 @@ export class FsFileStorageAdapter
     }
 
     async move(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<FileWriteEnum> {
-        const result = await this._copy(context, source, destination);
+        const result = await this._copy(source, destination, context);
         if (result === FILE_WRITE_ENUM.SUCCESS) {
             await this._removeMany(context, [source]);
         }
@@ -409,14 +409,14 @@ export class FsFileStorageAdapter
     }
 
     async moveAndReplace(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<boolean> {
         const hasMoved = await this.copyAndReplace(
-            context,
             source,
             destination,
+            context,
         );
         if (hasMoved) {
             await this._removeMany(context, [source]);
@@ -425,15 +425,15 @@ export class FsFileStorageAdapter
     }
 
     async removeMany(
-        context: IReadableContext,
         keys: Array<string>,
+        context: IReadableContext,
     ): Promise<boolean> {
         return this._removeMany(context, keys);
     }
 
     async removeByPrefix(
-        _context: IReadableContext,
         prefix: string,
+        _context: IReadableContext,
     ): Promise<void> {
         const encodedFiles = await fs.readdir(normalize(this.location), {
             recursive: true,

--- a/src/file-storage/implementations/adapters/memory-file-storage-adapter/memory-file-storage-adapter.test.ts
+++ b/src/file-storage/implementations/adapters/memory-file-storage-adapter/memory-file-storage-adapter.test.ts
@@ -40,10 +40,10 @@ describe("class: MemoryFileStorageAdapter", () => {
                 contentDisposition: null,
                 cacheControl: null,
             };
-            await adapter.add(noOpContext, "a", content);
-            await adapter.add(noOpContext, "a", content);
-            await adapter.add(noOpContext, "b", content);
-            await adapter.add(noOpContext, "b", content);
+            await adapter.add("a", content, noOpContext);
+            await adapter.add("a", content, noOpContext);
+            await adapter.add("b", content, noOpContext);
+            await adapter.add("b", content, noOpContext);
 
             await adapter.deInit();
 

--- a/src/file-storage/implementations/adapters/memory-file-storage-adapter/memory-file-storage-adapter.ts
+++ b/src/file-storage/implementations/adapters/memory-file-storage-adapter/memory-file-storage-adapter.ts
@@ -62,13 +62,13 @@ export class MemoryFileStorageAdapter
         return Promise.resolve();
     }
 
-    exists(_context: IReadableContext, key: string): Promise<boolean> {
+    exists(key: string, _context: IReadableContext): Promise<boolean> {
         return Promise.resolve(this.map.has(key));
     }
 
     getStream(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<FileAdapterStream | null> {
         const file = this.map.get(key);
         if (file === undefined) {
@@ -82,8 +82,8 @@ export class MemoryFileStorageAdapter
     }
 
     getBytes(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<Uint8Array | null> {
         const file = this.map.get(key);
         if (file === undefined) {
@@ -93,8 +93,8 @@ export class MemoryFileStorageAdapter
     }
 
     getMetaData(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<FileAdapterMetadata | null> {
         const file = this.map.get(key);
         if (file === undefined) {
@@ -111,9 +111,9 @@ export class MemoryFileStorageAdapter
     }
 
     add(
-        _context: IReadableContext,
         key: string,
         content: WritableFileAdapterContent,
+        _context: IReadableContext,
     ): Promise<boolean> {
         if (this.map.has(key)) {
             return Promise.resolve(false);
@@ -133,9 +133,9 @@ export class MemoryFileStorageAdapter
     }
 
     async addStream(
-        _context: IReadableContext,
         key: string,
         stream: WritableFileAdapterStream,
+        _context: IReadableContext,
     ): Promise<boolean> {
         if (this.map.has(key)) {
             return Promise.resolve(false);
@@ -156,9 +156,9 @@ export class MemoryFileStorageAdapter
     }
 
     update(
-        _context: IReadableContext,
         key: string,
         content: WritableFileAdapterContent,
+        _context: IReadableContext,
     ): Promise<boolean> {
         let file = this.map.get(key);
         if (file === undefined) {
@@ -181,9 +181,9 @@ export class MemoryFileStorageAdapter
     }
 
     async updateStream(
-        _context: IReadableContext,
         key: string,
         stream: WritableFileAdapterStream,
+        _context: IReadableContext,
     ): Promise<boolean> {
         let file = this.map.get(key);
         if (file === undefined) {
@@ -206,9 +206,9 @@ export class MemoryFileStorageAdapter
     }
 
     put(
-        _context: IReadableContext,
         key: string,
         content: WritableFileAdapterContent,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const contentData = Buffer.from(content.data);
         const copiedBuffer = Buffer.alloc(contentData.byteLength);
@@ -226,9 +226,9 @@ export class MemoryFileStorageAdapter
     }
 
     async putStream(
-        _context: IReadableContext,
         key: string,
         stream: WritableFileAdapterStream,
+        _context: IReadableContext,
     ): Promise<boolean> {
         let totalData = Buffer.from([]);
         for await (const chunk of stream.data) {
@@ -247,9 +247,9 @@ export class MemoryFileStorageAdapter
     }
 
     private _copy(
-        _context: IReadableContext,
         source: string,
         destination: string,
+        _context: IReadableContext,
     ): Promise<FileWriteEnum> {
         const sourceFile = this.map.get(source);
         if (sourceFile === undefined) {
@@ -268,17 +268,17 @@ export class MemoryFileStorageAdapter
     }
 
     copy(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<FileWriteEnum> {
-        return this._copy(context, source, destination);
+        return this._copy(source, destination, context);
     }
 
     private _copyAndReplace(
-        _context: IReadableContext,
         source: string,
         destination: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         const sourceFile = this.map.get(source);
         if (sourceFile === undefined) {
@@ -294,16 +294,16 @@ export class MemoryFileStorageAdapter
     }
 
     copyAndReplace(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<boolean> {
-        return this._copyAndReplace(context, source, destination);
+        return this._copyAndReplace(source, destination, context);
     }
 
     private _removeMany(
-        _context: IReadableContext,
         keys: Array<string>,
+        _context: IReadableContext,
     ): Promise<boolean> {
         let hasDeleted = false;
         for (const key of keys) {
@@ -316,41 +316,41 @@ export class MemoryFileStorageAdapter
     }
 
     async move(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<FileWriteEnum> {
-        const result = await this._copy(context, source, destination);
+        const result = await this._copy(source, destination, context);
         if (result === FILE_WRITE_ENUM.SUCCESS) {
-            await this._removeMany(context, [source]);
+            await this._removeMany([source], context);
         }
         return result;
     }
 
     async moveAndReplace(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<boolean> {
         const hasMoved = await this._copyAndReplace(
-            context,
             source,
             destination,
+            context,
         );
         if (hasMoved) {
-            await this._removeMany(context, [source]);
+            await this._removeMany([source], context);
         }
         return hasMoved;
     }
 
     removeMany(
-        context: IReadableContext,
         keys: Array<string>,
+        context: IReadableContext,
     ): Promise<boolean> {
-        return this._removeMany(context, keys);
+        return this._removeMany(keys, context);
     }
 
-    removeByPrefix(_context: IReadableContext, prefix: string): Promise<void> {
+    removeByPrefix(prefix: string, _context: IReadableContext): Promise<void> {
         for (const [key] of this.map) {
             if (!key.startsWith(prefix)) {
                 continue;

--- a/src/file-storage/implementations/adapters/no-op-file-storage-adapter/no-op-file-storage-adapter.ts
+++ b/src/file-storage/implementations/adapters/no-op-file-storage-adapter/no-op-file-storage-adapter.ts
@@ -23,141 +23,141 @@ import {
  */
 export class NoOpFileStorageAdapter implements ISignedFileStorageAdapter {
     getPublicUrl(
-        _context: IReadableContext,
         _key: string,
+        _context: IReadableContext,
     ): Promise<string | null> {
         return Promise.resolve(null);
     }
 
     getSignedDownloadUrl(
-        _context: IReadableContext,
         _key: string,
         _settings: FileAdapterSignedDownloadUrlSettings,
+        _context: IReadableContext,
     ): Promise<string | null> {
         return Promise.resolve(null);
     }
 
     getSignedUploadUrl(
-        _context: IReadableContext,
         _key: string,
         _settings: FileAdapterSignedUploadUrlSettings,
+        _context: IReadableContext,
     ): Promise<string> {
         return Promise.resolve("");
     }
 
-    exists(_context: IReadableContext, _key: string): Promise<boolean> {
+    exists(_key: string, _context: IReadableContext): Promise<boolean> {
         return Promise.resolve(false);
     }
 
     getStream(
-        _context: IReadableContext,
         _key: string,
+        _context: IReadableContext,
     ): Promise<FileAdapterStream | null> {
         return Promise.resolve(null);
     }
 
     getBytes(
-        _context: IReadableContext,
         _key: string,
+        _context: IReadableContext,
     ): Promise<Uint8Array | null> {
         return Promise.resolve(null);
     }
 
     getMetaData(
-        _context: IReadableContext,
         _key: string,
+        _context: IReadableContext,
     ): Promise<FileAdapterMetadata | null> {
         return Promise.resolve(null);
     }
 
     add(
-        _context: IReadableContext,
         _key: string,
         _content: WritableFileAdapterContent,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     addStream(
-        _context: IReadableContext,
         _key: string,
         _stream: WritableFileAdapterStream,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     update(
-        _context: IReadableContext,
         _key: string,
         _content: WritableFileAdapterContent,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     updateStream(
-        _context: IReadableContext,
         _key: string,
         _stream: WritableFileAdapterStream,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     put(
-        _context: IReadableContext,
         _key: string,
         _content: WritableFileAdapterContent,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     putStream(
-        _context: IReadableContext,
         _key: string,
         _stream: WritableFileAdapterStream,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     copy(
-        _context: IReadableContext,
         _source: string,
         _destination: string,
+        _context: IReadableContext,
     ): Promise<FileWriteEnum> {
         return Promise.resolve(FILE_WRITE_ENUM.SUCCESS);
     }
 
     copyAndReplace(
-        _context: IReadableContext,
         _source: string,
         _destination: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     move(
-        _context: IReadableContext,
         _source: string,
         _destination: string,
+        _context: IReadableContext,
     ): Promise<FileWriteEnum> {
         return Promise.resolve(FILE_WRITE_ENUM.SUCCESS);
     }
 
     moveAndReplace(
-        _context: IReadableContext,
         _source: string,
         _destination: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
     removeMany(
-        _context: IReadableContext,
         _keys: Array<string>,
+        _context: IReadableContext,
     ): Promise<boolean> {
         return Promise.resolve(true);
     }
 
-    removeByPrefix(_context: IReadableContext, _prefix: string): Promise<void> {
+    removeByPrefix(_prefix: string, _context: IReadableContext): Promise<void> {
         return Promise.resolve();
     }
 }

--- a/src/file-storage/implementations/adapters/s3-file-storage-adapter/s3-file-storage-adapter.test.ts
+++ b/src/file-storage/implementations/adapters/s3-file-storage-adapter/s3-file-storage-adapter.test.ts
@@ -85,7 +85,7 @@ describe("class: S3FileStorageAdapter", () => {
             );
 
             const key = "a";
-            const result = await adapter.getPublicUrl(noOpContext, key);
+            const result = await adapter.getPublicUrl(key, noOpContext);
 
             expect(result).toBeNull();
         });
@@ -116,7 +116,7 @@ describe("class: S3FileStorageAdapter", () => {
             );
 
             const key = "a";
-            const result = await adapter.getPublicUrl(noOpContext, key);
+            const result = await adapter.getPublicUrl(key, noOpContext);
 
             expect(result).toBeTypeOf("string");
         });
@@ -147,16 +147,20 @@ describe("class: S3FileStorageAdapter", () => {
 
             const key = "a";
             const data = new Uint8Array(Buffer.from("CONTENT"));
-            await adapter.add(noOpContext, key, {
-                cacheControl: null,
-                contentDisposition: null,
-                contentEncoding: null,
-                contentLanguage: null,
-                contentType: "text/plain",
-                fileSizeInBytes: data.byteLength,
-                data,
-            });
-            const url = await adapter.getPublicUrl(noOpContext, key);
+            await adapter.add(
+                key,
+                {
+                    cacheControl: null,
+                    contentDisposition: null,
+                    contentEncoding: null,
+                    contentLanguage: null,
+                    contentType: "text/plain",
+                    fileSizeInBytes: data.byteLength,
+                    data,
+                },
+                noOpContext,
+            );
+            const url = await adapter.getPublicUrl(key, noOpContext);
             if (url === null) {
                 throw new Error("url is null");
             }
@@ -179,13 +183,13 @@ describe("class: S3FileStorageAdapter", () => {
             const contentType = "text/plain";
             const contentDisposition = "inline";
             const result = await adapter.getSignedDownloadUrl(
-                noOpContext,
                 key,
                 {
                     expirationInSeconds: 5000,
                     contentType,
                     contentDisposition,
                 },
+                noOpContext,
             );
 
             expect(result).toBeNull();
@@ -203,13 +207,13 @@ describe("class: S3FileStorageAdapter", () => {
             const contentType = "text/plain";
             const contentDisposition = "inline";
             const result = await adapter.getSignedDownloadUrl(
-                noOpContext,
                 key,
                 {
                     expirationInSeconds: 5000,
                     contentType,
                     contentDisposition,
                 },
+                noOpContext,
             );
 
             expect(result).toBeTypeOf("string");
@@ -225,21 +229,29 @@ describe("class: S3FileStorageAdapter", () => {
             const key = "a";
             const data = new Uint8Array(Buffer.from("CONTENT"));
             const contentType = "text/plain";
-            await adapter.add(noOpContext, key, {
-                cacheControl: null,
-                contentDisposition: null,
-                contentEncoding: null,
-                contentLanguage: null,
-                contentType,
-                fileSizeInBytes: data.byteLength,
-                data,
-            });
+            await adapter.add(
+                key,
+                {
+                    cacheControl: null,
+                    contentDisposition: null,
+                    contentEncoding: null,
+                    contentLanguage: null,
+                    contentType,
+                    fileSizeInBytes: data.byteLength,
+                    data,
+                },
+                noOpContext,
+            );
             const contentDisposition = "inline";
-            const url = await adapter.getSignedDownloadUrl(noOpContext, key, {
-                expirationInSeconds: 5000,
-                contentType,
-                contentDisposition,
-            });
+            const url = await adapter.getSignedDownloadUrl(
+                key,
+                {
+                    expirationInSeconds: 5000,
+                    contentType,
+                    contentDisposition,
+                },
+                noOpContext,
+            );
             if (url === null) {
                 throw new Error("url is null");
             }
@@ -264,10 +276,14 @@ describe("class: S3FileStorageAdapter", () => {
 
             const key = "a";
             const contentType = "text/plain";
-            const url = await adapter.getSignedUploadUrl(noOpContext, key, {
-                expirationInSeconds: 5000,
-                contentType,
-            });
+            const url = await adapter.getSignedUploadUrl(
+                key,
+                {
+                    expirationInSeconds: 5000,
+                    contentType,
+                },
+                noOpContext,
+            );
 
             const data = new Uint8Array(Buffer.from("CONTENT"));
             await fetch(url, {
@@ -275,7 +291,7 @@ describe("class: S3FileStorageAdapter", () => {
                 body: data,
             });
 
-            const bytes = await adapter.getBytes(noOpContext, key);
+            const bytes = await adapter.getBytes(key, noOpContext);
             expect(bytes).toEqual(data);
         });
         test("Should persit file data when key exists", async () => {
@@ -289,27 +305,35 @@ describe("class: S3FileStorageAdapter", () => {
             const key = "a";
             const data = new Uint8Array(Buffer.from("CONTENT"));
             const contentType = "text/plain";
-            await adapter.add(noOpContext, key, {
-                data,
-                fileSizeInBytes: data.byteLength,
-                contentType,
-                contentLanguage: null,
-                contentEncoding: null,
-                contentDisposition: null,
-                cacheControl: null,
-            });
+            await adapter.add(
+                key,
+                {
+                    data,
+                    fileSizeInBytes: data.byteLength,
+                    contentType,
+                    contentLanguage: null,
+                    contentEncoding: null,
+                    contentDisposition: null,
+                    cacheControl: null,
+                },
+                noOpContext,
+            );
 
-            const url = await adapter.getSignedUploadUrl(noOpContext, key, {
-                expirationInSeconds: 5000,
-                contentType,
-            });
+            const url = await adapter.getSignedUploadUrl(
+                key,
+                {
+                    expirationInSeconds: 5000,
+                    contentType,
+                },
+                noOpContext,
+            );
             const newData = new Uint8Array(Buffer.from("NEW_CONTENT"));
             await fetch(url, {
                 method: "PUT",
                 body: newData,
             });
 
-            const bytes = await adapter.getBytes(noOpContext, key);
+            const bytes = await adapter.getBytes(key, noOpContext);
             expect(bytes).toEqual(newData);
         });
     });
@@ -327,15 +351,19 @@ describe("class: S3FileStorageAdapter", () => {
 
             const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
             const contentType = "application/octet-stream";
-            const result = await adapter.put(noOpContext, key, {
-                data,
-                cacheControl: null,
-                contentDisposition: null,
-                contentEncoding: null,
-                contentLanguage: null,
-                contentType,
-                fileSizeInBytes: data.length,
-            });
+            const result = await adapter.put(
+                key,
+                {
+                    data,
+                    cacheControl: null,
+                    contentDisposition: null,
+                    contentEncoding: null,
+                    contentLanguage: null,
+                    contentType,
+                    fileSizeInBytes: data.length,
+                },
+                noOpContext,
+            );
 
             expect(result).toBe(true);
         });
@@ -352,17 +380,21 @@ describe("class: S3FileStorageAdapter", () => {
 
             const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
             const contentType = "application/octet-stream";
-            await adapter.put(noOpContext, key, {
-                data,
-                cacheControl: null,
-                contentDisposition: null,
-                contentEncoding: null,
-                contentLanguage: null,
-                contentType,
-                fileSizeInBytes: data.length,
-            });
+            await adapter.put(
+                key,
+                {
+                    data,
+                    cacheControl: null,
+                    contentDisposition: null,
+                    contentEncoding: null,
+                    contentLanguage: null,
+                    contentType,
+                    fileSizeInBytes: data.length,
+                },
+                noOpContext,
+            );
 
-            const result = await adapter.getBytes(noOpContext, key);
+            const result = await adapter.getBytes(key, noOpContext);
             expect(result).toEqual(data);
         });
         test("Should return true when key exists and enableAccuratePut setting is false", async () => {
@@ -378,26 +410,34 @@ describe("class: S3FileStorageAdapter", () => {
 
             const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
             const contentType = "application/octet-stream";
-            await adapter.add(noOpContext, key, {
-                data,
-                cacheControl: null,
-                contentDisposition: null,
-                contentEncoding: null,
-                contentLanguage: null,
-                contentType,
-                fileSizeInBytes: data.length,
-            });
+            await adapter.add(
+                key,
+                {
+                    data,
+                    cacheControl: null,
+                    contentDisposition: null,
+                    contentEncoding: null,
+                    contentLanguage: null,
+                    contentType,
+                    fileSizeInBytes: data.length,
+                },
+                noOpContext,
+            );
 
             const newData = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-            const result = await adapter.put(noOpContext, key, {
-                data: newData,
-                cacheControl: null,
-                contentDisposition: null,
-                contentEncoding: null,
-                contentLanguage: null,
-                contentType,
-                fileSizeInBytes: data.length,
-            });
+            const result = await adapter.put(
+                key,
+                {
+                    data: newData,
+                    cacheControl: null,
+                    contentDisposition: null,
+                    contentEncoding: null,
+                    contentLanguage: null,
+                    contentType,
+                    fileSizeInBytes: data.length,
+                },
+                noOpContext,
+            );
 
             expect(result).toBe(true);
         });
@@ -414,28 +454,36 @@ describe("class: S3FileStorageAdapter", () => {
 
             const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
             const contentType = "application/octet-stream";
-            await adapter.add(noOpContext, key, {
-                data,
-                cacheControl: null,
-                contentDisposition: null,
-                contentEncoding: null,
-                contentLanguage: null,
-                contentType,
-                fileSizeInBytes: data.length,
-            });
+            await adapter.add(
+                key,
+                {
+                    data,
+                    cacheControl: null,
+                    contentDisposition: null,
+                    contentEncoding: null,
+                    contentLanguage: null,
+                    contentType,
+                    fileSizeInBytes: data.length,
+                },
+                noOpContext,
+            );
 
             const newData = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-            await adapter.put(noOpContext, key, {
-                data: newData,
-                cacheControl: null,
-                contentDisposition: null,
-                contentEncoding: null,
-                contentLanguage: null,
-                contentType,
-                fileSizeInBytes: data.length,
-            });
+            await adapter.put(
+                key,
+                {
+                    data: newData,
+                    cacheControl: null,
+                    contentDisposition: null,
+                    contentEncoding: null,
+                    contentLanguage: null,
+                    contentType,
+                    fileSizeInBytes: data.length,
+                },
+                noOpContext,
+            );
 
-            const result = await adapter.getBytes(noOpContext, key);
+            const result = await adapter.getBytes(key, noOpContext);
             expect(result).toEqual(newData);
         });
     });
@@ -449,11 +497,10 @@ describe("class: S3FileStorageAdapter", () => {
             });
             await adapter.init();
 
-            const result = await adapter.removeMany(noOpContext, [
-                "a",
-                "b",
-                "c",
-            ]);
+            const result = await adapter.removeMany(
+                ["a", "b", "c"],
+                noOpContext,
+            );
 
             expect(result).toBe(true);
         });
@@ -470,21 +517,24 @@ describe("class: S3FileStorageAdapter", () => {
 
             const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
             const contentType = "application/octet-stream";
-            await adapter.add(noOpContext, key, {
-                data,
-                cacheControl: null,
-                contentDisposition: null,
-                contentEncoding: null,
-                contentLanguage: null,
-                contentType,
-                fileSizeInBytes: data.length,
-            });
-
-            const result = await adapter.removeMany(noOpContext, [
+            await adapter.add(
                 key,
-                "b",
-                "c",
-            ]);
+                {
+                    data,
+                    cacheControl: null,
+                    contentDisposition: null,
+                    contentEncoding: null,
+                    contentLanguage: null,
+                    contentType,
+                    fileSizeInBytes: data.length,
+                },
+                noOpContext,
+            );
+
+            const result = await adapter.removeMany(
+                [key, "b", "c"],
+                noOpContext,
+            );
 
             expect(result).toBe(true);
         });
@@ -499,44 +549,56 @@ describe("class: S3FileStorageAdapter", () => {
 
             const data1 = new Uint8Array(Buffer.from("CONTENT_A", "utf8"));
             const contentType = "application/octet-stream";
-            await adapter.add(noOpContext, "a", {
-                data: data1,
-                cacheControl: null,
-                contentDisposition: null,
-                contentEncoding: null,
-                contentLanguage: null,
-                contentType,
-                fileSizeInBytes: data1.length,
-            });
+            await adapter.add(
+                "a",
+                {
+                    data: data1,
+                    cacheControl: null,
+                    contentDisposition: null,
+                    contentEncoding: null,
+                    contentLanguage: null,
+                    contentType,
+                    fileSizeInBytes: data1.length,
+                },
+                noOpContext,
+            );
 
             const data2 = new Uint8Array(Buffer.from("CONTENT_B", "utf8"));
-            await adapter.add(noOpContext, "b", {
-                data: data2,
-                cacheControl: null,
-                contentDisposition: null,
-                contentEncoding: null,
-                contentLanguage: null,
-                contentType,
-                fileSizeInBytes: data2.length,
-            });
+            await adapter.add(
+                "b",
+                {
+                    data: data2,
+                    cacheControl: null,
+                    contentDisposition: null,
+                    contentEncoding: null,
+                    contentLanguage: null,
+                    contentType,
+                    fileSizeInBytes: data2.length,
+                },
+                noOpContext,
+            );
 
             const data3 = new Uint8Array(Buffer.from("CONTENT_C", "utf8"));
-            await adapter.add(noOpContext, "c", {
-                data: data3,
-                cacheControl: null,
-                contentDisposition: null,
-                contentEncoding: null,
-                contentLanguage: null,
-                contentType,
-                fileSizeInBytes: data3.length,
-            });
+            await adapter.add(
+                "c",
+                {
+                    data: data3,
+                    cacheControl: null,
+                    contentDisposition: null,
+                    contentEncoding: null,
+                    contentLanguage: null,
+                    contentType,
+                    fileSizeInBytes: data3.length,
+                },
+                noOpContext,
+            );
 
-            await adapter.removeMany(noOpContext, ["a", "b"]);
+            await adapter.removeMany(["a", "b"], noOpContext);
 
             const result = [
-                await adapter.getBytes(noOpContext, "a"),
-                await adapter.getBytes(noOpContext, "b"),
-                await adapter.getBytes(noOpContext, "c"),
+                await adapter.getBytes("a", noOpContext),
+                await adapter.getBytes("b", noOpContext),
+                await adapter.getBytes("c", noOpContext),
             ];
             expect(result).toEqual([null, null, data3]);
         });

--- a/src/file-storage/implementations/adapters/s3-file-storage-adapter/s3-file-storage-adapter.ts
+++ b/src/file-storage/implementations/adapters/s3-file-storage-adapter/s3-file-storage-adapter.ts
@@ -249,12 +249,12 @@ export class S3FileStorageAdapter
     }
 
     async getPublicUrl(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<string | null> {
         if (
             this.enableAccurateGetPublicUrl &&
-            !(await this._exists(context, key))
+            !(await this._exists(key, context))
         ) {
             return null;
         }
@@ -270,13 +270,13 @@ export class S3FileStorageAdapter
     }
 
     async getSignedDownloadUrl(
-        context: IReadableContext,
         key: string,
         settings: FileAdapterSignedDownloadUrlSettings,
+        context: IReadableContext,
     ): Promise<string | null> {
         if (
             this.enableAccurateGetSignedDownloadUrl &&
-            !(await this._exists(context, key))
+            !(await this._exists(key, context))
         ) {
             return null;
         }
@@ -296,9 +296,9 @@ export class S3FileStorageAdapter
     }
 
     async getSignedUploadUrl(
-        _context: IReadableContext,
         key: string,
         settings: FileAdapterSignedUploadUrlSettings,
+        _context: IReadableContext,
     ): Promise<string> {
         return await getSignedUrl(
             this.client,
@@ -315,8 +315,8 @@ export class S3FileStorageAdapter
     }
 
     private async _exists(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         try {
             const response = await this.client.send(
@@ -332,13 +332,13 @@ export class S3FileStorageAdapter
         }
     }
 
-    async exists(context: IReadableContext, key: string): Promise<boolean> {
-        return this._exists(context, key);
+    async exists(key: string, context: IReadableContext): Promise<boolean> {
+        return this._exists(key, context);
     }
 
     async getStream(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<FileAdapterStream | null> {
         try {
             const response = await this.client.send(
@@ -358,8 +358,8 @@ export class S3FileStorageAdapter
     }
 
     async getBytes(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<Uint8Array | null> {
         try {
             const response = await this.client.send(
@@ -379,8 +379,8 @@ export class S3FileStorageAdapter
     }
 
     async getMetaData(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<FileAdapterMetadata | null> {
         try {
             const response = await this.client.send(
@@ -416,9 +416,9 @@ export class S3FileStorageAdapter
     }
 
     async add(
-        _context: IReadableContext,
         key: string,
         content: WritableFileAdapterContent,
+        _context: IReadableContext,
     ): Promise<boolean> {
         try {
             await this.client.send(
@@ -455,9 +455,9 @@ export class S3FileStorageAdapter
     }
 
     async addStream(
-        _context: IReadableContext,
         key: string,
         stream: WritableFileAdapterStream,
+        _context: IReadableContext,
     ): Promise<boolean> {
         try {
             await this.client.send(
@@ -484,9 +484,9 @@ export class S3FileStorageAdapter
     }
 
     async update(
-        _context: IReadableContext,
         key: string,
         content: WritableFileAdapterContent,
+        _context: IReadableContext,
     ): Promise<boolean> {
         try {
             await this.client.send(
@@ -511,9 +511,9 @@ export class S3FileStorageAdapter
     }
 
     async updateStream(
-        _context: IReadableContext,
         key: string,
         stream: WritableFileAdapterStream,
+        _context: IReadableContext,
     ): Promise<boolean> {
         try {
             await this.client.send(
@@ -600,9 +600,9 @@ export class S3FileStorageAdapter
     }
 
     async put(
-        _context: IReadableContext,
         key: string,
         content: WritableFileAdapterContent,
+        _context: IReadableContext,
     ): Promise<boolean> {
         if (!this.enableAccuratePut) {
             return await this.unaccuratePut(key, content);
@@ -612,11 +612,11 @@ export class S3FileStorageAdapter
     }
 
     private async accuratePutStream(
-        context: IReadableContext,
         key: string,
         stream: WritableFileAdapterStream,
+        context: IReadableContext,
     ): Promise<boolean> {
-        const exists = await this._exists(context, key);
+        const exists = await this._exists(key, context);
         await this.client.send(
             new PutObjectCommand({
                 ServerSideEncryption: this.serverSideEncryption,
@@ -654,28 +654,28 @@ export class S3FileStorageAdapter
     }
 
     async putStream(
-        context: IReadableContext,
         key: string,
         stream: WritableFileAdapterStream,
+        context: IReadableContext,
     ): Promise<boolean> {
         if (!this.enableAccuratePut) {
             return await this.unaccuratePutStream(key, stream);
         }
 
-        return await this.accuratePutStream(context, key, stream);
+        return await this.accuratePutStream(key, stream, context);
     }
 
     private async _copy(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<FileWriteEnum> {
-        const sourceExists = await this._exists(context, source);
+        const sourceExists = await this._exists(source, context);
         if (!sourceExists) {
             return FILE_WRITE_ENUM.NOT_FOUND;
         }
 
-        const destinationExists = await this._exists(context, destination);
+        const destinationExists = await this._exists(destination, context);
         if (destinationExists) {
             return FILE_WRITE_ENUM.KEY_EXISTS;
         }
@@ -697,17 +697,17 @@ export class S3FileStorageAdapter
     }
 
     async copy(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<FileWriteEnum> {
-        return this._copy(context, source, destination);
+        return this._copy(source, destination, context);
     }
 
     private async _copyAndReplace(
-        _context: IReadableContext,
         source: string,
         destination: string,
+        _context: IReadableContext,
     ): Promise<boolean> {
         try {
             await this.client.send(
@@ -726,44 +726,44 @@ export class S3FileStorageAdapter
     }
 
     async copyAndReplace(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<boolean> {
-        return this._copyAndReplace(context, source, destination);
+        return this._copyAndReplace(source, destination, context);
     }
 
     async move(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<FileWriteEnum> {
-        const result = await this._copy(context, source, destination);
+        const result = await this._copy(source, destination, context);
         if (result === FILE_WRITE_ENUM.SUCCESS) {
-            await this._removeMany(context, [source]);
+            await this._removeMany([source], context);
         }
         return result;
     }
 
     async moveAndReplace(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<boolean> {
         const hasMoved = await this._copyAndReplace(
-            context,
             source,
             destination,
+            context,
         );
         if (hasMoved) {
-            await this._removeMany(context, [source]);
+            await this._removeMany([source], context);
         }
         return hasMoved;
     }
 
     private async _removeMany(
-        context: IReadableContext,
         keys: Array<string>,
+        context: IReadableContext,
     ): Promise<boolean> {
         if (!this.enableAccurateRemoveMany) {
             await this.client.send(
@@ -778,7 +778,7 @@ export class S3FileStorageAdapter
         }
 
         const results = await Promise.all(
-            keys.map((key) => this._exists(context, key)),
+            keys.map((key) => this._exists(key, context)),
         );
         await this.client.send(
             new DeleteObjectsCommand({
@@ -797,15 +797,15 @@ export class S3FileStorageAdapter
     }
 
     async removeMany(
-        context: IReadableContext,
         keys: Array<string>,
+        context: IReadableContext,
     ): Promise<boolean> {
-        return this._removeMany(context, keys);
+        return this._removeMany(keys, context);
     }
 
     async removeByPrefix(
-        context: IReadableContext,
         prefix: string,
+        context: IReadableContext,
     ): Promise<void> {
         const listResponse = await this.client.send(
             new ListObjectsCommand({
@@ -820,6 +820,6 @@ export class S3FileStorageAdapter
             listResponse.Contents?.map((item) => item.Key).filter(
                 (key) => key !== undefined,
             ) ?? [];
-        await this._removeMany(context, keysToDelete);
+        await this._removeMany(keysToDelete, context);
     }
 }

--- a/src/file-storage/implementations/derivables/file-storage/file-storage.test.ts
+++ b/src/file-storage/implementations/derivables/file-storage/file-storage.test.ts
@@ -49,127 +49,127 @@ describe("class: FileStorage", () => {
 
     const mockedUrlAdapter: IFileUrlAdapter = {
         getPublicUrl(
-            _context: IReadableContext,
             _key: string,
+            _context: IReadableContext,
         ): Promise<string | null> {
             return Promise.resolve(null);
         },
         getSignedDownloadUrl(
-            _context: IReadableContext,
             _key: string,
             _settings: FileAdapterSignedDownloadUrlSettings,
+            _context: IReadableContext,
         ): Promise<string | null> {
             return Promise.resolve(null);
         },
         getSignedUploadUrl(
-            _context: IReadableContext,
             _key: string,
             _settings: FileAdapterSignedUploadUrlSettings,
+            _context: IReadableContext,
         ): Promise<string> {
             return Promise.resolve("");
         },
     };
     const mockedAdapter: IFileStorageAdapter = {
-        exists(_context: IReadableContext, _key: string): Promise<boolean> {
+        exists(_key: string, _context: IReadableContext): Promise<boolean> {
             throw new Error("Function not implemented.");
         },
         getStream(
-            _context: IReadableContext,
             _key: string,
+            _context: IReadableContext,
         ): Promise<FileAdapterStream | null> {
             throw new Error("Function not implemented.");
         },
         getBytes(
-            _context: IReadableContext,
             _key: string,
+            _context: IReadableContext,
         ): Promise<Uint8Array | null> {
             throw new Error("Function not implemented.");
         },
         getMetaData(
-            _context: IReadableContext,
             _key: string,
+            _context: IReadableContext,
         ): Promise<FileAdapterMetadata | null> {
             throw new Error("Function not implemented.");
         },
         add(
-            _context: IReadableContext,
             _key: string,
             _content: WritableFileAdapterContent,
+            _context: IReadableContext,
         ): Promise<boolean> {
             throw new Error("Function not implemented.");
         },
         addStream(
-            _context: IReadableContext,
             _key: string,
             _stream: WritableFileAdapterStream,
+            _context: IReadableContext,
         ): Promise<boolean> {
             throw new Error("Function not implemented.");
         },
         update(
-            _context: IReadableContext,
             _key: string,
             _content: WritableFileAdapterContent,
+            _context: IReadableContext,
         ): Promise<boolean> {
             throw new Error("Function not implemented.");
         },
         updateStream(
-            _context: IReadableContext,
             _key: string,
             _stream: WritableFileAdapterStream,
+            _context: IReadableContext,
         ): Promise<boolean> {
             throw new Error("Function not implemented.");
         },
         put(
-            _context: IReadableContext,
             _key: string,
             _content: WritableFileAdapterContent,
+            _context: IReadableContext,
         ): Promise<boolean> {
             throw new Error("Function not implemented.");
         },
         putStream(
-            _context: IReadableContext,
             _key: string,
             _stream: WritableFileAdapterStream,
+            _context: IReadableContext,
         ): Promise<boolean> {
             throw new Error("Function not implemented.");
         },
         copy(
-            _context: IReadableContext,
             _source: string,
             _destination: string,
+            _context: IReadableContext,
         ): Promise<FileWriteEnum> {
             throw new Error("Function not implemented.");
         },
         copyAndReplace(
-            _context: IReadableContext,
             _source: string,
             _destination: string,
+            _context: IReadableContext,
         ): Promise<boolean> {
             throw new Error("Function not implemented.");
         },
         move(
-            _context: IReadableContext,
             _source: string,
             _destination: string,
+            _context: IReadableContext,
         ): Promise<FileWriteEnum> {
             throw new Error("Function not implemented.");
         },
         moveAndReplace(
-            _context: IReadableContext,
             _source: string,
             _destination: string,
+            _context: IReadableContext,
         ): Promise<boolean> {
             throw new Error("Function not implemented.");
         },
         removeMany(
-            _context: IReadableContext,
             _keys: Array<string>,
+            _context: IReadableContext,
         ): Promise<boolean> {
             throw new Error("Function not implemented.");
         },
         removeByPrefix(
-            _context: IReadableContext,
             _prefix: string,
+            _context: IReadableContext,
         ): Promise<void> {
             throw new Error("Function not implemented.");
         },

--- a/src/file-storage/implementations/derivables/file-storage/file-storage.ts
+++ b/src/file-storage/implementations/derivables/file-storage/file-storage.ts
@@ -265,13 +265,13 @@ export class FileStorage implements IFileStorage {
     }
 
     async clear(): Promise<void> {
-        await this.adapter.removeByPrefix(this.context, "");
+        await this.adapter.removeByPrefix("", this.context);
     }
 
     async removeMany(files: Array<IFile>): Promise<boolean> {
         const keys = files.map((file) => {
             return file.key;
         });
-        return await this.adapter.removeMany(this.context, keys);
+        return await this.adapter.removeMany(keys, this.context);
     }
 }

--- a/src/file-storage/implementations/derivables/file-storage/file.ts
+++ b/src/file-storage/implementations/derivables/file-storage/file.ts
@@ -144,19 +144,19 @@ export class File implements IFile {
     async getTextOrFail(): Promise<string> {
         const text = await this.getText();
         if (text === null) {
-            throw KeyNotFoundFileError.create(this._key);
+            throw KeyNotFoundFileError.create(this._key, this.context);
         }
         return text;
     }
 
     async getBytes(): Promise<Uint8Array | null> {
-        return await this.adapter.getBytes(this.context, this._key.toString());
+        return await this.adapter.getBytes(this._key, this.context);
     }
 
     async getBytesOrFail(): Promise<Uint8Array> {
         const bytes = await this.getBytes();
         if (bytes === null) {
-            throw KeyNotFoundFileError.create(this._key);
+            throw KeyNotFoundFileError.create(this._key, this.context);
         }
         return bytes;
     }
@@ -172,16 +172,13 @@ export class File implements IFile {
     async getArrayBufferOrFail(): Promise<ArrayBuffer> {
         const arrayBuffer = await this.getArrayBuffer();
         if (arrayBuffer === null) {
-            throw KeyNotFoundFileError.create(this._key);
+            throw KeyNotFoundFileError.create(this._key, this.context);
         }
         return arrayBuffer;
     }
 
     async getReadableStream(): Promise<ReadableStream<Uint8Array> | null> {
-        const stream = await this.adapter.getStream(
-            this.context,
-            this._key.toString(),
-        );
+        const stream = await this.adapter.getStream(this._key, this.context);
         if (stream === null) {
             return null;
         }
@@ -191,15 +188,15 @@ export class File implements IFile {
     async getReadableStreamOrFail(): Promise<ReadableStream<Uint8Array>> {
         const stream = await this.getReadableStream();
         if (stream === null) {
-            throw KeyNotFoundFileError.create(this._key);
+            throw KeyNotFoundFileError.create(this._key, this.context);
         }
         return stream;
     }
 
     async getMetadata(): Promise<FileMetadata | null> {
         const metadata = await this.adapter.getMetaData(
+            this._key,
             this.context,
-            this._key.toString(),
         );
         if (metadata === null) {
             return null;
@@ -215,13 +212,13 @@ export class File implements IFile {
     async getMetadataOrFail(): Promise<FileMetadata> {
         const metadata = await this.getMetadata();
         if (metadata === null) {
-            throw KeyNotFoundFileError.create(this._key);
+            throw KeyNotFoundFileError.create(this._key, this.context);
         }
         return metadata;
     }
 
     async exists(): Promise<boolean> {
-        return await this.adapter.exists(this.context, this._key.toString());
+        return await this.adapter.exists(this._key, this.context);
     }
 
     async missing(): Promise<boolean> {
@@ -231,21 +228,25 @@ export class File implements IFile {
     async add(content: WritableFileContent): Promise<boolean> {
         const { data, contentType = this.getContentType(this._key) } = content;
         const resolvedData = resolveFileContent(data);
-        return await this.adapter.add(this.context, this._key.toString(), {
-            data: resolvedData,
-            contentType,
-            contentDisposition: this.defaultContentDisposition,
-            contentEncoding: this.defaultContentEncoding,
-            cacheControl: this.defaultCacheControl,
-            contentLanguage: this.defaultContentLanguage,
-            fileSizeInBytes: resolvedData.length,
-        });
+        return await this.adapter.add(
+            this._key,
+            {
+                data: resolvedData,
+                contentType,
+                contentDisposition: this.defaultContentDisposition,
+                contentEncoding: this.defaultContentEncoding,
+                cacheControl: this.defaultCacheControl,
+                contentLanguage: this.defaultContentLanguage,
+                fileSizeInBytes: resolvedData.length,
+            },
+            this.context,
+        );
     }
 
     async addOrFail(content: WritableFileContent): Promise<void> {
         const hasAdded = await this.add(content);
         if (!hasAdded) {
-            throw KeyExistsFileError.create(this._key);
+            throw KeyExistsFileError.create(this._key, this.context);
         }
     }
 
@@ -265,8 +266,7 @@ export class File implements IFile {
         } = stream;
 
         return await this.adapter.addStream(
-            this.context,
-            this._key.toString(),
+            this._key,
             {
                 data: new ResolveFileStream(data),
                 fileSizeInBytes: fileSize?.[TO_BYTES]() ?? null,
@@ -276,34 +276,39 @@ export class File implements IFile {
                 cacheControl: this.defaultCacheControl,
                 contentLanguage: this.defaultContentLanguage,
             },
+            this.context,
         );
     }
 
     async addStreamOrFail(stream: WritableFileStream): Promise<void> {
         const hasAdded = await this.addStream(stream);
         if (!hasAdded) {
-            throw KeyExistsFileError.create(this._key);
+            throw KeyExistsFileError.create(this._key, this.context);
         }
     }
 
     async update(content: WritableFileContent): Promise<boolean> {
         const { data, contentType = this.getContentType(this._key) } = content;
         const resolvedData = resolveFileContent(data);
-        return await this.adapter.update(this.context, this._key.toString(), {
-            data: resolvedData,
-            contentType,
-            contentDisposition: this.defaultContentDisposition,
-            contentEncoding: this.defaultContentEncoding,
-            cacheControl: this.defaultCacheControl,
-            contentLanguage: this.defaultContentLanguage,
-            fileSizeInBytes: resolvedData.length,
-        });
+        return await this.adapter.update(
+            this._key,
+            {
+                data: resolvedData,
+                contentType,
+                contentDisposition: this.defaultContentDisposition,
+                contentEncoding: this.defaultContentEncoding,
+                cacheControl: this.defaultCacheControl,
+                contentLanguage: this.defaultContentLanguage,
+                fileSizeInBytes: resolvedData.length,
+            },
+            this.context,
+        );
     }
 
     async updateOrFail(content: WritableFileContent): Promise<void> {
         const hasUpdated = await this.update(content);
         if (!hasUpdated) {
-            throw KeyNotFoundFileError.create(this._key);
+            throw KeyNotFoundFileError.create(this._key, this.context);
         }
     }
 
@@ -314,8 +319,7 @@ export class File implements IFile {
             contentType = this.getContentType(this._key),
         } = stream;
         return await this.adapter.updateStream(
-            this.context,
-            this._key.toString(),
+            this._key,
             {
                 data: new ResolveFileStream(data),
                 fileSizeInBytes: fileSize?.[TO_BYTES]() ?? null,
@@ -325,28 +329,33 @@ export class File implements IFile {
                 cacheControl: this.defaultCacheControl,
                 contentLanguage: this.defaultContentLanguage,
             },
+            this.context,
         );
     }
 
     async updateStreamOrFail(stream: WritableFileStream): Promise<void> {
         const hasUpdated = await this.updateStream(stream);
         if (!hasUpdated) {
-            throw KeyNotFoundFileError.create(this._key);
+            throw KeyNotFoundFileError.create(this._key, this.context);
         }
     }
 
     async put(content: WritableFileContent): Promise<boolean> {
         const { data, contentType = this.getContentType(this._key) } = content;
         const resolvedData = resolveFileContent(data);
-        return await this.adapter.put(this.context, this._key.toString(), {
-            data: resolvedData,
-            contentType,
-            contentDisposition: this.defaultContentDisposition,
-            contentEncoding: this.defaultContentEncoding,
-            cacheControl: this.defaultCacheControl,
-            contentLanguage: this.defaultContentLanguage,
-            fileSizeInBytes: resolvedData.length,
-        });
+        return await this.adapter.put(
+            this._key,
+            {
+                data: resolvedData,
+                contentType,
+                contentDisposition: this.defaultContentDisposition,
+                contentEncoding: this.defaultContentEncoding,
+                cacheControl: this.defaultCacheControl,
+                contentLanguage: this.defaultContentLanguage,
+                fileSizeInBytes: resolvedData.length,
+            },
+            this.context,
+        );
     }
 
     async putStream(stream: WritableFileStream): Promise<boolean> {
@@ -356,8 +365,7 @@ export class File implements IFile {
             contentType = this.getContentType(this._key),
         } = stream;
         return await this.adapter.putStream(
-            this.context,
-            this._key.toString(),
+            this._key,
             {
                 data: new ResolveFileStream(data),
                 fileSizeInBytes: fileSize?.[TO_BYTES]() ?? null,
@@ -367,104 +375,105 @@ export class File implements IFile {
                 cacheControl: this.defaultCacheControl,
                 contentLanguage: this.defaultContentLanguage,
             },
+            this.context,
         );
     }
 
     async remove(): Promise<boolean> {
-        return await this.adapter.removeMany(this.context, [this._key]);
+        return await this.adapter.removeMany([this._key], this.context);
     }
 
     async removeOrFail(): Promise<void> {
         const hasFound = await this.remove();
         if (!hasFound) {
-            throw KeyNotFoundFileError.create(this._key);
+            throw KeyNotFoundFileError.create(this._key, this.context);
         }
     }
 
     async copy(destination: string): Promise<boolean> {
         const result = await this.adapter.copy(
-            this.context,
-            this._key.toString(),
+            this._key,
             destination,
+            this.context,
         );
         return result === FILE_WRITE_ENUM.SUCCESS;
     }
 
     async copyOrFail(destination: string): Promise<void> {
         const result = await this.adapter.copy(
-            this.context,
-            this._key.toString(),
+            this._key,
             destination,
+            this.context,
         );
         if (result === FILE_WRITE_ENUM.KEY_EXISTS) {
-            throw KeyExistsFileError.create(this._key);
+            throw KeyExistsFileError.create(this._key, this.context);
         }
         if (result === FILE_WRITE_ENUM.NOT_FOUND) {
-            throw KeyNotFoundFileError.create(this._key);
+            throw KeyNotFoundFileError.create(this._key, this.context);
         }
     }
 
     async copyAndReplace(destination: string): Promise<boolean> {
         return await this.adapter.copyAndReplace(
-            this.context,
-            this._key.toString(),
+            this._key,
             destination,
+            this.context,
         );
     }
 
     async copyAndReplaceOrFail(destination: string): Promise<void> {
         const hasCopied = await this.copyAndReplace(destination);
         if (!hasCopied) {
-            throw KeyNotFoundFileError.create(this._key);
+            throw KeyNotFoundFileError.create(this._key, this.context);
         }
     }
 
     async move(destination: string): Promise<boolean> {
         const result = await this.adapter.move(
-            this.context,
-            this._key.toString(),
+            this._key,
             destination,
+            this.context,
         );
         return result === FILE_WRITE_ENUM.SUCCESS;
     }
 
     async moveOrFail(destination: string): Promise<void> {
         const result = await this.adapter.move(
-            this.context,
-            this._key.toString(),
+            this._key,
             destination,
+            this.context,
         );
         if (result === FILE_WRITE_ENUM.KEY_EXISTS) {
-            throw KeyExistsFileError.create(this._key);
+            throw KeyExistsFileError.create(this._key, this.context);
         }
         if (result === FILE_WRITE_ENUM.NOT_FOUND) {
-            throw KeyNotFoundFileError.create(this._key);
+            throw KeyNotFoundFileError.create(this._key, this.context);
         }
     }
 
     async moveAndReplace(destination: string): Promise<boolean> {
         return await this.adapter.moveAndReplace(
-            this.context,
-            this._key.toString(),
+            this._key,
             destination,
+            this.context,
         );
     }
 
     async moveAndReplaceOrFail(destination: string): Promise<void> {
         const hasCopied = await this.moveAndReplace(destination);
         if (!hasCopied) {
-            throw KeyNotFoundFileError.create(this._key);
+            throw KeyNotFoundFileError.create(this._key, this.context);
         }
     }
 
     async getPublicUrl(): Promise<string | null> {
-        return await this.adapter.getPublicUrl(this.context, this._key);
+        return await this.adapter.getPublicUrl(this._key, this.context);
     }
 
     async getPublicUrlOrFail(): Promise<string> {
         const url = await this.getPublicUrl();
         if (url === null) {
-            throw KeyNotFoundFileError.create(this._key);
+            throw KeyNotFoundFileError.create(this._key, this.context);
         }
         return url;
     }
@@ -474,12 +483,12 @@ export class File implements IFile {
     ): Promise<string> {
         const { ttl = TimeSpan.fromMinutes(10), contentType = null } = options;
         return await this.adapter.getSignedUploadUrl(
-            this.context,
-            this._key.toString(),
+            this._key,
             {
                 expirationInSeconds: TimeSpan.fromTimeSpan(ttl).toSeconds(),
                 contentType,
             },
+            this.context,
         );
     }
 
@@ -492,14 +501,14 @@ export class File implements IFile {
             contentDisposition = null,
         } = options;
         return await this.adapter.getSignedDownloadUrl(
-            this.context,
-            this._key.toString(),
+            this._key,
             {
                 expirationInSeconds:
                     TimeSpan.fromTimeSpan(expiration).toSeconds(),
                 contentType,
                 contentDisposition,
             },
+            this.context,
         );
     }
 
@@ -508,7 +517,7 @@ export class File implements IFile {
     ): Promise<string> {
         const url = await this.getSignedDownloadUrl(options);
         if (url === null) {
-            throw KeyNotFoundFileError.create(this._key);
+            throw KeyNotFoundFileError.create(this._key, this.context);
         }
         return url;
     }

--- a/src/file-storage/implementations/derivables/file-storage/is-signed-file-storage-adapter.test.ts
+++ b/src/file-storage/implementations/derivables/file-storage/is-signed-file-storage-adapter.test.ts
@@ -18,126 +18,126 @@ describe("function: isSignedFileStorageAdapter", () => {
     test("Should return true when given ISignedFileStorageAdapter", () => {
         const adapter: ISignedFileStorageAdapter = {
             getPublicUrl(
-                _context: IReadableContext,
                 _key: string,
+                _context: IReadableContext,
             ): Promise<string | null> {
                 throw new Error("Function not implemented.");
             },
             getSignedDownloadUrl(
-                _context: IReadableContext,
                 _key: string,
                 _settings: FileAdapterSignedDownloadUrlSettings,
+                _context: IReadableContext,
             ): Promise<string | null> {
                 throw new Error("Function not implemented.");
             },
 
             getSignedUploadUrl(
-                _context: IReadableContext,
                 _key: string,
                 _settings: FileAdapterSignedUploadUrlSettings,
+                _context: IReadableContext,
             ): Promise<string> {
                 throw new Error("Function not implemented.");
             },
-            exists(_context: IReadableContext, _key: string): Promise<boolean> {
+            exists(_key: string, _context: IReadableContext): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             getStream(
-                _context: IReadableContext,
                 _key: string,
+                _context: IReadableContext,
             ): Promise<FileAdapterStream | null> {
                 throw new Error("Function not implemented.");
             },
             getBytes(
-                _context: IReadableContext,
                 _key: string,
+                _context: IReadableContext,
             ): Promise<Uint8Array | null> {
                 throw new Error("Function not implemented.");
             },
             getMetaData(
-                _context: IReadableContext,
                 _key: string,
+                _context: IReadableContext,
             ): Promise<FileAdapterMetadata | null> {
                 throw new Error("Function not implemented.");
             },
             add(
-                _context: IReadableContext,
                 _key: string,
                 _content: WritableFileAdapterContent,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             addStream(
-                _context: IReadableContext,
                 _key: string,
                 _stream: WritableFileAdapterStream,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             update(
-                _context: IReadableContext,
                 _key: string,
                 _content: WritableFileAdapterContent,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             updateStream(
-                _context: IReadableContext,
                 _key: string,
                 _stream: WritableFileAdapterStream,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             put(
-                _context: IReadableContext,
                 _key: string,
                 _content: WritableFileAdapterContent,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             putStream(
-                _context: IReadableContext,
                 _key: string,
                 _stream: WritableFileAdapterStream,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             copy(
-                _context: IReadableContext,
                 _source: string,
                 _destination: string,
+                _context: IReadableContext,
             ): Promise<FileWriteEnum> {
                 throw new Error("Function not implemented.");
             },
             copyAndReplace(
-                _context: IReadableContext,
                 _source: string,
                 _destination: string,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             move(
-                _context: IReadableContext,
                 _source: string,
                 _destination: string,
+                _context: IReadableContext,
             ): Promise<FileWriteEnum> {
                 throw new Error("Function not implemented.");
             },
             moveAndReplace(
-                _context: IReadableContext,
                 _source: string,
                 _destination: string,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             removeMany(
-                _context: IReadableContext,
                 _keys: Array<string>,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             removeByPrefix(
-                _context: IReadableContext,
                 _prefix: string,
+                _context: IReadableContext,
             ): Promise<void> {
                 throw new Error("Function not implemented.");
             },
@@ -147,106 +147,106 @@ describe("function: isSignedFileStorageAdapter", () => {
     });
     test("Should return true when given IFileStorageAdapter", () => {
         const adapter: IFileStorageAdapter = {
-            exists(_context: IReadableContext, _key: string): Promise<boolean> {
+            exists(_key: string, _context: IReadableContext): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             getStream(
-                _context: IReadableContext,
                 _key: string,
+                _context: IReadableContext,
             ): Promise<FileAdapterStream | null> {
                 throw new Error("Function not implemented.");
             },
             getBytes(
-                _context: IReadableContext,
                 _key: string,
+                _context: IReadableContext,
             ): Promise<Uint8Array | null> {
                 throw new Error("Function not implemented.");
             },
             getMetaData(
-                _context: IReadableContext,
                 _key: string,
+                _context: IReadableContext,
             ): Promise<FileAdapterMetadata | null> {
                 throw new Error("Function not implemented.");
             },
             add(
-                _context: IReadableContext,
                 _key: string,
                 _content: WritableFileAdapterContent,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             addStream(
-                _context: IReadableContext,
                 _key: string,
                 _stream: WritableFileAdapterStream,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             update(
-                _context: IReadableContext,
                 _key: string,
                 _content: WritableFileAdapterContent,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             updateStream(
-                _context: IReadableContext,
                 _key: string,
                 _stream: WritableFileAdapterStream,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             put(
-                _context: IReadableContext,
                 _key: string,
                 _content: WritableFileAdapterContent,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             putStream(
-                _context: IReadableContext,
                 _key: string,
                 _stream: WritableFileAdapterStream,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             copy(
-                _context: IReadableContext,
                 _source: string,
                 _destination: string,
+                _context: IReadableContext,
             ): Promise<FileWriteEnum> {
                 throw new Error("Function not implemented.");
             },
             copyAndReplace(
-                _context: IReadableContext,
                 _source: string,
                 _destination: string,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             move(
-                _context: IReadableContext,
                 _source: string,
                 _destination: string,
+                _context: IReadableContext,
             ): Promise<FileWriteEnum> {
                 throw new Error("Function not implemented.");
             },
             moveAndReplace(
-                _context: IReadableContext,
                 _source: string,
                 _destination: string,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             removeMany(
-                _context: IReadableContext,
                 _keys: Array<string>,
+                _context: IReadableContext,
             ): Promise<boolean> {
                 throw new Error("Function not implemented.");
             },
             removeByPrefix(
-                _context: IReadableContext,
                 _prefix: string,
+                _context: IReadableContext,
             ): Promise<void> {
                 throw new Error("Function not implemented.");
             },

--- a/src/file-storage/implementations/derivables/file-storage/merged-file-url-adapter.ts
+++ b/src/file-storage/implementations/derivables/file-storage/merged-file-url-adapter.ts
@@ -18,42 +18,42 @@ export class MergedFileUrlAdapter implements IFileUrlAdapter {
     constructor(private readonly adapter: Partial<IFileUrlAdapter>) {}
 
     async getPublicUrl(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<string | null> {
         if (this.adapter.getPublicUrl === undefined) {
-            return this.noOpUrlAdapter.getPublicUrl(context, key);
+            return this.noOpUrlAdapter.getPublicUrl(key, context);
         }
-        return this.adapter.getPublicUrl(context, key);
+        return this.adapter.getPublicUrl(key, context);
     }
 
     async getSignedDownloadUrl(
-        context: IReadableContext,
         key: string,
         settings: FileAdapterSignedDownloadUrlSettings,
+        context: IReadableContext,
     ): Promise<string | null> {
         if (this.adapter.getSignedDownloadUrl === undefined) {
             return this.noOpUrlAdapter.getSignedDownloadUrl(
-                context,
                 key,
                 settings,
+                context,
             );
         }
-        return this.adapter.getSignedDownloadUrl(context, key, settings);
+        return this.adapter.getSignedDownloadUrl(key, settings, context);
     }
 
     async getSignedUploadUrl(
-        context: IReadableContext,
         key: string,
         settings: FileAdapterSignedUploadUrlSettings,
+        context: IReadableContext,
     ): Promise<string> {
         if (this.adapter.getSignedUploadUrl === undefined) {
             return this.noOpUrlAdapter.getSignedUploadUrl(
-                context,
                 key,
                 settings,
+                context,
             );
         }
-        return this.adapter.getSignedUploadUrl(context, key, settings);
+        return this.adapter.getSignedUploadUrl(key, settings, context);
     }
 }

--- a/src/file-storage/implementations/derivables/file-storage/no-op-file-url-adapter.ts
+++ b/src/file-storage/implementations/derivables/file-storage/no-op-file-url-adapter.ts
@@ -13,24 +13,24 @@ import {
  */
 export class NoOpFileUrlAdapter implements IFileUrlAdapter {
     getPublicUrl(
-        _context: IReadableContext,
         _key: string,
+        _context: IReadableContext,
     ): Promise<string | null> {
         return Promise.resolve(null);
     }
 
     getSignedDownloadUrl(
-        _context: IReadableContext,
         _key: string,
         _settings: FileAdapterSignedDownloadUrlSettings,
+        _context: IReadableContext,
     ): Promise<string | null> {
         return Promise.resolve(null);
     }
 
     getSignedUploadUrl(
-        _context: IReadableContext,
         _key: string,
         _settings: FileAdapterSignedUploadUrlSettings,
+        _context: IReadableContext,
     ): Promise<string> {
         return Promise.resolve("");
     }

--- a/src/file-storage/implementations/derivables/file-storage/signed-file-storage-adapter.test.ts
+++ b/src/file-storage/implementations/derivables/file-storage/signed-file-storage-adapter.test.ts
@@ -20,128 +20,128 @@ import { SignedFileStorageAdapter } from "@/file-storage/implementations/derivab
 describe("class: SignedFileStorageAdapter", () => {
     let signedFileStorageAdapter: SignedFileStorageAdapter;
     const fileStorageAdapter: IFileStorageAdapter = {
-        exists(_context: IReadableContext, _key: string): Promise<boolean> {
+        exists(_key: string, _context: IReadableContext): Promise<boolean> {
             return Promise.resolve(false);
         },
         getStream(
-            _context: IReadableContext,
             _key: string,
+            _context: IReadableContext,
         ): Promise<FileAdapterStream | null> {
             return Promise.resolve(null);
         },
         getBytes(
-            _context: IReadableContext,
             _key: string,
+            _context: IReadableContext,
         ): Promise<Uint8Array | null> {
             return Promise.resolve(null);
         },
         getMetaData(
-            _context: IReadableContext,
             _key: string,
+            _context: IReadableContext,
         ): Promise<FileAdapterMetadata | null> {
             return Promise.resolve(null);
         },
         add(
-            _context: IReadableContext,
             _key: string,
             _content: WritableFileAdapterContent,
+            _context: IReadableContext,
         ): Promise<boolean> {
             return Promise.resolve(false);
         },
         addStream(
-            _context: IReadableContext,
             _key: string,
             _stream: WritableFileAdapterStream,
+            _context: IReadableContext,
         ): Promise<boolean> {
             return Promise.resolve(false);
         },
         update(
-            _context: IReadableContext,
             _key: string,
             _content: WritableFileAdapterContent,
+            _context: IReadableContext,
         ): Promise<boolean> {
             return Promise.resolve(false);
         },
         updateStream(
-            _context: IReadableContext,
             _key: string,
             _stream: WritableFileAdapterStream,
+            _context: IReadableContext,
         ): Promise<boolean> {
             return Promise.resolve(false);
         },
         put(
-            _context: IReadableContext,
             _key: string,
             _content: WritableFileAdapterContent,
+            _context: IReadableContext,
         ): Promise<boolean> {
             return Promise.resolve(false);
         },
         putStream(
-            _context: IReadableContext,
             _key: string,
             _stream: WritableFileAdapterStream,
+            _context: IReadableContext,
         ): Promise<boolean> {
             return Promise.resolve(false);
         },
         copy(
-            _context: IReadableContext,
             _source: string,
             _destination: string,
+            _context: IReadableContext,
         ): Promise<FileWriteEnum> {
             return Promise.resolve(FILE_WRITE_ENUM.NOT_FOUND);
         },
         copyAndReplace(
-            _context: IReadableContext,
             _source: string,
             _destination: string,
+            _context: IReadableContext,
         ): Promise<boolean> {
             return Promise.resolve(false);
         },
         move(
-            _context: IReadableContext,
             _source: string,
             _destination: string,
+            _context: IReadableContext,
         ): Promise<FileWriteEnum> {
             return Promise.resolve(FILE_WRITE_ENUM.NOT_FOUND);
         },
         moveAndReplace(
-            _context: IReadableContext,
             _source: string,
             _destination: string,
+            _context: IReadableContext,
         ): Promise<boolean> {
             return Promise.resolve(false);
         },
         removeMany(
-            _context: IReadableContext,
             _keys: Array<string>,
+            _context: IReadableContext,
         ): Promise<boolean> {
             return Promise.resolve(false);
         },
         removeByPrefix(
-            _context: IReadableContext,
             _prefix: string,
+            _context: IReadableContext,
         ): Promise<void> {
             return Promise.resolve();
         },
     };
     const fileUrlAdapter: IFileUrlAdapter = {
         getPublicUrl(
-            _context: IReadableContext,
             _key: string,
+            _context: IReadableContext,
         ): Promise<string | null> {
             return Promise.resolve(null);
         },
         getSignedDownloadUrl(
-            _context: IReadableContext,
             _key: string,
             _settings: FileAdapterSignedDownloadUrlSettings,
+            _context: IReadableContext,
         ): Promise<string | null> {
             return Promise.resolve(null);
         },
         getSignedUploadUrl(
-            _context: IReadableContext,
             _key: string,
             _settings: FileAdapterSignedUploadUrlSettings,
+            _context: IReadableContext,
         ): Promise<string> {
             return Promise.resolve("");
         },
@@ -159,7 +159,7 @@ describe("class: SignedFileStorageAdapter", () => {
         test("Should call IFileStorageAdapter.exists", async () => {
             const existsSpy = vi.spyOn(fileStorageAdapter, "exists");
 
-            await signedFileStorageAdapter.exists(noOpContext, "a");
+            await signedFileStorageAdapter.exists("a", noOpContext);
 
             expect(existsSpy).toHaveBeenCalledOnce();
         });
@@ -168,7 +168,7 @@ describe("class: SignedFileStorageAdapter", () => {
         test("Should call IFileStorageAdapter.getStream", async () => {
             const getStreamSpy = vi.spyOn(fileStorageAdapter, "getStream");
 
-            await signedFileStorageAdapter.getStream(noOpContext, "a");
+            await signedFileStorageAdapter.getStream("a", noOpContext);
 
             expect(getStreamSpy).toHaveBeenCalledOnce();
         });
@@ -177,7 +177,7 @@ describe("class: SignedFileStorageAdapter", () => {
         test("Should call IFileStorageAdapter.getBytes", async () => {
             const getBytesSpy = vi.spyOn(fileStorageAdapter, "getBytes");
 
-            await signedFileStorageAdapter.getBytes(noOpContext, "a");
+            await signedFileStorageAdapter.getBytes("a", noOpContext);
 
             expect(getBytesSpy).toHaveBeenCalledOnce();
         });
@@ -186,7 +186,7 @@ describe("class: SignedFileStorageAdapter", () => {
         test("Should call IFileStorageAdapter.getMetaData", async () => {
             const getMetaDataSpy = vi.spyOn(fileStorageAdapter, "getMetaData");
 
-            await signedFileStorageAdapter.getMetaData(noOpContext, "a");
+            await signedFileStorageAdapter.getMetaData("a", noOpContext);
 
             expect(getMetaDataSpy).toHaveBeenCalledOnce();
         });
@@ -195,15 +195,19 @@ describe("class: SignedFileStorageAdapter", () => {
         test("Should call IFileStorageAdapter.add", async () => {
             const addSpy = vi.spyOn(fileStorageAdapter, "add");
 
-            await signedFileStorageAdapter.add(noOpContext, "a", {
-                contentType: "",
-                contentLanguage: null,
-                contentEncoding: null,
-                contentDisposition: null,
-                cacheControl: null,
-                data: new Uint8Array(Buffer.from("CONTENT", "utf8")),
-                fileSizeInBytes: 0,
-            });
+            await signedFileStorageAdapter.add(
+                "a",
+                {
+                    contentType: "",
+                    contentLanguage: null,
+                    contentEncoding: null,
+                    contentDisposition: null,
+                    cacheControl: null,
+                    data: new Uint8Array(Buffer.from("CONTENT", "utf8")),
+                    fileSizeInBytes: 0,
+                },
+                noOpContext,
+            );
 
             expect(addSpy).toHaveBeenCalledOnce();
         });
@@ -212,21 +216,25 @@ describe("class: SignedFileStorageAdapter", () => {
         test("Should call IFileStorageAdapter.addStream", async () => {
             const addStreamSpy = vi.spyOn(fileStorageAdapter, "addStream");
 
-            await signedFileStorageAdapter.addStream(noOpContext, "a", {
-                contentType: "",
-                contentLanguage: null,
-                contentEncoding: null,
-                contentDisposition: null,
-                cacheControl: null,
-                data: {
-                    async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                        yield Promise.resolve(
-                            new Uint8Array(Buffer.from("CONTENT", "utf8")),
-                        );
+            await signedFileStorageAdapter.addStream(
+                "a",
+                {
+                    contentType: "",
+                    contentLanguage: null,
+                    contentEncoding: null,
+                    contentDisposition: null,
+                    cacheControl: null,
+                    data: {
+                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                            yield Promise.resolve(
+                                new Uint8Array(Buffer.from("CONTENT", "utf8")),
+                            );
+                        },
                     },
+                    fileSizeInBytes: 0,
                 },
-                fileSizeInBytes: 0,
-            });
+                noOpContext,
+            );
             expect(addStreamSpy).toHaveBeenCalledOnce();
         });
     });
@@ -234,15 +242,19 @@ describe("class: SignedFileStorageAdapter", () => {
         test("Should call IFileStorageAdapter.update", async () => {
             const updateSpy = vi.spyOn(fileStorageAdapter, "update");
 
-            await signedFileStorageAdapter.update(noOpContext, "a", {
-                contentType: "",
-                contentLanguage: null,
-                contentEncoding: null,
-                contentDisposition: null,
-                cacheControl: null,
-                data: new Uint8Array(Buffer.from("CONTENT", "utf8")),
-                fileSizeInBytes: 0,
-            });
+            await signedFileStorageAdapter.update(
+                "a",
+                {
+                    contentType: "",
+                    contentLanguage: null,
+                    contentEncoding: null,
+                    contentDisposition: null,
+                    cacheControl: null,
+                    data: new Uint8Array(Buffer.from("CONTENT", "utf8")),
+                    fileSizeInBytes: 0,
+                },
+                noOpContext,
+            );
 
             expect(updateSpy).toHaveBeenCalledOnce();
         });
@@ -254,21 +266,25 @@ describe("class: SignedFileStorageAdapter", () => {
                 "updateStream",
             );
 
-            await signedFileStorageAdapter.updateStream(noOpContext, "a", {
-                contentType: "",
-                contentLanguage: null,
-                contentEncoding: null,
-                contentDisposition: null,
-                cacheControl: null,
-                data: {
-                    async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                        yield Promise.resolve(
-                            new Uint8Array(Buffer.from("CONTENT", "utf8")),
-                        );
+            await signedFileStorageAdapter.updateStream(
+                "a",
+                {
+                    contentType: "",
+                    contentLanguage: null,
+                    contentEncoding: null,
+                    contentDisposition: null,
+                    cacheControl: null,
+                    data: {
+                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                            yield Promise.resolve(
+                                new Uint8Array(Buffer.from("CONTENT", "utf8")),
+                            );
+                        },
                     },
+                    fileSizeInBytes: 0,
                 },
-                fileSizeInBytes: 0,
-            });
+                noOpContext,
+            );
 
             expect(updateStreamSpy).toHaveBeenCalledOnce();
         });
@@ -277,15 +293,19 @@ describe("class: SignedFileStorageAdapter", () => {
         test("Should call IFileStorageAdapter.put", async () => {
             const putSpy = vi.spyOn(fileStorageAdapter, "put");
 
-            await signedFileStorageAdapter.put(noOpContext, "a", {
-                contentType: "",
-                contentLanguage: null,
-                contentEncoding: null,
-                contentDisposition: null,
-                cacheControl: null,
-                data: new Uint8Array(Buffer.from("CONTENT", "utf8")),
-                fileSizeInBytes: 0,
-            });
+            await signedFileStorageAdapter.put(
+                "a",
+                {
+                    contentType: "",
+                    contentLanguage: null,
+                    contentEncoding: null,
+                    contentDisposition: null,
+                    cacheControl: null,
+                    data: new Uint8Array(Buffer.from("CONTENT", "utf8")),
+                    fileSizeInBytes: 0,
+                },
+                noOpContext,
+            );
 
             expect(putSpy).toHaveBeenCalledOnce();
         });
@@ -294,21 +314,25 @@ describe("class: SignedFileStorageAdapter", () => {
         test("Should call IFileStorageAdapter.putStream", async () => {
             const putStreamSpy = vi.spyOn(fileStorageAdapter, "putStream");
 
-            await signedFileStorageAdapter.putStream(noOpContext, "a", {
-                contentType: "",
-                contentLanguage: null,
-                contentEncoding: null,
-                contentDisposition: null,
-                cacheControl: null,
-                data: {
-                    async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                        yield Promise.resolve(
-                            new Uint8Array(Buffer.from("CONTENT", "utf8")),
-                        );
+            await signedFileStorageAdapter.putStream(
+                "a",
+                {
+                    contentType: "",
+                    contentLanguage: null,
+                    contentEncoding: null,
+                    contentDisposition: null,
+                    cacheControl: null,
+                    data: {
+                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                            yield Promise.resolve(
+                                new Uint8Array(Buffer.from("CONTENT", "utf8")),
+                            );
+                        },
                     },
+                    fileSizeInBytes: 0,
                 },
-                fileSizeInBytes: 0,
-            });
+                noOpContext,
+            );
 
             expect(putStreamSpy).toHaveBeenCalledOnce();
         });
@@ -317,7 +341,7 @@ describe("class: SignedFileStorageAdapter", () => {
         test("Should call IFileStorageAdapter.copy", async () => {
             const copySpy = vi.spyOn(fileStorageAdapter, "copy");
 
-            await signedFileStorageAdapter.copy(noOpContext, "a", "b");
+            await signedFileStorageAdapter.copy("a", "b", noOpContext);
 
             expect(copySpy).toHaveBeenCalledOnce();
         });
@@ -330,9 +354,9 @@ describe("class: SignedFileStorageAdapter", () => {
             );
 
             await signedFileStorageAdapter.copyAndReplace(
-                noOpContext,
                 "a",
                 "b",
+                noOpContext,
             );
 
             expect(copyAndReplaceSpy).toHaveBeenCalledOnce();
@@ -342,7 +366,7 @@ describe("class: SignedFileStorageAdapter", () => {
         test("Should call IFileStorageAdapter.move", async () => {
             const moveSpy = vi.spyOn(fileStorageAdapter, "move");
 
-            await signedFileStorageAdapter.move(noOpContext, "a", "b");
+            await signedFileStorageAdapter.move("a", "b", noOpContext);
 
             expect(moveSpy).toHaveBeenCalledOnce();
         });
@@ -355,9 +379,9 @@ describe("class: SignedFileStorageAdapter", () => {
             );
 
             await signedFileStorageAdapter.moveAndReplace(
-                noOpContext,
                 "a",
                 "b",
+                noOpContext,
             );
 
             expect(moveAndReplaceSpy).toHaveBeenCalledOnce();
@@ -367,7 +391,7 @@ describe("class: SignedFileStorageAdapter", () => {
         test("Should call IFileStorageAdapter.removeMany", async () => {
             const removeManySpy = vi.spyOn(fileStorageAdapter, "removeMany");
 
-            await signedFileStorageAdapter.removeMany(noOpContext, ["a"]);
+            await signedFileStorageAdapter.removeMany(["a"], noOpContext);
 
             expect(removeManySpy).toHaveBeenCalledOnce();
         });
@@ -379,7 +403,7 @@ describe("class: SignedFileStorageAdapter", () => {
                 "removeByPrefix",
             );
 
-            await signedFileStorageAdapter.removeByPrefix(noOpContext, "a");
+            await signedFileStorageAdapter.removeByPrefix("a", noOpContext);
 
             expect(removeManySpy).toHaveBeenCalledOnce();
         });
@@ -388,7 +412,7 @@ describe("class: SignedFileStorageAdapter", () => {
         test("Should call IFileUrlAdapter.getPublicUrl", async () => {
             const getPublicUrlSpy = vi.spyOn(fileUrlAdapter, "getPublicUrl");
 
-            await signedFileStorageAdapter.getPublicUrl(noOpContext, "a");
+            await signedFileStorageAdapter.getPublicUrl("a", noOpContext);
 
             expect(getPublicUrlSpy).toHaveBeenCalledOnce();
         });
@@ -401,13 +425,13 @@ describe("class: SignedFileStorageAdapter", () => {
             );
 
             await signedFileStorageAdapter.getSignedDownloadUrl(
-                noOpContext,
                 "a",
                 {
                     contentDisposition: null,
                     contentType: null,
                     expirationInSeconds: 5000,
                 },
+                noOpContext,
             );
 
             expect(getSignedDownloadUrlSpy).toHaveBeenCalledOnce();
@@ -421,12 +445,12 @@ describe("class: SignedFileStorageAdapter", () => {
             );
 
             await signedFileStorageAdapter.getSignedUploadUrl(
-                noOpContext,
                 "a",
                 {
                     contentType: null,
                     expirationInSeconds: 5000,
                 },
+                noOpContext,
             );
 
             expect(getSignedUploadUrlSpy).toHaveBeenCalledOnce();

--- a/src/file-storage/implementations/derivables/file-storage/signed-file-storage-adapter.ts
+++ b/src/file-storage/implementations/derivables/file-storage/signed-file-storage-adapter.ts
@@ -30,160 +30,160 @@ export class SignedFileStorageAdapter implements ISignedFileStorageAdapter {
     }
 
     async getPublicUrl(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<string | null> {
-        return await this.fileUrlAdapter.getPublicUrl(context, key);
+        return await this.fileUrlAdapter.getPublicUrl(key, context);
     }
 
     async getSignedDownloadUrl(
-        context: IReadableContext,
         key: string,
         settings: FileAdapterSignedDownloadUrlSettings,
+        context: IReadableContext,
     ): Promise<string | null> {
         return await this.fileUrlAdapter.getSignedDownloadUrl(
-            context,
             key,
             settings,
+            context,
         );
     }
 
     async getSignedUploadUrl(
-        context: IReadableContext,
         key: string,
         settings: FileAdapterSignedUploadUrlSettings,
+        context: IReadableContext,
     ): Promise<string> {
         return await this.fileUrlAdapter.getSignedUploadUrl(
-            context,
             key,
             settings,
+            context,
         );
     }
 
-    async exists(context: IReadableContext, key: string): Promise<boolean> {
-        return await this.fileStorageAdapter.exists(context, key);
+    async exists(key: string, context: IReadableContext): Promise<boolean> {
+        return await this.fileStorageAdapter.exists(key, context);
     }
 
     async getStream(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<FileAdapterStream | null> {
-        return await this.fileStorageAdapter.getStream(context, key);
+        return await this.fileStorageAdapter.getStream(key, context);
     }
 
     async getBytes(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<Uint8Array | null> {
-        return await this.fileStorageAdapter.getBytes(context, key);
+        return await this.fileStorageAdapter.getBytes(key, context);
     }
 
     async getMetaData(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<FileAdapterMetadata | null> {
-        return await this.fileStorageAdapter.getMetaData(context, key);
+        return await this.fileStorageAdapter.getMetaData(key, context);
     }
 
     async add(
-        context: IReadableContext,
         key: string,
         content: WritableFileAdapterContent,
+        context: IReadableContext,
     ): Promise<boolean> {
-        return await this.fileStorageAdapter.add(context, key, content);
+        return await this.fileStorageAdapter.add(key, content, context);
     }
 
     async addStream(
-        context: IReadableContext,
         key: string,
         stream: WritableFileAdapterStream,
+        context: IReadableContext,
     ): Promise<boolean> {
-        return await this.fileStorageAdapter.addStream(context, key, stream);
+        return await this.fileStorageAdapter.addStream(key, stream, context);
     }
 
     async update(
-        context: IReadableContext,
         key: string,
         content: WritableFileAdapterContent,
+        context: IReadableContext,
     ): Promise<boolean> {
-        return await this.fileStorageAdapter.update(context, key, content);
+        return await this.fileStorageAdapter.update(key, content, context);
     }
 
     async updateStream(
-        context: IReadableContext,
         key: string,
         stream: WritableFileAdapterStream,
+        context: IReadableContext,
     ): Promise<boolean> {
-        return await this.fileStorageAdapter.updateStream(context, key, stream);
+        return await this.fileStorageAdapter.updateStream(key, stream, context);
     }
 
     async put(
-        context: IReadableContext,
         key: string,
         content: WritableFileAdapterContent,
+        context: IReadableContext,
     ): Promise<boolean> {
-        return await this.fileStorageAdapter.put(context, key, content);
+        return await this.fileStorageAdapter.put(key, content, context);
     }
 
     async putStream(
-        context: IReadableContext,
         key: string,
         stream: WritableFileAdapterStream,
+        context: IReadableContext,
     ): Promise<boolean> {
-        return await this.fileStorageAdapter.putStream(context, key, stream);
+        return await this.fileStorageAdapter.putStream(key, stream, context);
     }
 
     async copy(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<FileWriteEnum> {
-        return await this.fileStorageAdapter.copy(context, source, destination);
+        return await this.fileStorageAdapter.copy(source, destination, context);
     }
 
     async copyAndReplace(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<boolean> {
         return await this.fileStorageAdapter.copyAndReplace(
-            context,
             source,
             destination,
+            context,
         );
     }
 
     async move(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<FileWriteEnum> {
-        return await this.fileStorageAdapter.move(context, source, destination);
+        return await this.fileStorageAdapter.move(source, destination, context);
     }
 
     async moveAndReplace(
-        context: IReadableContext,
         source: string,
         destination: string,
+        context: IReadableContext,
     ): Promise<boolean> {
         return await this.fileStorageAdapter.moveAndReplace(
-            context,
             source,
             destination,
+            context,
         );
     }
 
     async removeMany(
-        context: IReadableContext,
         keys: Array<string>,
+        context: IReadableContext,
     ): Promise<boolean> {
-        return await this.fileStorageAdapter.removeMany(context, keys);
+        return await this.fileStorageAdapter.removeMany(keys, context);
     }
 
     async removeByPrefix(
-        context: IReadableContext,
         prefix: string,
+        context: IReadableContext,
     ): Promise<void> {
-        await this.fileStorageAdapter.removeByPrefix(context, prefix);
+        await this.fileStorageAdapter.removeByPrefix(prefix, context);
     }
 }

--- a/src/file-storage/implementations/plugins/with-file-storage-lock/with-file-storage-lock.test.ts
+++ b/src/file-storage/implementations/plugins/with-file-storage-lock/with-file-storage-lock.test.ts
@@ -36,7 +36,7 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.getPublicUrl(context, "myKey");
+                await enhanced.getPublicUrl("myKey", context);
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -55,7 +55,7 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                const result = await enhanced.getPublicUrl(context, "myKey");
+                const result = await enhanced.getPublicUrl("myKey", context);
 
                 expect(result).toBe("https://example.com/file");
             });
@@ -74,7 +74,7 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.exists(context, "myKey");
+                await enhanced.exists("myKey", context);
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -95,7 +95,7 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.getStream(context, "myKey");
+                await enhanced.getStream("myKey", context);
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -116,7 +116,7 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.getBytes(context, "myKey");
+                await enhanced.getBytes("myKey", context);
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -137,7 +137,7 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.getMetaData(context, "myKey");
+                await enhanced.getMetaData("myKey", context);
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -158,11 +158,15 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.getSignedDownloadUrl(context, "myKey", {
-                    expirationInSeconds: 3600,
-                    contentType: null,
-                    contentDisposition: null,
-                });
+                await enhanced.getSignedDownloadUrl(
+                    "myKey",
+                    {
+                        expirationInSeconds: 3600,
+                        contentType: null,
+                        contentDisposition: null,
+                    },
+                    context,
+                );
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -183,10 +187,14 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.getSignedUploadUrl(context, "myKey", {
-                    expirationInSeconds: 3600,
-                    contentType: null,
-                });
+                await enhanced.getSignedUploadUrl(
+                    "myKey",
+                    {
+                        expirationInSeconds: 3600,
+                        contentType: null,
+                    },
+                    context,
+                );
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -209,15 +217,19 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.add(context, "myKey", {
-                    data: new Uint8Array(),
-                    fileSizeInBytes: 0,
-                    contentType: "application/octet-stream",
-                    contentLanguage: null,
-                    contentEncoding: null,
-                    contentDisposition: null,
-                    cacheControl: null,
-                });
+                await enhanced.add(
+                    "myKey",
+                    {
+                        data: new Uint8Array(),
+                        fileSizeInBytes: 0,
+                        contentType: "application/octet-stream",
+                        contentLanguage: null,
+                        contentEncoding: null,
+                        contentDisposition: null,
+                        cacheControl: null,
+                    },
+                    context,
+                );
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -238,15 +250,19 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.addStream(context, "myKey", {
-                    data: (async function* () {})() as unknown as ReadableStream,
-                    fileSizeInBytes: null,
-                    contentType: "application/octet-stream",
-                    contentLanguage: null,
-                    contentEncoding: null,
-                    contentDisposition: null,
-                    cacheControl: null,
-                });
+                await enhanced.addStream(
+                    "myKey",
+                    {
+                        data: (async function* () {})() as unknown as ReadableStream,
+                        fileSizeInBytes: null,
+                        contentType: "application/octet-stream",
+                        contentLanguage: null,
+                        contentEncoding: null,
+                        contentDisposition: null,
+                        cacheControl: null,
+                    },
+                    context,
+                );
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -267,15 +283,19 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.update(context, "myKey", {
-                    data: new Uint8Array(),
-                    fileSizeInBytes: 0,
-                    contentType: "application/octet-stream",
-                    contentLanguage: null,
-                    contentEncoding: null,
-                    contentDisposition: null,
-                    cacheControl: null,
-                });
+                await enhanced.update(
+                    "myKey",
+                    {
+                        data: new Uint8Array(),
+                        fileSizeInBytes: 0,
+                        contentType: "application/octet-stream",
+                        contentLanguage: null,
+                        contentEncoding: null,
+                        contentDisposition: null,
+                        cacheControl: null,
+                    },
+                    context,
+                );
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -296,15 +316,19 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.updateStream(context, "myKey", {
-                    data: (async function* () {})() as unknown as ReadableStream,
-                    fileSizeInBytes: null,
-                    contentType: "application/octet-stream",
-                    contentLanguage: null,
-                    contentEncoding: null,
-                    contentDisposition: null,
-                    cacheControl: null,
-                });
+                await enhanced.updateStream(
+                    "myKey",
+                    {
+                        data: (async function* () {})() as unknown as ReadableStream,
+                        fileSizeInBytes: null,
+                        contentType: "application/octet-stream",
+                        contentLanguage: null,
+                        contentEncoding: null,
+                        contentDisposition: null,
+                        cacheControl: null,
+                    },
+                    context,
+                );
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -325,15 +349,19 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.put(context, "myKey", {
-                    data: new Uint8Array(),
-                    fileSizeInBytes: 0,
-                    contentType: "application/octet-stream",
-                    contentLanguage: null,
-                    contentEncoding: null,
-                    contentDisposition: null,
-                    cacheControl: null,
-                });
+                await enhanced.put(
+                    "myKey",
+                    {
+                        data: new Uint8Array(),
+                        fileSizeInBytes: 0,
+                        contentType: "application/octet-stream",
+                        contentLanguage: null,
+                        contentEncoding: null,
+                        contentDisposition: null,
+                        cacheControl: null,
+                    },
+                    context,
+                );
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -354,15 +382,19 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.putStream(context, "myKey", {
-                    data: (async function* () {})() as unknown as ReadableStream,
-                    fileSizeInBytes: null,
-                    contentType: "application/octet-stream",
-                    contentLanguage: null,
-                    contentEncoding: null,
-                    contentDisposition: null,
-                    cacheControl: null,
-                });
+                await enhanced.putStream(
+                    "myKey",
+                    {
+                        data: (async function* () {})() as unknown as ReadableStream,
+                        fileSizeInBytes: null,
+                        contentType: "application/octet-stream",
+                        contentLanguage: null,
+                        contentEncoding: null,
+                        contentDisposition: null,
+                        cacheControl: null,
+                    },
+                    context,
+                );
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -385,7 +417,7 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.copy(context, "sourceKey", "destKey");
+                await enhanced.copy("sourceKey", "destKey", context);
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("sourceKey");
@@ -406,7 +438,7 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.copyAndReplace(context, "sourceKey", "destKey");
+                await enhanced.copyAndReplace("sourceKey", "destKey", context);
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("sourceKey");
@@ -427,7 +459,7 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.move(context, "sourceKey", "destKey");
+                await enhanced.move("sourceKey", "destKey", context);
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("sourceKey");
@@ -448,7 +480,7 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.moveAndReplace(context, "sourceKey", "destKey");
+                await enhanced.moveAndReplace("sourceKey", "destKey", context);
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("sourceKey");
@@ -470,7 +502,7 @@ describe("function: withFileStorageLock", () => {
                 withFileStorageLock({ lockFactory }),
             );
 
-            await enhanced.removeMany(context, ["key1", "key2", "key3"]);
+            await enhanced.removeMany(["key1", "key2", "key3"], context);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledWith("key1");
@@ -491,12 +523,10 @@ describe("function: withFileStorageLock", () => {
                 withFileStorageLock({ lockFactory }),
             );
 
-            await enhanced.removeMany(context, [
-                "key1",
-                "key2",
-                "key1",
-                "key3",
-            ]);
+            await enhanced.removeMany(
+                ["key1", "key2", "key1", "key3"],
+                context,
+            );
 
             expect(spy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledTimes(3);
@@ -516,7 +546,7 @@ describe("function: withFileStorageLock", () => {
                 withFileStorageLock({ lockFactory }),
             );
 
-            const result = await enhanced.removeMany(context, ["key1", "key2"]);
+            const result = await enhanced.removeMany(["key1", "key2"], context);
 
             expect(result).toBe(true);
         });
@@ -538,12 +568,12 @@ describe("function: withFileStorageLock", () => {
                 }),
             );
 
-            await enhanced.exists(context, "myKey");
+            await enhanced.exists("myKey", context);
             expect(createSpy).toHaveBeenCalledWith("myKey");
             expect(runSpy).toHaveBeenCalledTimes(1);
 
             vi.clearAllMocks();
-            await enhanced.getBytes(context, "myKey");
+            await enhanced.getBytes("myKey", context);
             expect(createSpy).not.toHaveBeenCalled();
             expect(runSpy).not.toHaveBeenCalled();
             expect(existsSpy).not.toHaveBeenCalled();

--- a/src/file-storage/implementations/plugins/with-file-storage-lock/with-file-storage-lock.ts
+++ b/src/file-storage/implementations/plugins/with-file-storage-lock/with-file-storage-lock.ts
@@ -114,22 +114,18 @@ function withFileStorageReadLock(
 
     return (_adapter, _enhance) => {
         if (onlyMethods.includes("getPublicUrl")) {
-            _enhance(
-                _adapter,
-                "getPublicUrl",
-                ({ args: [_context, key, ..._rest], next }) => {
-                    return lockFactory.create(key).runOrFail(() => {
-                        return next();
-                    });
-                },
-            );
+            _enhance(_adapter, "getPublicUrl", ({ args: [key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
         }
 
         if (onlyMethods.includes("getSignedDownloadUrl")) {
             _enhance(
                 _adapter,
                 "getSignedDownloadUrl",
-                ({ args: [_context, key, ..._rest], next }) => {
+                ({ args: [key], next }) => {
                     return lockFactory.create(key).runOrFail(() => {
                         return next();
                     });
@@ -141,7 +137,7 @@ function withFileStorageReadLock(
             _enhance(
                 _adapter,
                 "getSignedUploadUrl",
-                ({ args: [_context, key, ..._rest], next }) => {
+                ({ args: [key], next }) => {
                     return lockFactory.create(key).runOrFail(() => {
                         return next();
                     });
@@ -150,7 +146,7 @@ function withFileStorageReadLock(
         }
 
         if (onlyMethods.includes("exists")) {
-            _enhance(_adapter, "exists", ({ args: [_context, key], next }) => {
+            _enhance(_adapter, "exists", ({ args: [key], next }) => {
                 return lockFactory.create(key).runOrFail(() => {
                     return next();
                 });
@@ -158,39 +154,27 @@ function withFileStorageReadLock(
         }
 
         if (onlyMethods.includes("getStream")) {
-            _enhance(
-                _adapter,
-                "getStream",
-                ({ args: [_context, key], next }) => {
-                    return lockFactory.create(key).runOrFail(() => {
-                        return next();
-                    });
-                },
-            );
+            _enhance(_adapter, "getStream", ({ args: [key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
         }
 
         if (onlyMethods.includes("getBytes")) {
-            _enhance(
-                _adapter,
-                "getBytes",
-                ({ args: [_context, key], next }) => {
-                    return lockFactory.create(key).runOrFail(() => {
-                        return next();
-                    });
-                },
-            );
+            _enhance(_adapter, "getBytes", ({ args: [key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
         }
 
         if (onlyMethods.includes("getMetaData")) {
-            _enhance(
-                _adapter,
-                "getMetaData",
-                ({ args: [_context, key], next }) => {
-                    return lockFactory.create(key).runOrFail(() => {
-                        return next();
-                    });
-                },
-            );
+            _enhance(_adapter, "getMetaData", ({ args: [key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
         }
     };
 }
@@ -215,75 +199,51 @@ function withFileStorageMutationLock(
 
     return (_adapter, _enhance) => {
         if (onlyMethods.includes("add")) {
-            _enhance(
-                _adapter,
-                "add",
-                ({ args: [_context, key, ..._rest], next }) => {
-                    return lockFactory.create(key).runOrFail(() => {
-                        return next();
-                    });
-                },
-            );
+            _enhance(_adapter, "add", ({ args: [key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
         }
 
         if (onlyMethods.includes("addStream")) {
-            _enhance(
-                _adapter,
-                "addStream",
-                ({ args: [_context, key, ..._rest], next }) => {
-                    return lockFactory.create(key).runOrFail(() => {
-                        return next();
-                    });
-                },
-            );
+            _enhance(_adapter, "addStream", ({ args: [key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
         }
 
         if (onlyMethods.includes("update")) {
-            _enhance(
-                _adapter,
-                "update",
-                ({ args: [_context, key, ..._rest], next }) => {
-                    return lockFactory.create(key).runOrFail(() => {
-                        return next();
-                    });
-                },
-            );
+            _enhance(_adapter, "update", ({ args: [key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
         }
 
         if (onlyMethods.includes("updateStream")) {
-            _enhance(
-                _adapter,
-                "updateStream",
-                ({ args: [_context, key, ..._rest], next }) => {
-                    return lockFactory.create(key).runOrFail(() => {
-                        return next();
-                    });
-                },
-            );
+            _enhance(_adapter, "updateStream", ({ args: [key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
         }
 
         if (onlyMethods.includes("put")) {
-            _enhance(
-                _adapter,
-                "put",
-                ({ args: [_context, key, ..._rest], next }) => {
-                    return lockFactory.create(key).runOrFail(() => {
-                        return next();
-                    });
-                },
-            );
+            _enhance(_adapter, "put", ({ args: [key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
         }
 
         if (onlyMethods.includes("putStream")) {
-            _enhance(
-                _adapter,
-                "putStream",
-                ({ args: [_context, key, ..._rest], next }) => {
-                    return lockFactory.create(key).runOrFail(() => {
-                        return next();
-                    });
-                },
-            );
+            _enhance(_adapter, "putStream", ({ args: [key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
         }
     };
 }
@@ -301,51 +261,35 @@ function withFileStorageCopyMoveLock(
 
     return (_adapter, _enhance) => {
         if (onlyMethods.includes("copy")) {
-            _enhance(
-                _adapter,
-                "copy",
-                ({ args: [_context, key, ..._rest], next }) => {
-                    return lockFactory.create(key).runOrFail(() => {
-                        return next();
-                    });
-                },
-            );
+            _enhance(_adapter, "copy", ({ args: [key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
         }
 
         if (onlyMethods.includes("copyAndReplace")) {
-            _enhance(
-                _adapter,
-                "copyAndReplace",
-                ({ args: [_context, key, ..._rest], next }) => {
-                    return lockFactory.create(key).runOrFail(() => {
-                        return next();
-                    });
-                },
-            );
+            _enhance(_adapter, "copyAndReplace", ({ args: [key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
         }
 
         if (onlyMethods.includes("move")) {
-            _enhance(
-                _adapter,
-                "move",
-                ({ args: [_context, key, ..._rest], next }) => {
-                    return lockFactory.create(key).runOrFail(() => {
-                        return next();
-                    });
-                },
-            );
+            _enhance(_adapter, "move", ({ args: [key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
         }
 
         if (onlyMethods.includes("moveAndReplace")) {
-            _enhance(
-                _adapter,
-                "moveAndReplace",
-                ({ args: [_context, key, ..._rest], next }) => {
-                    return lockFactory.create(key).runOrFail(() => {
-                        return next();
-                    });
-                },
-            );
+            _enhance(_adapter, "moveAndReplace", ({ args: [key], next }) => {
+                return lockFactory.create(key).runOrFail(() => {
+                    return next();
+                });
+            });
         }
     };
 }
@@ -360,18 +304,14 @@ function withFileStorageRemovalLock(
 
     return (_adapter, _enhance) => {
         if (onlyMethods.includes("removeMany")) {
-            _enhance(
-                _adapter,
-                "removeMany",
-                ({ args: [_context, keys], next }) => {
-                    let fn = () => next();
-                    for (const key of [...new Set(keys)].reverse()) {
-                        const prevFn = fn;
-                        fn = () => lockFactory.create(key).runOrFail(prevFn);
-                    }
-                    return fn();
-                },
-            );
+            _enhance(_adapter, "removeMany", ({ args: [keys], next }) => {
+                let fn = () => next();
+                for (const key of [...new Set(keys)].reverse()) {
+                    const prevFn = fn;
+                    fn = () => lockFactory.create(key).runOrFail(prevFn);
+                }
+                return fn();
+            });
         }
     };
 }

--- a/src/file-storage/implementations/plugins/with-file-storage-prefix/with-file-storage-prefix.test.ts
+++ b/src/file-storage/implementations/plugins/with-file-storage-prefix/with-file-storage-prefix.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
-import { type WritableFileAdapterContent } from "@/file-storage/contracts/_module.js";
+import {
+    type ISignedFileStorageAdapter,
+    type WritableFileAdapterContent,
+} from "@/file-storage/contracts/_module.js";
 import { NoOpFileStorageAdapter } from "@/file-storage/implementations/adapters/no-op-file-storage-adapter/_module.js";
 import { withFileStoragePrefix } from "@/file-storage/implementations/plugins/with-file-storage-prefix/with-file-storage-prefix.js";
 import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enhance-factory.js";
@@ -16,7 +19,6 @@ describe("function: withFileStoragePrefix", () => {
     afterEach(() => {
         vi.clearAllMocks();
     });
-
     describe("method: getPublicUrl", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -24,13 +26,14 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.getPublicUrl(context, "myKey");
+            await enhanced.getPublicUrl("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["getPublicUrl"]>
+            >(`${prefix}myKey`, context);
         });
     });
-
     describe("method: getSignedDownloadUrl", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -38,21 +41,30 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.getSignedDownloadUrl(context, "myKey", {
-                expirationInSeconds: 3600,
-                contentType: null,
-                contentDisposition: null,
-            });
+            await enhanced.getSignedDownloadUrl(
+                "myKey",
+                {
+                    expirationInSeconds: 3600,
+                    contentType: null,
+                    contentDisposition: null,
+                },
+                context,
+            );
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, {
-                expirationInSeconds: 3600,
-                contentType: null,
-                contentDisposition: null,
-            });
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["getSignedDownloadUrl"]>
+            >(
+                `${prefix}myKey`,
+                {
+                    expirationInSeconds: 3600,
+                    contentType: null,
+                    contentDisposition: null,
+                },
+                context,
+            );
         });
     });
-
     describe("method: getSignedUploadUrl", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -60,19 +72,28 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.getSignedUploadUrl(context, "myKey", {
-                expirationInSeconds: 3600,
-                contentType: null,
-            });
+            await enhanced.getSignedUploadUrl(
+                "myKey",
+                {
+                    expirationInSeconds: 3600,
+                    contentType: null,
+                },
+                context,
+            );
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, {
-                expirationInSeconds: 3600,
-                contentType: null,
-            });
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["getSignedUploadUrl"]>
+            >(
+                `${prefix}myKey`,
+                {
+                    expirationInSeconds: 3600,
+                    contentType: null,
+                },
+                context,
+            );
         });
     });
-
     describe("method: exists", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -80,13 +101,14 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.exists(context, "myKey");
+            await enhanced.exists("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["exists"]>
+            >(`${prefix}myKey`, context);
         });
     });
-
     describe("method: getStream", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -94,13 +116,14 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.getStream(context, "myKey");
+            await enhanced.getStream("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["getStream"]>
+            >(`${prefix}myKey`, context);
         });
     });
-
     describe("method: getBytes", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -108,13 +131,14 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.getBytes(context, "myKey");
+            await enhanced.getBytes("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["getBytes"]>
+            >(`${prefix}myKey`, context);
         });
     });
-
     describe("method: getMetaData", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -122,13 +146,14 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.getMetaData(context, "myKey");
+            await enhanced.getMetaData("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["getMetaData"]>
+            >(`${prefix}myKey`, context);
         });
     });
-
     describe("method: add", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -145,17 +170,14 @@ describe("function: withFileStoragePrefix", () => {
             };
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.add(context, "myKey", content);
+            await enhanced.add("myKey", content, context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(
-                context,
-                `${prefix}myKey`,
-                content,
-            );
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["add"]>
+            >(`${prefix}myKey`, content, context);
         });
     });
-
     describe("method: addStream", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -172,29 +194,38 @@ describe("function: withFileStoragePrefix", () => {
                         }),
                 }),
             };
-            await enhanced.addStream(context, "myKey", {
-                data: stream,
-                fileSizeInBytes: null,
-                contentType: "text/plain",
-                contentLanguage: null,
-                contentEncoding: null,
-                contentDisposition: null,
-                cacheControl: null,
-            });
+            await enhanced.addStream(
+                "myKey",
+                {
+                    data: stream,
+                    fileSizeInBytes: null,
+                    contentType: "text/plain",
+                    contentLanguage: null,
+                    contentEncoding: null,
+                    contentDisposition: null,
+                    cacheControl: null,
+                },
+                context,
+            );
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, {
-                data: stream,
-                fileSizeInBytes: null,
-                contentType: "text/plain",
-                contentLanguage: null,
-                contentEncoding: null,
-                contentDisposition: null,
-                cacheControl: null,
-            });
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["addStream"]>
+            >(
+                `${prefix}myKey`,
+                {
+                    data: stream,
+                    fileSizeInBytes: null,
+                    contentType: "text/plain",
+                    contentLanguage: null,
+                    contentEncoding: null,
+                    contentDisposition: null,
+                    cacheControl: null,
+                },
+                context,
+            );
         });
     });
-
     describe("method: update", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -211,17 +242,14 @@ describe("function: withFileStoragePrefix", () => {
             };
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.update(context, "myKey", content);
+            await enhanced.update("myKey", content, context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(
-                context,
-                `${prefix}myKey`,
-                content,
-            );
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["update"]>
+            >(`${prefix}myKey`, content, context);
         });
     });
-
     describe("method: updateStream", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -238,29 +266,38 @@ describe("function: withFileStoragePrefix", () => {
                         }),
                 }),
             };
-            await enhanced.updateStream(context, "myKey", {
-                data: stream2,
-                fileSizeInBytes: null,
-                contentType: "text/plain",
-                contentLanguage: null,
-                contentEncoding: null,
-                contentDisposition: null,
-                cacheControl: null,
-            });
+            await enhanced.updateStream(
+                "myKey",
+                {
+                    data: stream2,
+                    fileSizeInBytes: null,
+                    contentType: "text/plain",
+                    contentLanguage: null,
+                    contentEncoding: null,
+                    contentDisposition: null,
+                    cacheControl: null,
+                },
+                context,
+            );
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, {
-                data: stream2,
-                fileSizeInBytes: null,
-                contentType: "text/plain",
-                contentLanguage: null,
-                contentEncoding: null,
-                contentDisposition: null,
-                cacheControl: null,
-            });
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["updateStream"]>
+            >(
+                `${prefix}myKey`,
+                {
+                    data: stream2,
+                    fileSizeInBytes: null,
+                    contentType: "text/plain",
+                    contentLanguage: null,
+                    contentEncoding: null,
+                    contentDisposition: null,
+                    cacheControl: null,
+                },
+                context,
+            );
         });
     });
-
     describe("method: put", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -277,17 +314,14 @@ describe("function: withFileStoragePrefix", () => {
             };
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.put(context, "myKey", content);
+            await enhanced.put("myKey", content, context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(
-                context,
-                `${prefix}myKey`,
-                content,
-            );
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["put"]>
+            >(`${prefix}myKey`, content, context);
         });
     });
-
     describe("method: putStream", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -304,29 +338,38 @@ describe("function: withFileStoragePrefix", () => {
                         }),
                 }),
             };
-            await enhanced.putStream(context, "myKey", {
-                data: stream3,
-                fileSizeInBytes: null,
-                contentType: "text/plain",
-                contentLanguage: null,
-                contentEncoding: null,
-                contentDisposition: null,
-                cacheControl: null,
-            });
+            await enhanced.putStream(
+                "myKey",
+                {
+                    data: stream3,
+                    fileSizeInBytes: null,
+                    contentType: "text/plain",
+                    contentLanguage: null,
+                    contentEncoding: null,
+                    contentDisposition: null,
+                    cacheControl: null,
+                },
+                context,
+            );
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, {
-                data: stream3,
-                fileSizeInBytes: null,
-                contentType: "text/plain",
-                contentLanguage: null,
-                contentEncoding: null,
-                contentDisposition: null,
-                cacheControl: null,
-            });
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["putStream"]>
+            >(
+                `${prefix}myKey`,
+                {
+                    data: stream3,
+                    fileSizeInBytes: null,
+                    contentType: "text/plain",
+                    contentLanguage: null,
+                    contentEncoding: null,
+                    contentDisposition: null,
+                    cacheControl: null,
+                },
+                context,
+            );
         });
     });
-
     describe("method: copy", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -334,17 +377,14 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.copy(context, "sourceKey", "destKey");
+            await enhanced.copy("sourceKey", "destKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(
-                context,
-                `${prefix}sourceKey`,
-                "destKey",
-            );
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["copy"]>
+            >(`${prefix}sourceKey`, `${prefix}destKey`, context);
         });
     });
-
     describe("method: copyAndReplace", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -352,17 +392,14 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.copyAndReplace(context, "sourceKey", "destKey");
+            await enhanced.copyAndReplace("sourceKey", "destKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(
-                context,
-                `${prefix}sourceKey`,
-                "destKey",
-            );
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["copyAndReplace"]>
+            >(`${prefix}sourceKey`, `${prefix}destKey`, context);
         });
     });
-
     describe("method: move", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -370,17 +407,14 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.move(context, "sourceKey", "destKey");
+            await enhanced.move("sourceKey", "destKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(
-                context,
-                `${prefix}sourceKey`,
-                "destKey",
-            );
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["move"]>
+            >(`${prefix}sourceKey`, `${prefix}destKey`, context);
         });
     });
-
     describe("method: moveAndReplace", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -388,17 +422,14 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.moveAndReplace(context, "sourceKey", "destKey");
+            await enhanced.moveAndReplace("sourceKey", "destKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(
-                context,
-                `${prefix}sourceKey`,
-                "destKey",
-            );
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["moveAndReplace"]>
+            >(`${prefix}sourceKey`, `${prefix}destKey`, context);
         });
     });
-
     describe("method: removeMany", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -406,16 +437,14 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.removeMany(context, ["key1", "key2"]);
+            await enhanced.removeMany(["key1", "key2"], context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, [
-                `${prefix}key1`,
-                `${prefix}key2`,
-            ]);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["removeMany"]>
+            >([`${prefix}key1`, `${prefix}key2`], context);
         });
     });
-
     describe("method: removeByPrefix", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpFileStorageAdapter();
@@ -423,10 +452,12 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.removeByPrefix(context, "myKey");
+            await enhanced.removeByPrefix("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ISignedFileStorageAdapter["removeByPrefix"]>
+            >(`${prefix}myKey`, context);
         });
     });
 });

--- a/src/file-storage/implementations/plugins/with-file-storage-prefix/with-file-storage-prefix.ts
+++ b/src/file-storage/implementations/plugins/with-file-storage-prefix/with-file-storage-prefix.ts
@@ -29,98 +29,86 @@ export function withFileStoragePrefix(
         return prefix + key;
     }
     return (adapter, enhance) => {
-        enhance(
-            adapter,
-            "getPublicUrl",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
-            },
-        );
+        enhance(adapter, "getPublicUrl", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
+        });
         enhance(
             adapter,
             "getSignedDownloadUrl",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
+            ({ args: [key, ...rest], next }) => {
+                return next([withPrefix(key), ...rest]);
             },
         );
         enhance(
             adapter,
             "getSignedUploadUrl",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
+            ({ args: [key, ...rest], next }) => {
+                return next([withPrefix(key), ...rest]);
             },
         );
-        enhance(adapter, "exists", ({ args: [context, key], next }) => {
-            return next([context, withPrefix(key)]);
+        enhance(adapter, "exists", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
         });
-        enhance(adapter, "getStream", ({ args: [context, key], next }) => {
-            return next([context, withPrefix(key)]);
+        enhance(adapter, "getStream", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
         });
-        enhance(adapter, "getBytes", ({ args: [context, key], next }) => {
-            return next([context, withPrefix(key)]);
+        enhance(adapter, "getBytes", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
         });
-        enhance(adapter, "getMetaData", ({ args: [context, key], next }) => {
-            return next([context, withPrefix(key)]);
+        enhance(adapter, "getMetaData", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
         });
-        enhance(adapter, "add", ({ args: [context, key, ...rest], next }) => {
-            return next([context, withPrefix(key), ...rest]);
+        enhance(adapter, "add", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
+        });
+        enhance(adapter, "addStream", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
+        });
+        enhance(adapter, "update", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
+        });
+        enhance(adapter, "updateStream", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
+        });
+        enhance(adapter, "put", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
+        });
+        enhance(adapter, "putStream", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
         });
         enhance(
             adapter,
-            "addStream",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
+            "copy",
+            ({ args: [srcKey, destKey, ...rest], next }) => {
+                return next([withPrefix(srcKey), withPrefix(destKey), ...rest]);
             },
         );
-        enhance(
-            adapter,
-            "update",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
-            },
-        );
-        enhance(
-            adapter,
-            "updateStream",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
-            },
-        );
-        enhance(adapter, "put", ({ args: [context, key, ...rest], next }) => {
-            return next([context, withPrefix(key), ...rest]);
-        });
-        enhance(
-            adapter,
-            "putStream",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
-            },
-        );
-        enhance(adapter, "copy", ({ args: [context, key, ...rest], next }) => {
-            return next([context, withPrefix(key), ...rest]);
-        });
         enhance(
             adapter,
             "copyAndReplace",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
+            ({ args: [srcKey, destKey, ...rest], next }) => {
+                return next([withPrefix(srcKey), withPrefix(destKey), ...rest]);
             },
         );
-        enhance(adapter, "move", ({ args: [context, key, ...rest], next }) => {
-            return next([context, withPrefix(key), ...rest]);
-        });
+        enhance(
+            adapter,
+            "move",
+            ({ args: [srcKey, destKey, ...rest], next }) => {
+                return next([withPrefix(srcKey), withPrefix(destKey), ...rest]);
+            },
+        );
         enhance(
             adapter,
             "moveAndReplace",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
+            ({ args: [srcKey, destKey, ...rest], next }) => {
+                return next([withPrefix(srcKey), withPrefix(destKey), ...rest]);
             },
         );
-        enhance(adapter, "removeMany", ({ args: [context, keys], next }) => {
-            return next([context, keys.map(withPrefix)]);
+        enhance(adapter, "removeMany", ({ args: [keys, ...rest], next }) => {
+            return next([keys.map(withPrefix), ...rest]);
         });
-        enhance(adapter, "removeByPrefix", ({ args: [context, key], next }) => {
-            return next([context, withPrefix(key)]);
+        enhance(adapter, "removeByPrefix", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
         });
     };
 }

--- a/src/file-storage/implementations/test-utilities/file-storage-adapter.test-suite.ts
+++ b/src/file-storage/implementations/test-utilities/file-storage-adapter.test-suite.ts
@@ -80,7 +80,7 @@ export function fileStorageAdapterTestSuite(
             test("Should return false when key does not exists", async () => {
                 const noneExistingKey = "a";
 
-                const result = await adapter.exists(context, noneExistingKey);
+                const result = await adapter.exists(noneExistingKey, context);
 
                 expect(result).toBe(false);
             });
@@ -89,16 +89,20 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
-                const result = await adapter.exists(context, key);
+                await adapter.add(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
+                const result = await adapter.exists(key, context);
 
                 expect(result).toBe(true);
             });
@@ -108,8 +112,8 @@ export function fileStorageAdapterTestSuite(
                 const noneExistingKey = "a";
 
                 const result = await adapter.getStream(
-                    context,
                     noneExistingKey,
+                    context,
                 );
 
                 expect(result).toBeNull();
@@ -119,17 +123,21 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
                 const result = await resolveStream(
-                    await adapter.getStream(context, key),
+                    await adapter.getStream(key, context),
                 );
 
                 expect(result).toEqual(data);
@@ -139,7 +147,7 @@ export function fileStorageAdapterTestSuite(
             test("Should return null when key does not exists", async () => {
                 const noneExistingKey = "a";
 
-                const result = await adapter.getBytes(context, noneExistingKey);
+                const result = await adapter.getBytes(noneExistingKey, context);
 
                 expect(result).toBeNull();
             });
@@ -148,16 +156,20 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
-                const result = await adapter.getBytes(context, key);
+                await adapter.add(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
+                const result = await adapter.getBytes(key, context);
 
                 expect(result).toEqual(data);
             });
@@ -167,8 +179,8 @@ export function fileStorageAdapterTestSuite(
                 const noneExistingKey = "a";
 
                 const result = await adapter.getMetaData(
-                    context,
                     noneExistingKey,
+                    context,
                 );
 
                 expect(result).toBeNull();
@@ -178,16 +190,20 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "text/plain";
-                await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
-                const result = await adapter.getMetaData(context, key);
+                await adapter.add(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
+                const result = await adapter.getMetaData(key, context);
 
                 expect(result).toEqual({
                     etag: expect.any(String) as string,
@@ -201,16 +217,20 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "text/plain";
-                await adapter.put(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
-                const result = await adapter.getMetaData(context, key);
+                await adapter.put(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
+                const result = await adapter.getMetaData(key, context);
 
                 expect(result).toEqual({
                     etag: expect.any(String) as string,
@@ -224,28 +244,36 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "text/plain";
-                await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 const newContentType = "application/octet-stream";
                 const newData = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                await adapter.update(context, key, {
-                    data: newData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType: newContentType,
-                    fileSizeInBytes: newData.length,
-                });
-                const result = await adapter.getMetaData(context, key);
+                await adapter.update(
+                    key,
+                    {
+                        data: newData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType: newContentType,
+                        fileSizeInBytes: newData.length,
+                    },
+                    context,
+                );
+                const result = await adapter.getMetaData(key, context);
 
                 expect(result).toEqual({
                     etag: expect.any(String) as string,
@@ -259,28 +287,36 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "text/plain";
-                await adapter.put(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.put(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 const newContentType = "application/octet-stream";
                 const newData = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                await adapter.update(context, key, {
-                    data: newData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType: newContentType,
-                    fileSizeInBytes: newData.length,
-                });
-                const result = await adapter.getMetaData(context, key);
+                await adapter.update(
+                    key,
+                    {
+                        data: newData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType: newContentType,
+                        fileSizeInBytes: newData.length,
+                    },
+                    context,
+                );
+                const result = await adapter.getMetaData(key, context);
 
                 expect(result).toEqual({
                     etag: expect.any(String) as string,
@@ -294,28 +330,36 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "text/plain";
-                await adapter.put(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.put(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 const newContentType = "application/octet-stream";
                 const newData = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                await adapter.put(context, key, {
-                    data: newData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType: newContentType,
-                    fileSizeInBytes: newData.length,
-                });
-                const result = await adapter.getMetaData(context, key);
+                await adapter.put(
+                    key,
+                    {
+                        data: newData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType: newContentType,
+                        fileSizeInBytes: newData.length,
+                    },
+                    context,
+                );
+                const result = await adapter.getMetaData(key, context);
 
                 expect(result).toEqual({
                     etag: expect.any(String) as string,
@@ -329,20 +373,24 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "text/plain";
-                await adapter.addStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(data);
+                await adapter.addStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(data);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
-                const result = await adapter.getMetaData(context, key);
+                    context,
+                );
+                const result = await adapter.getMetaData(key, context);
 
                 expect(result).toEqual({
                     etag: expect.any(String) as string,
@@ -356,20 +404,24 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "text/plain";
-                await adapter.putStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(data);
+                await adapter.putStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(data);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
-                const result = await adapter.getMetaData(context, key);
+                    context,
+                );
+                const result = await adapter.getMetaData(key, context);
 
                 expect(result).toEqual({
                     etag: expect.any(String) as string,
@@ -383,36 +435,44 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "text/plain";
-                await adapter.addStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(data);
+                await adapter.addStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(data);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                    context,
+                );
 
                 const newContentType = "application/octet-stream";
                 const newData = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                await adapter.updateStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(newData);
+                await adapter.updateStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(newData);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType: newContentType,
+                        fileSizeInBytes: newData.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType: newContentType,
-                    fileSizeInBytes: newData.length,
-                });
-                const result = await adapter.getMetaData(context, key);
+                    context,
+                );
+                const result = await adapter.getMetaData(key, context);
 
                 expect(result).toEqual({
                     etag: expect.any(String) as string,
@@ -426,36 +486,44 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "text/plain";
-                await adapter.putStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(data);
+                await adapter.putStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(data);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                    context,
+                );
 
                 const newContentType = "application/octet-stream";
                 const newData = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                await adapter.updateStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(newData);
+                await adapter.updateStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(newData);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType: newContentType,
+                        fileSizeInBytes: newData.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType: newContentType,
-                    fileSizeInBytes: newData.length,
-                });
-                const result = await adapter.getMetaData(context, key);
+                    context,
+                );
+                const result = await adapter.getMetaData(key, context);
 
                 expect(result).toEqual({
                     etag: expect.any(String) as string,
@@ -469,36 +537,44 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "text/plain";
-                await adapter.putStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(data);
+                await adapter.putStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(data);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                    context,
+                );
 
                 const newContentType = "application/octet-stream";
                 const newData = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                await adapter.putStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(newData);
+                await adapter.putStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(newData);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType: newContentType,
+                        fileSizeInBytes: newData.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType: newContentType,
-                    fileSizeInBytes: newData.length,
-                });
-                const result = await adapter.getMetaData(context, key);
+                    context,
+                );
+                const result = await adapter.getMetaData(key, context);
 
                 expect(result).toEqual({
                     etag: expect.any(String) as string,
@@ -514,15 +590,19 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                const result = await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                const result = await adapter.add(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 expect(result).toBe(true);
             });
@@ -531,28 +611,36 @@ export function fileStorageAdapterTestSuite(
 
                 const contentType = "application/octet-stream";
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 const newData = new Uint8Array(
                     Buffer.from("NEW_CONTENT", "utf8"),
                 );
-                const result = await adapter.add(context, key, {
-                    data: newData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                const result = await adapter.add(
+                    key,
+                    {
+                        data: newData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 expect(result).toBe(false);
             });
@@ -561,17 +649,21 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
-                const result = await adapter.getBytes(context, key);
+                const result = await adapter.getBytes(key, context);
                 expect(result).toEqual(data);
             });
             test("Should not persist data when key exists", async () => {
@@ -579,30 +671,38 @@ export function fileStorageAdapterTestSuite(
 
                 const contentType = "application/octet-stream";
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 const newData = new Uint8Array(
                     Buffer.from("NEW_CONTENT", "utf8"),
                 );
-                await adapter.add(context, key, {
-                    data: newData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    key,
+                    {
+                        data: newData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
-                const result = await adapter.getBytes(context, key);
+                const result = await adapter.getBytes(key, context);
                 expect(result).toEqual(data);
             });
         });
@@ -612,19 +712,23 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                const result = await adapter.addStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(data);
+                const result = await adapter.addStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(data);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                    context,
+                );
 
                 expect(result).toBe(true);
             });
@@ -633,36 +737,44 @@ export function fileStorageAdapterTestSuite(
 
                 const contentType = "application/octet-stream";
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                await adapter.addStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(data);
+                await adapter.addStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(data);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                    context,
+                );
 
                 const newData = new Uint8Array(
                     Buffer.from("NEW_CONTENT", "utf8"),
                 );
-                const result = await adapter.addStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(newData);
+                const result = await adapter.addStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(newData);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                    context,
+                );
 
                 expect(result).toBe(false);
             });
@@ -671,21 +783,25 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.addStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(data);
+                await adapter.addStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(data);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                    context,
+                );
 
-                const result = await adapter.getBytes(context, key);
+                const result = await adapter.getBytes(key, context);
                 expect(result).toEqual(data);
             });
             test("Should not persist data when key exists", async () => {
@@ -693,38 +809,46 @@ export function fileStorageAdapterTestSuite(
 
                 const contentType = "application/octet-stream";
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                await adapter.addStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(data);
+                await adapter.addStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(data);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                    context,
+                );
 
                 const newData = new Uint8Array(
                     Buffer.from("NEW_CONTENT", "utf8"),
                 );
-                await adapter.addStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(newData);
+                await adapter.addStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(newData);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                    context,
+                );
 
-                const result = await adapter.getBytes(context, key);
+                const result = await adapter.getBytes(key, context);
                 expect(result).toEqual(data);
             });
         });
@@ -734,15 +858,19 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                const result = await adapter.update(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                const result = await adapter.update(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 expect(result).toBe(false);
             });
@@ -751,17 +879,21 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.update(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.update(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
-                const result = await adapter.getBytes(context, key);
+                const result = await adapter.getBytes(key, context);
                 expect(result).toBeNull();
             });
             test("Should return true when key exist", async () => {
@@ -769,26 +901,34 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 const newData = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                const result = await adapter.update(context, key, {
-                    data: newData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                const result = await adapter.update(
+                    key,
+                    {
+                        data: newData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 expect(result).toBe(true);
             });
@@ -797,28 +937,36 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 const newData = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                await adapter.update(context, key, {
-                    data: newData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.update(
+                    key,
+                    {
+                        data: newData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
-                const result = await adapter.getBytes(context, key);
+                const result = await adapter.getBytes(key, context);
                 expect(result).toEqual(newData);
             });
         });
@@ -828,19 +976,23 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                const result = await adapter.updateStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(data);
+                const result = await adapter.updateStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(data);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                    context,
+                );
 
                 expect(result).toBe(false);
             });
@@ -849,21 +1001,25 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.updateStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(data);
+                await adapter.updateStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(data);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                    context,
+                );
 
-                const result = await adapter.getBytes(context, key);
+                const result = await adapter.getBytes(key, context);
                 expect(result).toBeNull();
             });
             test("Should return true when key exist", async () => {
@@ -871,30 +1027,38 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 const newData = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                const result = await adapter.updateStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(newData);
+                const result = await adapter.updateStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(newData);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                    context,
+                );
 
                 expect(result).toBe(true);
             });
@@ -903,32 +1067,40 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 const newData = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                await adapter.updateStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(newData);
+                await adapter.updateStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(newData);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                    context,
+                );
 
-                const result = await adapter.getBytes(context, key);
+                const result = await adapter.getBytes(key, context);
                 expect(result).toEqual(newData);
             });
         });
@@ -938,15 +1110,19 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                const result = await adapter.put(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                const result = await adapter.put(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 expect(result).toBe(false);
             });
@@ -955,17 +1131,21 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.put(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.put(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
-                const result = await adapter.getBytes(context, key);
+                const result = await adapter.getBytes(key, context);
                 expect(result).toEqual(data);
             });
             test("Should return true when key exist", async () => {
@@ -973,26 +1153,34 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 const newData = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                const result = await adapter.put(context, key, {
-                    data: newData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                const result = await adapter.put(
+                    key,
+                    {
+                        data: newData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 expect(result).toBe(true);
             });
@@ -1001,28 +1189,36 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 const newData = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                await adapter.put(context, key, {
-                    data: newData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.put(
+                    key,
+                    {
+                        data: newData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
-                const result = await adapter.getBytes(context, key);
+                const result = await adapter.getBytes(key, context);
                 expect(result).toEqual(newData);
             });
         });
@@ -1032,19 +1228,23 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                const result = await adapter.putStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(data);
+                const result = await adapter.putStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(data);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                    context,
+                );
 
                 expect(result).toBe(false);
             });
@@ -1053,21 +1253,25 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.putStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(data);
+                await adapter.putStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(data);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                    context,
+                );
 
-                const result = await adapter.getBytes(context, key);
+                const result = await adapter.getBytes(key, context);
                 expect(result).toEqual(data);
             });
             test("Should return true when key exist", async () => {
@@ -1075,30 +1279,38 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 const newData = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                const result = await adapter.putStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(newData);
+                const result = await adapter.putStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(newData);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                    context,
+                );
 
                 expect(result).toBe(true);
             });
@@ -1107,32 +1319,40 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    key,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 const newData = new Uint8Array(Buffer.from("CONTENT", "utf8"));
-                await adapter.putStream(context, key, {
-                    data: {
-                        async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-                            yield Promise.resolve(newData);
+                await adapter.putStream(
+                    key,
+                    {
+                        data: {
+                            async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+                                yield Promise.resolve(newData);
+                            },
                         },
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
                     },
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                    context,
+                );
 
-                const result = await adapter.getBytes(context, key);
+                const result = await adapter.getBytes(key, context);
                 expect(result).toEqual(newData);
             });
         });
@@ -1142,9 +1362,9 @@ export function fileStorageAdapterTestSuite(
                 const noneExistingDestination = "c";
 
                 const result = await adapter.copy(
-                    context,
                     noneExistingSource,
                     noneExistingDestination,
+                    context,
                 );
 
                 expect(result).toBe(FILE_WRITE_ENUM.NOT_FOUND);
@@ -1155,20 +1375,24 @@ export function fileStorageAdapterTestSuite(
                 const destination = "c";
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, destination, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    destination,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 const result = await adapter.copy(
-                    context,
                     noneExistingSource,
                     destination,
+                    context,
                 );
 
                 expect(result).toBe(FILE_WRITE_ENUM.NOT_FOUND);
@@ -1179,31 +1403,39 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
                 const destinationData = new Uint8Array(
                     Buffer.from("CONTENT", "utf8"),
                 );
-                await adapter.add(context, destination, {
-                    data: destinationData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: destinationData.length,
-                });
+                await adapter.add(
+                    destination,
+                    {
+                        data: destinationData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: destinationData.length,
+                    },
+                    context,
+                );
 
-                const result = await adapter.copy(context, source, destination);
+                const result = await adapter.copy(source, destination, context);
 
                 expect(result).toBe(FILE_WRITE_ENUM.KEY_EXISTS);
             });
@@ -1213,33 +1445,41 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
                 const destinationData = new Uint8Array(
                     Buffer.from("CONTENT", "utf8"),
                 );
-                await adapter.add(context, destination, {
-                    data: destinationData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: destinationData.length,
-                });
+                await adapter.add(
+                    destination,
+                    {
+                        data: destinationData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: destinationData.length,
+                    },
+                    context,
+                );
 
-                await adapter.copy(context, source, destination);
+                await adapter.copy(source, destination, context);
 
-                const result = await adapter.getBytes(context, destination);
+                const result = await adapter.getBytes(destination, context);
                 expect(result).toEqual(destinationData);
             });
             test("Should return FILE_WRITE_ENUM.SUCCESS when source exists and destination does not exists", async () => {
@@ -1248,18 +1488,22 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
-                const result = await adapter.copy(context, source, destination);
+                const result = await adapter.copy(source, destination, context);
 
                 expect(result).toBe(FILE_WRITE_ENUM.SUCCESS);
             });
@@ -1269,20 +1513,24 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
-                await adapter.copy(context, source, destination);
+                await adapter.copy(source, destination, context);
 
-                const result = await adapter.getBytes(context, destination);
+                const result = await adapter.getBytes(destination, context);
                 expect(result).toEqual(sourceData);
             });
         });
@@ -1292,9 +1540,9 @@ export function fileStorageAdapterTestSuite(
                 const noneExistingDestination = "c";
 
                 const result = await adapter.copyAndReplace(
-                    context,
                     noneExistingSource,
                     noneExistingDestination,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -1305,20 +1553,24 @@ export function fileStorageAdapterTestSuite(
                 const destination = "c";
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, destination, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    destination,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 const result = await adapter.copyAndReplace(
-                    context,
                     noneExistingSource,
                     destination,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -1329,34 +1581,42 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
                 const destinationData = new Uint8Array(
                     Buffer.from("CONTENT", "utf8"),
                 );
-                await adapter.add(context, destination, {
-                    data: destinationData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: destinationData.length,
-                });
+                await adapter.add(
+                    destination,
+                    {
+                        data: destinationData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: destinationData.length,
+                    },
+                    context,
+                );
 
                 const result = await adapter.copyAndReplace(
-                    context,
                     source,
                     destination,
+                    context,
                 );
 
                 expect(result).toBe(true);
@@ -1367,33 +1627,41 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
                 const destinationData = new Uint8Array(
                     Buffer.from("CONTENT", "utf8"),
                 );
-                await adapter.add(context, destination, {
-                    data: destinationData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: destinationData.length,
-                });
+                await adapter.add(
+                    destination,
+                    {
+                        data: destinationData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: destinationData.length,
+                    },
+                    context,
+                );
 
-                await adapter.copyAndReplace(context, source, destination);
+                await adapter.copyAndReplace(source, destination, context);
 
-                const result = await adapter.getBytes(context, destination);
+                const result = await adapter.getBytes(destination, context);
                 expect(result).toEqual(sourceData);
             });
             test("Should return true when source exists and destination does not exists", async () => {
@@ -1402,21 +1670,25 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
                 const result = await adapter.copyAndReplace(
-                    context,
                     source,
                     destination,
+                    context,
                 );
 
                 expect(result).toBe(true);
@@ -1427,20 +1699,24 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
-                await adapter.copyAndReplace(context, source, destination);
+                await adapter.copyAndReplace(source, destination, context);
 
-                const result = await adapter.getBytes(context, destination);
+                const result = await adapter.getBytes(destination, context);
                 expect(result).toEqual(sourceData);
             });
         });
@@ -1450,9 +1726,9 @@ export function fileStorageAdapterTestSuite(
                 const noneExistingDestination = "c";
 
                 const result = await adapter.move(
-                    context,
                     noneExistingSource,
                     noneExistingDestination,
+                    context,
                 );
 
                 expect(result).toBe(FILE_WRITE_ENUM.NOT_FOUND);
@@ -1463,20 +1739,24 @@ export function fileStorageAdapterTestSuite(
                 const destination = "c";
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, destination, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    destination,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 const result = await adapter.move(
-                    context,
                     noneExistingSource,
                     destination,
+                    context,
                 );
 
                 expect(result).toBe(FILE_WRITE_ENUM.NOT_FOUND);
@@ -1487,31 +1767,39 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
                 const destinationData = new Uint8Array(
                     Buffer.from("CONTENT", "utf8"),
                 );
-                await adapter.add(context, destination, {
-                    data: destinationData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: destinationData.length,
-                });
+                await adapter.add(
+                    destination,
+                    {
+                        data: destinationData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: destinationData.length,
+                    },
+                    context,
+                );
 
-                const result = await adapter.move(context, source, destination);
+                const result = await adapter.move(source, destination, context);
 
                 expect(result).toBe(FILE_WRITE_ENUM.KEY_EXISTS);
             });
@@ -1521,33 +1809,41 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
                 const destinationData = new Uint8Array(
                     Buffer.from("CONTENT", "utf8"),
                 );
-                await adapter.add(context, destination, {
-                    data: destinationData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: destinationData.length,
-                });
+                await adapter.add(
+                    destination,
+                    {
+                        data: destinationData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: destinationData.length,
+                    },
+                    context,
+                );
 
-                await adapter.move(context, source, destination);
+                await adapter.move(source, destination, context);
 
-                const result = await adapter.getBytes(context, destination);
+                const result = await adapter.getBytes(destination, context);
                 expect(result).toEqual(destinationData);
             });
             test("Should return FILE_WRITE_ENUM.SUCCESS when source exists and destination does not exists", async () => {
@@ -1556,18 +1852,22 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
-                const result = await adapter.move(context, source, destination);
+                const result = await adapter.move(source, destination, context);
 
                 expect(result).toBe(FILE_WRITE_ENUM.SUCCESS);
             });
@@ -1577,20 +1877,24 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
-                await adapter.move(context, source, destination);
+                await adapter.move(source, destination, context);
 
-                const result = await adapter.getBytes(context, destination);
+                const result = await adapter.getBytes(destination, context);
                 expect(result).toEqual(sourceData);
             });
             test("Should remove source when source exists and destination does not exists", async () => {
@@ -1599,20 +1903,24 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
-                await adapter.move(context, source, destination);
+                await adapter.move(source, destination, context);
 
-                const result = await adapter.getBytes(context, source);
+                const result = await adapter.getBytes(source, context);
                 expect(result).toBeNull();
             });
         });
@@ -1622,9 +1930,9 @@ export function fileStorageAdapterTestSuite(
                 const noneExistingDestination = "c";
 
                 const result = await adapter.moveAndReplace(
-                    context,
                     noneExistingSource,
                     noneExistingDestination,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -1635,20 +1943,24 @@ export function fileStorageAdapterTestSuite(
                 const destination = "c";
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, destination, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
+                await adapter.add(
+                    destination,
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
 
                 const result = await adapter.moveAndReplace(
-                    context,
                     noneExistingSource,
                     destination,
+                    context,
                 );
 
                 expect(result).toBe(false);
@@ -1659,34 +1971,42 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
                 const destinationData = new Uint8Array(
                     Buffer.from("CONTENT", "utf8"),
                 );
-                await adapter.add(context, destination, {
-                    data: destinationData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: destinationData.length,
-                });
+                await adapter.add(
+                    destination,
+                    {
+                        data: destinationData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: destinationData.length,
+                    },
+                    context,
+                );
 
                 const result = await adapter.moveAndReplace(
-                    context,
                     source,
                     destination,
+                    context,
                 );
 
                 expect(result).toBe(true);
@@ -1697,33 +2017,41 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
                 const destinationData = new Uint8Array(
                     Buffer.from("CONTENT", "utf8"),
                 );
-                await adapter.add(context, destination, {
-                    data: destinationData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: destinationData.length,
-                });
+                await adapter.add(
+                    destination,
+                    {
+                        data: destinationData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: destinationData.length,
+                    },
+                    context,
+                );
 
-                await adapter.moveAndReplace(context, source, destination);
+                await adapter.moveAndReplace(source, destination, context);
 
-                const result = await adapter.getBytes(context, destination);
+                const result = await adapter.getBytes(destination, context);
                 expect(result).toEqual(sourceData);
             });
             test("Should remove source when source exists and destination exists", async () => {
@@ -1732,33 +2060,41 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
                 const destinationData = new Uint8Array(
                     Buffer.from("CONTENT", "utf8"),
                 );
-                await adapter.add(context, destination, {
-                    data: destinationData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: destinationData.length,
-                });
+                await adapter.add(
+                    destination,
+                    {
+                        data: destinationData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: destinationData.length,
+                    },
+                    context,
+                );
 
-                await adapter.moveAndReplace(context, source, destination);
+                await adapter.moveAndReplace(source, destination, context);
 
-                const result = await adapter.getBytes(context, source);
+                const result = await adapter.getBytes(source, context);
                 expect(result).toBeNull();
             });
             test("Should return true when source exists and destination does not exists", async () => {
@@ -1767,21 +2103,25 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
                 const result = await adapter.moveAndReplace(
-                    context,
                     source,
                     destination,
+                    context,
                 );
 
                 expect(result).toBe(true);
@@ -1792,20 +2132,24 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
-                await adapter.moveAndReplace(context, source, destination);
+                await adapter.moveAndReplace(source, destination, context);
 
-                const result = await adapter.getBytes(context, destination);
+                const result = await adapter.getBytes(destination, context);
                 expect(result).toEqual(sourceData);
             });
             test("Should remove source when source exists and destination does not exists", async () => {
@@ -1814,30 +2158,33 @@ export function fileStorageAdapterTestSuite(
                     Buffer.from("CONTENT", "utf8"),
                 );
                 const contentType = "application/octet-stream";
-                await adapter.add(context, source, {
-                    data: sourceData,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: sourceData.length,
-                });
+                await adapter.add(
+                    source,
+                    {
+                        data: sourceData,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: sourceData.length,
+                    },
+                    context,
+                );
 
                 const destination = "c";
-                await adapter.moveAndReplace(context, source, destination);
+                await adapter.moveAndReplace(source, destination, context);
 
-                const result = await adapter.getBytes(context, source);
+                const result = await adapter.getBytes(source, context);
                 expect(result).toBeNull();
             });
         });
         describe("method: removeMany", () => {
             test("Should return false when all keys does not exists", async () => {
-                const result = await adapter.removeMany(context, [
-                    "a",
-                    "b",
-                    "c",
-                ]);
+                const result = await adapter.removeMany(
+                    ["a", "b", "c"],
+                    context,
+                );
 
                 expect(result).toBe(false);
             });
@@ -1846,65 +2193,80 @@ export function fileStorageAdapterTestSuite(
 
                 const data = new Uint8Array(Buffer.from("CONTENT", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, key, {
-                    data,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data.length,
-                });
-
-                const result = await adapter.removeMany(context, [
+                await adapter.add(
                     key,
-                    "b",
-                    "c",
-                ]);
+                    {
+                        data,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data.length,
+                    },
+                    context,
+                );
+
+                const result = await adapter.removeMany(
+                    [key, "b", "c"],
+                    context,
+                );
 
                 expect(result).toBe(true);
             });
             test("Should persist removal of the keys that exists", async () => {
                 const data1 = new Uint8Array(Buffer.from("CONTENT_A", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, "a", {
-                    data: data1,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data1.length,
-                });
+                await adapter.add(
+                    "a",
+                    {
+                        data: data1,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data1.length,
+                    },
+                    context,
+                );
 
                 const data2 = new Uint8Array(Buffer.from("CONTENT_B", "utf8"));
-                await adapter.add(context, "b", {
-                    data: data2,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data2.length,
-                });
+                await adapter.add(
+                    "b",
+                    {
+                        data: data2,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data2.length,
+                    },
+                    context,
+                );
 
                 const data3 = new Uint8Array(Buffer.from("CONTENT_C", "utf8"));
-                await adapter.add(context, "c", {
-                    data: data3,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: data3.length,
-                });
+                await adapter.add(
+                    "c",
+                    {
+                        data: data3,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: data3.length,
+                    },
+                    context,
+                );
 
-                await adapter.removeMany(context, ["a", "b"]);
+                await adapter.removeMany(["a", "b"], context);
 
                 const result = [
-                    await adapter.getBytes(context, "a"),
-                    await adapter.getBytes(context, "b"),
-                    await adapter.getBytes(context, "c"),
+                    await adapter.getBytes("a", context),
+                    await adapter.getBytes("b", context),
+                    await adapter.getBytes("c", context),
                 ];
                 expect(result).toEqual([null, null, data3]);
             });
@@ -1913,44 +2275,56 @@ export function fileStorageAdapterTestSuite(
             test(`Should remove all keys that start with prefix "file-storage"`, async () => {
                 const dataA = new Uint8Array(Buffer.from("CONTENT_A", "utf8"));
                 const contentType = "application/octet-stream";
-                await adapter.add(context, "cache/a", {
-                    data: dataA,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: dataA.length,
-                });
+                await adapter.add(
+                    "cache/a",
+                    {
+                        data: dataA,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: dataA.length,
+                    },
+                    context,
+                );
 
                 const dataB = new Uint8Array(Buffer.from("CONTENT_B", "utf8"));
-                await adapter.add(context, "cache/b", {
-                    data: dataB,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: dataB.length,
-                });
+                await adapter.add(
+                    "cache/b",
+                    {
+                        data: dataB,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: dataB.length,
+                    },
+                    context,
+                );
 
                 const dataC = new Uint8Array(Buffer.from("CONTENT_C", "utf8"));
-                await adapter.add(context, "c", {
-                    data: dataC,
-                    cacheControl: null,
-                    contentDisposition: null,
-                    contentEncoding: null,
-                    contentLanguage: null,
-                    contentType,
-                    fileSizeInBytes: dataC.length,
-                });
+                await adapter.add(
+                    "c",
+                    {
+                        data: dataC,
+                        cacheControl: null,
+                        contentDisposition: null,
+                        contentEncoding: null,
+                        contentLanguage: null,
+                        contentType,
+                        fileSizeInBytes: dataC.length,
+                    },
+                    context,
+                );
 
-                await adapter.removeByPrefix(context, "cache");
+                await adapter.removeByPrefix("cache", context);
 
                 const result = [
-                    await adapter.getBytes(context, "cache/a"),
-                    await adapter.getBytes(context, "cache/b"),
-                    await adapter.getBytes(context, "c"),
+                    await adapter.getBytes("cache/a", context),
+                    await adapter.getBytes("cache/b", context),
+                    await adapter.getBytes("c", context),
                 ];
                 expect(result).toEqual([null, null, dataC]);
             });


### PR DESCRIPTION
- **refactor(file-storage): reorder parameters to put context last in contract methods**
- **refactor(file-storage): update test suite to match new parameter order**
- **refactor(file-storage): reorder parameters in NoOpFileStorageAdapter**
- **refactor(file-storage): reorder parameters in MemoryFileStorageAdapter and test**
- **refactor(file-storage): reorder parameters in FsFileStorageAdapter and test**
- **refactor(file-storage): reorder parameters in S3FileStorageAdapter and test**
- **refactor(file-storage): reorder parameters and add context to error creation**
- **refactor(file-storage): reorder parameters in signed storage and tests**
- **refactor(file-storage): reorder parameters in lock and prefix plugins**
