### PR TITLE
enhacement/circuit breaker adapter update

### DIFF
--- a/src/circuit-breaker/contracts/circuit-breaker-adapter.contract.ts
+++ b/src/circuit-breaker/contracts/circuit-breaker-adapter.contract.ts
@@ -38,27 +38,29 @@ export type ICircuitBreakerAdapter = {
     /**
      * Retrieves the current operational state of a circuit breaker.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the circuit breaker instance
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise resolving to one of: CLOSED (normal operation), OPEN (rejecting calls),
      *          HALF_OPEN (testing recovery), or ISOLATED (manually blocked)
      */
     getState(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<CircuitBreakerState>;
 
     /**
      * Evaluates the circuit breaker's policy and transitions to a new state if necessary.
      * Consults the policy to determine if enough time has passed or metrics have changed to warrant a state change.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the circuit breaker instance
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise resolving to the transition details (from and to states)
      */
     updateState(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<CircuitBreakerStateTransition>;
 
     /**
@@ -66,39 +68,43 @@ export type ICircuitBreakerAdapter = {
      * In isolated state, all calls are rejected regardless of the underlying service status.
      * Must be manually reset to restore normal operation.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the circuit breaker instance
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise that resolves when isolation is applied
      */
-    isolate(context: IReadableContext, key: string): Promise<void>;
+    isolate(key: string, context: IReadableContext): Promise<void>;
 
     /**
      * Records a failure event in the circuit breaker's metrics.
      * Used by the policy to accumulate failure counts and determine if the circuit should open.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the circuit breaker instance
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise that resolves when the failure is recorded
      */
-    trackFailure(context: IReadableContext, key: string): Promise<void>;
+    trackFailure(key: string, context: IReadableContext): Promise<void>;
 
     /**
      * Records a successful call in the circuit breaker's metrics.
      * Used by the policy to reset failure counts or validate recovery during HALF_OPEN state.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the circuit breaker instance
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise that resolves when the success is recorded
      */
-    trackSuccess(context: IReadableContext, key: string): Promise<void>;
+    trackSuccess(key: string, context: IReadableContext): Promise<void>;
 
     /**
      * Resets the circuit breaker to its initial state, discarding all accumulated metrics and history.
      * Useful for recovery from stuck states or when the underlying service has been repaired.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the circuit breaker instance
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise that resolves when the reset is complete
      */
-    reset(context: IReadableContext, key: string): Promise<void>;
+    reset(key: string, context: IReadableContext): Promise<void>;
 };

--- a/src/circuit-breaker/contracts/circuit-breaker-storage-adapter.contract.ts
+++ b/src/circuit-breaker/contracts/circuit-breaker-storage-adapter.contract.ts
@@ -18,21 +18,23 @@ export type ICircuitBreakerStorageAdapterTransaction<TType = unknown> = {
      * Creates a new circuit breaker record if it doesn't exist, or updates the existing one.
      * Used to persist the current state and metrics of a circuit breaker.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the circuit breaker instance
      * @param state - The serialized circuit breaker state to persist
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise that resolves when the upsert operation completes
      */
-    upsert(context: IReadableContext, key: string, state: TType): Promise<void>;
+    upsert(key: string, state: TType, context: IReadableContext): Promise<void>;
 
     /**
      * Retrieves the persisted circuit breaker state for a given key.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the circuit breaker instance
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise resolving to the circuit breaker state if found, otherwise null
      */
-    find(context: IReadableContext, key: string): Promise<TType | null>;
+    find(key: string, context: IReadableContext): Promise<TType | null>;
 };
 
 /**
@@ -51,35 +53,38 @@ export type ICircuitBreakerStorageAdapter<TType = unknown> = {
      * Used to coordinate state updates with policy evaluations in a consistent manner.
      *
      * @template TValue - The return type of the transaction function
-     * @param context - Readable execution context for the operation
      * @param fn - Function to execute within the transaction, receives transaction object
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise resolving to the return value of the transaction function
      */
     transaction<TValue>(
-        context: IReadableContext,
         fn: InvokableFn<
             [transaction: ICircuitBreakerStorageAdapterTransaction<TType>],
             Promise<TValue>
         >,
+        context: IReadableContext,
     ): Promise<TValue>;
 
     /**
      * Retrieves the persisted circuit breaker state for a given key.
      * Used to fetch the current state without opening a transaction.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the circuit breaker instance
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise resolving to the circuit breaker state if found, otherwise null
      */
-    find(context: IReadableContext, key: string): Promise<TType | null>;
+    find(key: string, context: IReadableContext): Promise<TType | null>;
 
     /**
      * Removes a circuit breaker record from persistent storage.
      * Used for cleanup when circuit breaker instances are no longer needed.
      *
-     * @param context - Readable execution context for the operation
      * @param key - Unique identifier for the circuit breaker instance to remove
+     * @param context - Readable execution context for the operation
+     *
      * @returns Promise that resolves when the removal is complete
      */
-    remove(context: IReadableContext, key: string): Promise<void>;
+    remove(key: string, context: IReadableContext): Promise<void>;
 };

--- a/src/circuit-breaker/implementations/adapters/database-circuit-breaker-adapter/circuit-breaker-storage.ts
+++ b/src/circuit-breaker/implementations/adapters/database-circuit-breaker-adapter/circuit-breaker-storage.ts
@@ -25,40 +25,40 @@ export class CircuitBreakerStorage<TMetrics = unknown> {
     ) {}
 
     async atomicUpdate(
-        context: IReadableContext,
         key: string,
         update: DatabaseCircuitBreakerUpdateStateFn<TMetrics>,
+        context: IReadableContext,
     ): Promise<CircuitBreakerStateTransition> {
         const currentDate = new Date();
-        return await this.adapter.transaction(context, async (trx) => {
+        return await this.adapter.transaction(async (trx) => {
             const currentState =
-                (await trx.find(context, key)) ??
+                (await trx.find(key, context)) ??
                 this.circuitBreakerPolicy.initialState();
 
             const newState = update(currentState, currentDate);
 
             if (!this.circuitBreakerPolicy.isEqual(currentState, newState)) {
-                await trx.upsert(context, key, newState);
+                await trx.upsert(key, newState, context);
             }
 
             return {
                 from: currentState.type,
                 to: newState.type,
             };
-        });
+        }, context);
     }
 
     async find(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<AllCircuitBreakerState<TMetrics>> {
         return (
-            (await this.adapter.find(context, key)) ??
+            (await this.adapter.find(key, context)) ??
             this.circuitBreakerPolicy.initialState()
         );
     }
 
-    async remove(context: IReadableContext, key: string): Promise<void> {
-        await this.adapter.remove(context, key);
+    async remove(key: string, context: IReadableContext): Promise<void> {
+        await this.adapter.remove(key, context);
     }
 }

--- a/src/circuit-breaker/implementations/adapters/database-circuit-breaker-adapter/database-circuit-breaker-adapter.ts
+++ b/src/circuit-breaker/implementations/adapters/database-circuit-breaker-adapter/database-circuit-breaker-adapter.ts
@@ -103,49 +103,49 @@ export class DatabaseCircuitBreakerAdapter<
     }
 
     async getState(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<CircuitBreakerState> {
-        const state = await this.circuitBreakerStorage.find(context, key);
+        const state = await this.circuitBreakerStorage.find(key, context);
         return state.type;
     }
 
     async updateState(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<CircuitBreakerStateTransition> {
         return await this.circuitBreakerStorage.atomicUpdate(
-            context,
             key,
             this.circuitBreakerStateManager.updateState,
+            context,
         );
     }
 
-    async trackFailure(context: IReadableContext, key: string): Promise<void> {
+    async trackFailure(key: string, context: IReadableContext): Promise<void> {
         await this.circuitBreakerStorage.atomicUpdate(
-            context,
             key,
             this.circuitBreakerStateManager.trackFailure,
+            context,
         );
     }
 
-    async trackSuccess(context: IReadableContext, key: string): Promise<void> {
+    async trackSuccess(key: string, context: IReadableContext): Promise<void> {
         await this.circuitBreakerStorage.atomicUpdate(
-            context,
             key,
             this.circuitBreakerStateManager.trackSuccess,
+            context,
         );
     }
 
-    async reset(context: IReadableContext, key: string): Promise<void> {
-        await this.circuitBreakerStorage.remove(context, key);
+    async reset(key: string, context: IReadableContext): Promise<void> {
+        await this.circuitBreakerStorage.remove(key, context);
     }
 
-    async isolate(context: IReadableContext, key: string): Promise<void> {
+    async isolate(key: string, context: IReadableContext): Promise<void> {
         await this.circuitBreakerStorage.atomicUpdate(
-            context,
             key,
             this.circuitBreakerStateManager.isolate,
+            context,
         );
     }
 }

--- a/src/circuit-breaker/implementations/adapters/kysely-circuit-breaker-storage-adapter/kysely-circuit-breaker-storage-adapter.ts
+++ b/src/circuit-breaker/implementations/adapters/kysely-circuit-breaker-storage-adapter/kysely-circuit-breaker-storage-adapter.ts
@@ -100,9 +100,9 @@ class KyselyCircuitBreakerStorageAdapterTransaction<
     }
 
     async upsert(
-        _context: IReadableContext,
         key: string,
         state: TType,
+        _context: IReadableContext,
     ): Promise<void> {
         const serializedState = this.serde.serialize(state);
         await this.kysely
@@ -126,7 +126,7 @@ class KyselyCircuitBreakerStorageAdapterTransaction<
             .execute();
     }
 
-    async find(_context: IReadableContext, key: string): Promise<TType | null> {
+    async find(key: string, _context: IReadableContext): Promise<TType | null> {
         return find(key, {
             serde: this.serde,
             kysely: this.kysely,
@@ -230,11 +230,11 @@ export class KyselyCircuitBreakerStorageAdapter<TType>
     }
 
     async transaction<TValue>(
-        _context: IReadableContext,
         fn: InvokableFn<
             [transaction: ICircuitBreakerStorageAdapterTransaction],
             Promise<TValue>
         >,
+        _context: IReadableContext,
     ): Promise<TValue> {
         return await this._transaction(async (trx) => {
             return await fn(
@@ -246,14 +246,14 @@ export class KyselyCircuitBreakerStorageAdapter<TType>
         });
     }
 
-    async find(_context: IReadableContext, key: string): Promise<TType | null> {
+    async find(key: string, _context: IReadableContext): Promise<TType | null> {
         return find(key, {
             serde: this.serde,
             kysely: this.kysely,
         });
     }
 
-    async remove(_context: IReadableContext, key: string): Promise<void> {
+    async remove(key: string, _context: IReadableContext): Promise<void> {
         await this.kysely
             .deleteFrom("circuitBreaker")
             .where("circuitBreaker.key", "=", key)

--- a/src/circuit-breaker/implementations/adapters/memory-circuit-breaker-storage-adapter/memory-circuit-breaker-storage-adapter.test.ts
+++ b/src/circuit-breaker/implementations/adapters/memory-circuit-breaker-storage-adapter/memory-circuit-breaker-storage-adapter.test.ts
@@ -13,10 +13,10 @@ describe("class: MemoryCircuitBreakerStorageAdapter", () => {
             );
             const map = new Map<string, unknown>();
             const adapter = new MemoryCircuitBreakerStorageAdapter(map);
-            await adapter.transaction(noOpContext, async (trx) => {
-                await trx.upsert(noOpContext, "a", "1");
-                await trx.upsert(noOpContext, "b", "1");
-            });
+            await adapter.transaction(async (trx) => {
+                await trx.upsert("a", "1", noOpContext);
+                await trx.upsert("b", "1", noOpContext);
+            }, noOpContext);
             await adapter.deInit();
 
             expect(map.size).toBe(0);

--- a/src/circuit-breaker/implementations/adapters/memory-circuit-breaker-storage-adapter/memory-circuit-breaker-storage-adapter.ts
+++ b/src/circuit-breaker/implementations/adapters/memory-circuit-breaker-storage-adapter/memory-circuit-breaker-storage-adapter.ts
@@ -47,32 +47,32 @@ export class MemoryCircuitBreakerStorageAdapter<TType = unknown>
     }
 
     private upsert(
-        _context: IReadableContext,
         key: string,
         state: TType,
+        _context: IReadableContext,
     ): Promise<void> {
         this.map.set(key, state);
         return Promise.resolve();
     }
 
     async transaction<TValue>(
-        _context: IReadableContext,
         fn: InvokableFn<
             [transaction: ICircuitBreakerStorageAdapterTransaction<TType>],
             Promise<TValue>
         >,
+        _context: IReadableContext,
     ): Promise<TValue> {
         return await fn({
-            upsert: (context, key, state) => this.upsert(context, key, state),
-            find: (context, key) => this.find(context, key),
+            upsert: (key, state, context) => this.upsert(key, state, context),
+            find: (key, context) => this.find(key, context),
         });
     }
 
-    async find(_context: IReadableContext, key: string): Promise<TType | null> {
+    async find(key: string, _context: IReadableContext): Promise<TType | null> {
         return Promise.resolve(this.map.get(key) ?? null);
     }
 
-    async remove(_context: IReadableContext, key: string): Promise<void> {
+    async remove(key: string, _context: IReadableContext): Promise<void> {
         this.map.delete(key);
         return Promise.resolve();
     }

--- a/src/circuit-breaker/implementations/adapters/mongodb-circuit-breaker-storage-adapter/mongodb-circuit-breaker-storage-adapter.ts
+++ b/src/circuit-breaker/implementations/adapters/mongodb-circuit-breaker-storage-adapter/mongodb-circuit-breaker-storage-adapter.ts
@@ -166,9 +166,9 @@ export class MongodbCircuitBreakerStorageAdapter<TType = unknown>
     }
 
     private async upsert<TType_>(
-        _context: IReadableContext,
         key: string,
         state: TType_,
+        _context: IReadableContext,
         session?: ClientSession,
     ): Promise<void> {
         await this.collection.updateOne(
@@ -201,24 +201,24 @@ export class MongodbCircuitBreakerStorageAdapter<TType = unknown>
     }
 
     async transaction<TValue>(
-        _context: IReadableContext,
         fn: InvokableFn<
             [transaction: ICircuitBreakerStorageAdapterTransaction<TType>],
             Promise<TValue>
         >,
+        _context: IReadableContext,
     ): Promise<TValue> {
         return await this._transaction(async (session) => {
             return await fn({
-                upsert: (context, key, state) =>
-                    this.upsert(context, key, state, session),
-                find: (context, key) => this.find(context, key, session),
+                upsert: (key, state, context) =>
+                    this.upsert(key, state, context, session),
+                find: (key, context) => this.find(key, context, session),
             });
         });
     }
 
     async find(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
         session?: ClientSession,
     ): Promise<TType | null> {
         const doc = await this.collection.findOne(
@@ -234,8 +234,8 @@ export class MongodbCircuitBreakerStorageAdapter<TType = unknown>
     }
 
     async remove(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
         session?: ClientSession,
     ): Promise<void> {
         await this.collection.deleteOne(

--- a/src/circuit-breaker/implementations/adapters/no-op-circuit-breaker-adapter/no-op-circuit-breaker-adapter.ts
+++ b/src/circuit-breaker/implementations/adapters/no-op-circuit-breaker-adapter/no-op-circuit-breaker-adapter.ts
@@ -20,15 +20,15 @@ import { type IReadableContext } from "@/execution-context/contracts/_module.js"
  */
 export class NoOpCircuitBreakerAdapter implements ICircuitBreakerAdapter {
     getState(
-        _context: IReadableContext,
         _key: string,
+        _context: IReadableContext,
     ): Promise<CircuitBreakerState> {
         return Promise.resolve(CIRCUIT_BREAKER_STATE.CLOSED);
     }
 
     updateState(
-        _context: IReadableContext,
         _key: string,
+        _context: IReadableContext,
     ): Promise<CircuitBreakerStateTransition> {
         return Promise.resolve({
             from: CIRCUIT_BREAKER_STATE.CLOSED,
@@ -36,19 +36,19 @@ export class NoOpCircuitBreakerAdapter implements ICircuitBreakerAdapter {
         } satisfies CircuitBreakerStateTransition);
     }
 
-    isolate(_context: IReadableContext, _key: string): Promise<void> {
+    isolate(_key: string, _context: IReadableContext): Promise<void> {
         return Promise.resolve();
     }
 
-    trackFailure(_context: IReadableContext, _key: string): Promise<void> {
+    trackFailure(_key: string, _context: IReadableContext): Promise<void> {
         return Promise.resolve();
     }
 
-    trackSuccess(_context: IReadableContext, _key: string): Promise<void> {
+    trackSuccess(_key: string, _context: IReadableContext): Promise<void> {
         return Promise.resolve();
     }
 
-    reset(_context: IReadableContext, _key: string): Promise<void> {
+    reset(_key: string, _context: IReadableContext): Promise<void> {
         return Promise.resolve();
     }
 }

--- a/src/circuit-breaker/implementations/adapters/no-op-circuit-breaker-storage-adapter/no-op-circuit-breaker-storage-adapter.ts
+++ b/src/circuit-breaker/implementations/adapters/no-op-circuit-breaker-storage-adapter/no-op-circuit-breaker-storage-adapter.ts
@@ -21,32 +21,32 @@ export class NoOpCircuitBreakerStorageAdapter<
     TType,
 > implements ICircuitBreakerStorageAdapter<TType> {
     transaction<TValue>(
-        _context: IReadableContext,
         fn: InvokableFn<
             [transaction: ICircuitBreakerStorageAdapterTransaction<TType>],
             Promise<TValue>
         >,
+        _context: IReadableContext,
     ): Promise<TValue> {
         return Promise.resolve(
             fn({
                 find: (
-                    _nestedContext: IReadableContext,
                     _key: string,
+                    _nestedContext: IReadableContext,
                 ): Promise<TType | null> => Promise.resolve(null),
                 upsert: (
-                    _nestedContext: IReadableContext,
                     _key: string,
                     _state: TType,
+                    _nestedContext: IReadableContext,
                 ) => Promise.resolve(),
             }),
         );
     }
 
-    find(_context: IReadableContext, _key: string): Promise<TType | null> {
+    find(_key: string, _context: IReadableContext): Promise<TType | null> {
         return Promise.resolve(null);
     }
 
-    remove(_context: IReadableContext, _key: string): Promise<void> {
+    remove(_key: string, _context: IReadableContext): Promise<void> {
         return Promise.resolve();
     }
 }

--- a/src/circuit-breaker/implementations/adapters/redis-circuit-breaker-adapter/redis-circuit-breaker-adapter.ts
+++ b/src/circuit-breaker/implementations/adapters/redis-circuit-breaker-adapter/redis-circuit-breaker-adapter.ts
@@ -204,8 +204,8 @@ export class RedisCircuitBreakerAdapter implements ICircuitBreakerAdapter {
     }
 
     async getState(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<CircuitBreakerState> {
         const value = await this.database.get(key);
         if (value === null) {
@@ -216,8 +216,8 @@ export class RedisCircuitBreakerAdapter implements ICircuitBreakerAdapter {
     }
 
     async updateState(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<CircuitBreakerStateTransition> {
         const value = await this.database.daiso_circuit_breaker_update_state(
             key,
@@ -230,7 +230,7 @@ export class RedisCircuitBreakerAdapter implements ICircuitBreakerAdapter {
         return JSON.parse(value) as CircuitBreakerStateTransition;
     }
 
-    async isolate(_context: IReadableContext, key: string): Promise<void> {
+    async isolate(key: string, _context: IReadableContext): Promise<void> {
         await this.database.set(
             key,
             JSON.stringify({
@@ -239,7 +239,7 @@ export class RedisCircuitBreakerAdapter implements ICircuitBreakerAdapter {
         );
     }
 
-    async trackFailure(_context: IReadableContext, key: string): Promise<void> {
+    async trackFailure(key: string, _context: IReadableContext): Promise<void> {
         await this.database.daiso_circuit_breaker_track_failure(
             key,
             JSON.stringify(serializeBackoffSettingsEnum(this.backoff)),
@@ -250,7 +250,7 @@ export class RedisCircuitBreakerAdapter implements ICircuitBreakerAdapter {
         );
     }
 
-    async trackSuccess(_context: IReadableContext, key: string): Promise<void> {
+    async trackSuccess(key: string, _context: IReadableContext): Promise<void> {
         await this.database.daiso_circuit_breaker_track_success(
             key,
             JSON.stringify(serializeBackoffSettingsEnum(this.backoff)),
@@ -261,7 +261,7 @@ export class RedisCircuitBreakerAdapter implements ICircuitBreakerAdapter {
         );
     }
 
-    async reset(_context: IReadableContext, key: string): Promise<void> {
+    async reset(key: string, _context: IReadableContext): Promise<void> {
         await this.database.del(key);
     }
 }

--- a/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker-factory.test.ts
+++ b/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker-factory.test.ts
@@ -26,27 +26,27 @@ import { delay } from "@/utilities/_module.js";
 describe("class: CircuitBreakerFactory", () => {
     const adapter: ICircuitBreakerAdapter = {
         getState(
-            _context: IReadableContext,
             _key: string,
+            _context: IReadableContext,
         ): Promise<CircuitBreakerState> {
             throw new UnexpectedErrorA("Function not implemented.");
         },
         updateState(
-            _context: IReadableContext,
             _key: string,
+            _context: IReadableContext,
         ): Promise<CircuitBreakerStateTransition> {
             throw new UnexpectedErrorA("Function not implemented.");
         },
-        isolate(_context: IReadableContext, _key: string): Promise<void> {
+        isolate(_key: string, _context: IReadableContext): Promise<void> {
             throw new UnexpectedErrorA("Function not implemented.");
         },
-        trackFailure(_context: IReadableContext, _key: string): Promise<void> {
+        trackFailure(_key: string, _context: IReadableContext): Promise<void> {
             throw new UnexpectedErrorA("Function not implemented.");
         },
-        trackSuccess(_context: IReadableContext, _key: string): Promise<void> {
+        trackSuccess(_key: string, _context: IReadableContext): Promise<void> {
             throw new UnexpectedErrorA("Function not implemented.");
         },
-        reset(_context: IReadableContext, _key: string): Promise<void> {
+        reset(_key: string, _context: IReadableContext): Promise<void> {
             throw new UnexpectedErrorA("Function not implemented.");
         },
     };
@@ -557,34 +557,34 @@ describe("class: CircuitBreakerFactory", () => {
                 ) {}
 
                 getState(
-                    context: IReadableContext,
                     key: string,
+                    context: IReadableContext,
                 ): Promise<CircuitBreakerState> {
-                    return this.adapter_.getState(context, key);
+                    return this.adapter_.getState(key, context);
                 }
                 updateState(
-                    context: IReadableContext,
                     key: string,
+                    context: IReadableContext,
                 ): Promise<CircuitBreakerStateTransition> {
-                    return this.adapter_.updateState(context, key);
+                    return this.adapter_.updateState(key, context);
                 }
-                isolate(context: IReadableContext, key: string): Promise<void> {
-                    return this.adapter_.isolate(context, key);
+                isolate(key: string, context: IReadableContext): Promise<void> {
+                    return this.adapter_.isolate(key, context);
                 }
                 trackFailure(
-                    context: IReadableContext,
                     key: string,
+                    context: IReadableContext,
                 ): Promise<void> {
-                    return this.adapter_.trackFailure(context, key);
+                    return this.adapter_.trackFailure(key, context);
                 }
                 trackSuccess(
-                    context: IReadableContext,
                     key: string,
+                    context: IReadableContext,
                 ): Promise<void> {
-                    return this.adapter_.trackSuccess(context, key);
+                    return this.adapter_.trackSuccess(key, context);
                 }
-                reset(context: IReadableContext, key: string): Promise<void> {
-                    return this.adapter_.reset(context, key);
+                reset(key: string, context: IReadableContext): Promise<void> {
+                    return this.adapter_.reset(key, context);
                 }
             }
 

--- a/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker.ts
+++ b/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker.ts
@@ -110,29 +110,29 @@ export class CircuitBreaker implements ICircuitBreaker {
     }
 
     async getState(): Promise<CircuitBreakerState> {
-        return this.adapter.getState(this.context, this._key.toString());
+        return this.adapter.getState(this._key.toString(), this.context);
     }
 
     private async trackFailure(): Promise<void> {
         if (this.enableAsyncTracking) {
             callInvokable(
                 this.waitUntil,
-                this.adapter.trackFailure(this.context, this._key.toString()),
+                this.adapter.trackFailure(this._key.toString(), this.context),
             );
             return;
         }
-        await this.adapter.trackFailure(this.context, this._key.toString());
+        await this.adapter.trackFailure(this._key.toString(), this.context);
     }
 
     private async trackSuccess(): Promise<void> {
         if (this.enableAsyncTracking) {
             callInvokable(
                 this.waitUntil,
-                this.adapter.trackSuccess(this.context, this._key.toString()),
+                this.adapter.trackSuccess(this._key.toString(), this.context),
             );
             return;
         }
-        await this.adapter.trackSuccess(this.context, this._key.toString());
+        await this.adapter.trackSuccess(this._key.toString(), this.context);
     }
 
     private async trackErrorWrapper<TValue = void>(
@@ -191,8 +191,8 @@ export class CircuitBreaker implements ICircuitBreaker {
 
     private async guard(): Promise<void> {
         const transition = await this.adapter.updateState(
-            this.context,
             this._key.toString(),
+            this.context,
         );
 
         const isInOpenState = transition.to === CIRCUIT_BREAKER_STATE.OPEN;
@@ -219,10 +219,10 @@ export class CircuitBreaker implements ICircuitBreaker {
     }
 
     async reset(): Promise<void> {
-        await this.adapter.reset(this.context, this._key.toString());
+        await this.adapter.reset(this._key.toString(), this.context);
     }
 
     async isolate(): Promise<void> {
-        await this.adapter.isolate(this.context, this._key.toString());
+        await this.adapter.isolate(this._key.toString(), this.context);
     }
 }

--- a/src/circuit-breaker/implementations/plugins/with-circuit-breaker-prefix/with-circuit-breaker-prefix.test.ts
+++ b/src/circuit-breaker/implementations/plugins/with-circuit-breaker-prefix/with-circuit-breaker-prefix.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
+import { type ICircuitBreakerAdapter } from "@/circuit-breaker/contracts/_module.js";
 import { NoOpCircuitBreakerAdapter } from "@/circuit-breaker/implementations/adapters/_module.js";
 import { withCircuitBreakerPrefix } from "@/circuit-breaker/implementations/plugins/with-circuit-breaker-prefix/with-circuit-breaker-prefix.js";
 import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
@@ -26,13 +27,14 @@ describe("function: withCircuitBreakerPrefix", () => {
                 withCircuitBreakerPrefix(prefix),
             );
 
-            await enhanced.getState(context, "myKey");
+            await enhanced.getState("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ICircuitBreakerAdapter["getState"]>
+            >(`${prefix}myKey`, context);
         });
     });
-
     describe("method: isolate", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpCircuitBreakerAdapter();
@@ -43,13 +45,14 @@ describe("function: withCircuitBreakerPrefix", () => {
                 withCircuitBreakerPrefix(prefix),
             );
 
-            await enhanced.isolate(context, "myKey");
+            await enhanced.isolate("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ICircuitBreakerAdapter["isolate"]>
+            >(`${prefix}myKey`, context);
         });
     });
-
     describe("method: reset", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpCircuitBreakerAdapter();
@@ -60,13 +63,14 @@ describe("function: withCircuitBreakerPrefix", () => {
                 withCircuitBreakerPrefix(prefix),
             );
 
-            await enhanced.reset(context, "myKey");
+            await enhanced.reset("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ICircuitBreakerAdapter["reset"]>
+            >(`${prefix}myKey`, context);
         });
     });
-
     describe("method: trackFailure", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpCircuitBreakerAdapter();
@@ -77,13 +81,14 @@ describe("function: withCircuitBreakerPrefix", () => {
                 withCircuitBreakerPrefix(prefix),
             );
 
-            await enhanced.trackFailure(context, "myKey");
+            await enhanced.trackFailure("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ICircuitBreakerAdapter["trackFailure"]>
+            >(`${prefix}myKey`, context);
         });
     });
-
     describe("method: trackSuccess", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpCircuitBreakerAdapter();
@@ -94,13 +99,14 @@ describe("function: withCircuitBreakerPrefix", () => {
                 withCircuitBreakerPrefix(prefix),
             );
 
-            await enhanced.trackSuccess(context, "myKey");
+            await enhanced.trackSuccess("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ICircuitBreakerAdapter["trackSuccess"]>
+            >(`${prefix}myKey`, context);
         });
     });
-
     describe("method: updateState", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpCircuitBreakerAdapter();
@@ -111,10 +117,12 @@ describe("function: withCircuitBreakerPrefix", () => {
                 withCircuitBreakerPrefix(prefix),
             );
 
-            await enhanced.updateState(context, "myKey");
+            await enhanced.updateState("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<ICircuitBreakerAdapter["updateState"]>
+            >(`${prefix}myKey`, context);
         });
     });
 });

--- a/src/circuit-breaker/implementations/plugins/with-circuit-breaker-prefix/with-circuit-breaker-prefix.ts
+++ b/src/circuit-breaker/implementations/plugins/with-circuit-breaker-prefix/with-circuit-breaker-prefix.ts
@@ -26,23 +26,23 @@ export function withCircuitBreakerPrefix(
         return prefix + key;
     }
     return (adapter, enhance) => {
-        enhance(adapter, "getState", ({ args: [context, key], next }) => {
-            return next([context, withPrefix(key)]);
+        enhance(adapter, "getState", ({ args: [key, context], next }) => {
+            return next([withPrefix(key), context]);
         });
-        enhance(adapter, "isolate", ({ args: [context, key], next }) => {
-            return next([context, withPrefix(key)]);
+        enhance(adapter, "isolate", ({ args: [key, context], next }) => {
+            return next([withPrefix(key), context]);
         });
-        enhance(adapter, "reset", ({ args: [context, key], next }) => {
-            return next([context, withPrefix(key)]);
+        enhance(adapter, "reset", ({ args: [key, context], next }) => {
+            return next([withPrefix(key), context]);
         });
-        enhance(adapter, "trackFailure", ({ args: [context, key], next }) => {
-            return next([context, withPrefix(key)]);
+        enhance(adapter, "trackFailure", ({ args: [key, context], next }) => {
+            return next([withPrefix(key), context]);
         });
-        enhance(adapter, "trackSuccess", ({ args: [context, key], next }) => {
-            return next([context, withPrefix(key)]);
+        enhance(adapter, "trackSuccess", ({ args: [key, context], next }) => {
+            return next([withPrefix(key), context]);
         });
-        enhance(adapter, "updateState", ({ args: [context, key], next }) => {
-            return next([context, withPrefix(key)]);
+        enhance(adapter, "updateState", ({ args: [key, context], next }) => {
+            return next([withPrefix(key), context]);
         });
     };
 }

--- a/src/circuit-breaker/implementations/test-utilities/circuit-breaker-storage-adapter.test-suite.ts
+++ b/src/circuit-breaker/implementations/test-utilities/circuit-breaker-storage-adapter.test-suite.ts
@@ -88,11 +88,11 @@ export function circuitBreakerStorageAdapterTestSuite(
                 const key = "a";
                 const input = "b";
 
-                await adapter.transaction(context, async (trx) => {
-                    await trx.upsert(context, key, input);
-                });
+                await adapter.transaction(async (trx) => {
+                    await trx.upsert(key, input, context);
+                }, context);
 
-                const value = await adapter.find(context, key);
+                const value = await adapter.find(key, context);
 
                 expect(value).toBe(input);
             });
@@ -101,12 +101,12 @@ export function circuitBreakerStorageAdapterTestSuite(
                 const input1 = "b";
                 const input2 = "c";
 
-                await adapter.transaction(context, async (trx) => {
-                    await trx.upsert(context, key, input1);
-                    await trx.upsert(context, key, input2);
-                });
+                await adapter.transaction(async (trx) => {
+                    await trx.upsert(key, input1, context);
+                    await trx.upsert(key, input2, context);
+                }, context);
 
-                const value = await adapter.find(context, key);
+                const value = await adapter.find(key, context);
                 expect(value).toBe(input2);
             });
         });
@@ -114,12 +114,9 @@ export function circuitBreakerStorageAdapterTestSuite(
             test("Should return null when key doesnt exists", async () => {
                 const noneExistingKey = "a";
 
-                const value = await adapter.transaction(
-                    context,
-                    async (trx) => {
-                        return await trx.find(context, noneExistingKey);
-                    },
-                );
+                const value = await adapter.transaction(async (trx) => {
+                    return await trx.find(noneExistingKey, context);
+                }, context);
 
                 expect(value).toBeNull();
             });
@@ -127,13 +124,10 @@ export function circuitBreakerStorageAdapterTestSuite(
                 const key = "a";
                 const input = "b";
 
-                const value = await adapter.transaction(
-                    context,
-                    async (trx) => {
-                        await trx.upsert(context, key, input);
-                        return await trx.find(context, key);
-                    },
-                );
+                const value = await adapter.transaction(async (trx) => {
+                    await trx.upsert(key, input, context);
+                    return await trx.find(key, context);
+                }, context);
 
                 expect(value).toBe(input);
             });
@@ -142,7 +136,7 @@ export function circuitBreakerStorageAdapterTestSuite(
             test("Should return null when key doesnt exists", async () => {
                 const noneExistingKey = "a";
 
-                const value = await adapter.find(context, noneExistingKey);
+                const value = await adapter.find(noneExistingKey, context);
 
                 expect(value).toBeNull();
             });
@@ -150,10 +144,10 @@ export function circuitBreakerStorageAdapterTestSuite(
                 const key = "a";
                 const input = "b";
 
-                await adapter.transaction(context, async (trx) => {
-                    await trx.upsert(context, key, input);
-                });
-                const value = await adapter.find(context, key);
+                await adapter.transaction(async (trx) => {
+                    await trx.upsert(key, input, context);
+                }, context);
+                const value = await adapter.find(key, context);
 
                 expect(value).toBe(input);
             });
@@ -162,13 +156,13 @@ export function circuitBreakerStorageAdapterTestSuite(
             test("Should remove key when exists", async () => {
                 const key = "a";
 
-                await adapter.transaction(context, async (trx) => {
-                    await trx.upsert(context, key, "value");
-                });
+                await adapter.transaction(async (trx) => {
+                    await trx.upsert(key, "value", context);
+                }, context);
 
-                await adapter.remove(context, key);
+                await adapter.remove(key, context);
 
-                const value = await adapter.find(context, key);
+                const value = await adapter.find(key, context);
                 expect(value).toBeNull();
             });
         });

--- a/src/circuit-breaker/implementations/test-utilities/consecutive-breaker.test-suite.ts
+++ b/src/circuit-breaker/implementations/test-utilities/consecutive-breaker.test-suite.ts
@@ -144,81 +144,81 @@ export function consecutiveBreakerTestSuite(
 
         describe("method: getState", () => {
             test("Should return CIRCUIT_BREAKER_STATE.CLOSED as initial state", async () => {
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.CLOSED);
             });
             test("Should return CIRCUIT_BREAKER_STATE.CLOSED when in ClosedState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.CLOSED);
             });
             test("Should return CIRCUIT_BREAKER_STATE.OPEN when in OpenedState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.OPEN);
             });
             test("Should return CIRCUIT_BREAKER_STATE.HALF_OPEN when in HalfOpenState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                await adapter.updateState(context, KEY);
+                await adapter.updateState(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.HALF_OPEN);
             });
             test("Should return CIRCUIT_BREAKER_STATE.ISOLATED when in IsolatedState", async () => {
-                await adapter.isolate(context, KEY);
+                await adapter.isolate(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.ISOLATED);
             });
         });
         describe("method: updateState / trackFailure / trackSuccess", () => {
             test("Should transition ClosedState -> ClosedState when 1 failure has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                const transition = await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                const transition = await adapter.updateState(KEY, context);
 
                 expect(transition).toEqual({
                     from: CIRCUIT_BREAKER_STATE.CLOSED,
@@ -226,17 +226,17 @@ export function consecutiveBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> ClosedState when 4 consecutive failures has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                const transition = await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                const transition = await adapter.updateState(KEY, context);
 
                 expect(transition).toEqual({
                     from: CIRCUIT_BREAKER_STATE.CLOSED,
@@ -244,20 +244,20 @@ export function consecutiveBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenState when 5 consecutive failures has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                const transition = await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                const transition = await adapter.updateState(KEY, context);
 
                 expect(transition).toEqual({
                     from: CIRCUIT_BREAKER_STATE.CLOSED,
@@ -265,23 +265,23 @@ export function consecutiveBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> ClosedState when 4 consecutive failures, 1 success and 1 failure has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                const transition = await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                const transition = await adapter.updateState(KEY, context);
 
                 expect(transition).toEqual({
                     from: CIRCUIT_BREAKER_STATE.CLOSED,
@@ -289,23 +289,23 @@ export function consecutiveBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenState -> OpenState when 5 consecutive failures has occurred and wait time is not reached", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime.divide(2));
-                const transition = await adapter.updateState(context, KEY);
+                const transition = await adapter.updateState(KEY, context);
 
                 expect(transition).toEqual({
                     from: CIRCUIT_BREAKER_STATE.OPEN,
@@ -313,23 +313,23 @@ export function consecutiveBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenState -> HalfOpenState when 5 consecutive failures has occurred and wait time is reached", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                const transition = await adapter.updateState(context, KEY);
+                const transition = await adapter.updateState(KEY, context);
 
                 expect(transition).toEqual({
                     from: CIRCUIT_BREAKER_STATE.OPEN,
@@ -337,26 +337,26 @@ export function consecutiveBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenState -> HalfOpenState -> HalfOpenState when 5 consecutive failures, wait time is reached and 1 consecutive successes has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                await adapter.updateState(context, KEY);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                const transition = await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                const transition = await adapter.updateState(KEY, context);
 
                 expect(transition).toEqual({
                     from: CIRCUIT_BREAKER_STATE.HALF_OPEN,
@@ -364,35 +364,35 @@ export function consecutiveBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenState -> HalfOpenState -> HalfOpenState when 5 consecutive failures, wait time is reached and 4 consecutive successes has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                await adapter.updateState(context, KEY);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                const transition = await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                const transition = await adapter.updateState(KEY, context);
 
                 expect(transition).toEqual({
                     from: CIRCUIT_BREAKER_STATE.HALF_OPEN,
@@ -400,38 +400,38 @@ export function consecutiveBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenState -> HalfOpenState -> ClosedState when 5 consecutive failures, wait time is reached and 5 consecutive successes has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                await adapter.updateState(context, KEY);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                const transition = await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                const transition = await adapter.updateState(KEY, context);
 
                 expect(transition).toEqual({
                     from: CIRCUIT_BREAKER_STATE.HALF_OPEN,
@@ -439,26 +439,26 @@ export function consecutiveBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenState -> HalfOpenState -> OpenState when 5 consecutive failures, wait time is reached and 1 failure has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                await adapter.updateState(context, KEY);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                const transition = await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                const transition = await adapter.updateState(KEY, context);
 
                 expect(transition).toEqual({
                     from: CIRCUIT_BREAKER_STATE.HALF_OPEN,
@@ -466,38 +466,38 @@ export function consecutiveBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenState -> HalfOpenState -> OpenState when 5 consecutive failures, wait time is reached, 4 consecutive successes and 1 failure has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                await adapter.updateState(context, KEY);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                const transition = await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                const transition = await adapter.updateState(KEY, context);
 
                 expect(transition).toEqual({
                     from: CIRCUIT_BREAKER_STATE.HALF_OPEN,
@@ -507,154 +507,154 @@ export function consecutiveBreakerTestSuite(
         });
         describe("method: updateState / trackFailure / isolate / getState", () => {
             test("Should transition to IsolatedState when in ClosedState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.isolate(context, KEY);
+                await adapter.isolate(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.ISOLATED);
             });
             test("Should transition to IsolatedState when in OpenedState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.isolate(context, KEY);
+                await adapter.isolate(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.ISOLATED);
             });
             test("Should transition to IsolatedState when in HalfOpenState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                await adapter.updateState(context, KEY);
+                await adapter.updateState(KEY, context);
 
-                await adapter.isolate(context, KEY);
+                await adapter.isolate(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.ISOLATED);
             });
         });
         describe("method: updateState / trackFailure / reset", () => {
             test("Should reset when in ClosedState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.reset(context, KEY);
+                await adapter.reset(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.CLOSED);
             });
             test("Should reset when in OpenedState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.reset(context, KEY);
+                await adapter.reset(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.CLOSED);
             });
             test("Should reset when in HalfOpenState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                await adapter.updateState(context, KEY);
+                await adapter.updateState(KEY, context);
 
-                await adapter.reset(context, KEY);
+                await adapter.reset(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.CLOSED);
             });
             test("Should reset when in IsolatedState", async () => {
-                await adapter.isolate(context, KEY);
+                await adapter.isolate(KEY, context);
 
-                await adapter.reset(context, KEY);
+                await adapter.reset(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.CLOSED);
             });
         });
 
         test.skip("TEST", async () => {
-            await adapter.trackFailure(context, KEY);
-            await adapter.updateState(context, KEY);
+            await adapter.trackFailure(KEY, context);
+            await adapter.updateState(KEY, context);
         });
     });
 }

--- a/src/circuit-breaker/implementations/test-utilities/count-breaker.test-suite.ts
+++ b/src/circuit-breaker/implementations/test-utilities/count-breaker.test-suite.ts
@@ -146,110 +146,110 @@ export function countBreakerTestSuite(
 
         describe("method: getState", () => {
             test("Should return CIRCUIT_BREAKER_STATE.CLOSED as initial state", async () => {
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.CLOSED);
             });
             test("Should return CIRCUIT_BREAKER_STATE.CLOSED when in ClosedState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.CLOSED);
             });
             test("Should return CIRCUIT_BREAKER_STATE.OPEN when in OpenedState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.OPEN);
             });
             test("Should return CIRCUIT_BREAKER_STATE.HALF_OPEN when in HalfOpenedState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                await adapter.updateState(context, KEY);
+                await adapter.updateState(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.HALF_OPEN);
             });
             test("Should return CIRCUIT_BREAKER_STATE.ISOLATED when in IsolatedState", async () => {
-                await adapter.isolate(context, KEY);
+                await adapter.isolate(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.ISOLATED);
             });
         });
         describe("method: updateState / trackFailure / trackSuccess", () => {
             test("Should transition ClosedState -> ClosedState when 1 failure has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                const state = await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                const state = await adapter.updateState(KEY, context);
 
                 expect(state).toEqual({
                     from: CIRCUIT_BREAKER_STATE.CLOSED,
@@ -257,20 +257,20 @@ export function countBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> ClosedState when 5 failures has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                const state = await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                const state = await adapter.updateState(KEY, context);
 
                 expect(state).toEqual({
                     from: CIRCUIT_BREAKER_STATE.CLOSED,
@@ -278,23 +278,23 @@ export function countBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> ClosedState when 1 failure and 5 successes has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                const state = await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                const state = await adapter.updateState(KEY, context);
 
                 expect(state).toEqual({
                     from: CIRCUIT_BREAKER_STATE.CLOSED,
@@ -302,29 +302,29 @@ export function countBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenedState when 1 failure, 5 successes and 2 failures has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                const state = await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                const state = await adapter.updateState(KEY, context);
 
                 expect(state).toEqual({
                     from: CIRCUIT_BREAKER_STATE.CLOSED,
@@ -332,23 +332,23 @@ export function countBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenedState when 6 failures", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                const state = await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                const state = await adapter.updateState(KEY, context);
 
                 expect(state).toEqual({
                     from: CIRCUIT_BREAKER_STATE.CLOSED,
@@ -356,26 +356,26 @@ export function countBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenedState -> OpenedState when 6 failures and wait time is not reached", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime.divide(2));
-                const state = await adapter.updateState(context, KEY);
+                const state = await adapter.updateState(KEY, context);
 
                 expect(state).toEqual({
                     from: CIRCUIT_BREAKER_STATE.OPEN,
@@ -383,26 +383,26 @@ export function countBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenedState -> HalfOpenedState when 6 failures and wait time is reached", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                const state = await adapter.updateState(context, KEY);
+                const state = await adapter.updateState(KEY, context);
 
                 expect(state).toEqual({
                     from: CIRCUIT_BREAKER_STATE.OPEN,
@@ -410,35 +410,35 @@ export function countBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> ClosedState when 1 failure, 8 successes and 1 failure", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                const state = await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                const state = await adapter.updateState(KEY, context);
 
                 expect(state).toEqual({
                     from: CIRCUIT_BREAKER_STATE.CLOSED,
@@ -446,35 +446,35 @@ export function countBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenedState when 2 failures, 7 successes and 1 failure", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                const state = await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                const state = await adapter.updateState(KEY, context);
 
                 expect(state).toEqual({
                     from: CIRCUIT_BREAKER_STATE.CLOSED,
@@ -482,44 +482,44 @@ export function countBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> ClosedState when 1 failure, 10 successes and 1 failure", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                const state = await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                const state = await adapter.updateState(KEY, context);
 
                 expect(state).toEqual({
                     from: CIRCUIT_BREAKER_STATE.CLOSED,
@@ -527,38 +527,38 @@ export function countBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenedState -> OpenedState when 2 failures, 7 successes, 1 failure and wait time is not reached", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime.divide(2));
-                const state = await adapter.updateState(context, KEY);
+                const state = await adapter.updateState(KEY, context);
 
                 expect(state).toEqual({
                     from: CIRCUIT_BREAKER_STATE.OPEN,
@@ -566,38 +566,38 @@ export function countBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenedState -> HalfOpenedState when 2 failures, 7 successes, 1 failure and wait time is reached", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                const state = await adapter.updateState(context, KEY);
+                const state = await adapter.updateState(KEY, context);
 
                 expect(state).toEqual({
                     from: CIRCUIT_BREAKER_STATE.OPEN,
@@ -605,29 +605,29 @@ export function countBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenedState -> HalfOpenedState -> HalfOpenedState when 6 failures, wait time is reached, 1 success has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                await adapter.updateState(context, KEY);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                const state = await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                const state = await adapter.updateState(KEY, context);
 
                 expect(state).toEqual({
                     from: CIRCUIT_BREAKER_STATE.HALF_OPEN,
@@ -635,41 +635,41 @@ export function countBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenedState -> HalfOpenedState -> HalfOpenedState when 6 failures, wait time is reached, 5 successess has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                await adapter.updateState(context, KEY);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                const state = await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                const state = await adapter.updateState(KEY, context);
 
                 expect(state).toEqual({
                     from: CIRCUIT_BREAKER_STATE.HALF_OPEN,
@@ -677,41 +677,41 @@ export function countBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenedState -> HalfOpenedState -> HalfOpenedState when 6 failures, wait time is reached, 1 success and 4 failures has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                await adapter.updateState(context, KEY);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                const state = await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                const state = await adapter.updateState(KEY, context);
 
                 expect(state).toEqual({
                     from: CIRCUIT_BREAKER_STATE.HALF_OPEN,
@@ -719,44 +719,44 @@ export function countBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenedState -> HalfOpenedState -> OpenedState when 6 failures, wait time is reached, 1 failures, 4 successess and 1 failure has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                await adapter.updateState(context, KEY);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                const state = await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                const state = await adapter.updateState(KEY, context);
 
                 expect(state).toEqual({
                     from: CIRCUIT_BREAKER_STATE.HALF_OPEN,
@@ -764,44 +764,44 @@ export function countBreakerTestSuite(
                 } satisfies CircuitBreakerStateTransition);
             });
             test("Should transition ClosedState -> OpenedState -> HalfOpenedState -> ClosedState when 6 failures, wait time is reached, 1 failures, 5 successess has occurred", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                await adapter.updateState(context, KEY);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                const state = await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                const state = await adapter.updateState(KEY, context);
 
                 expect(state).toEqual({
                     from: CIRCUIT_BREAKER_STATE.HALF_OPEN,
@@ -811,201 +811,201 @@ export function countBreakerTestSuite(
         });
         describe("method: updateState / trackFailure / isolate", () => {
             test("Should transition to IsolatedState when in ClosedState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.isolate(context, KEY);
+                await adapter.isolate(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.ISOLATED);
             });
             test("Should transition to IsolatedState when in OpenedState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.isolate(context, KEY);
+                await adapter.isolate(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.ISOLATED);
             });
             test("Should transition to IsolatedState when in HalfOpenState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                await adapter.updateState(context, KEY);
+                await adapter.updateState(KEY, context);
 
-                await adapter.isolate(context, KEY);
+                await adapter.isolate(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.ISOLATED);
             });
         });
         describe("method: updateState / trackFailure / reset", () => {
             test("Should reset when in ClosedState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.reset(context, KEY);
+                await adapter.reset(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.CLOSED);
             });
             test("Should reset when in OpenedState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.reset(context, KEY);
+                await adapter.reset(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.CLOSED);
             });
             test("Should reset when in HalfOpenState", async () => {
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackSuccess(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackSuccess(KEY, context);
+                await adapter.updateState(KEY, context);
 
-                await adapter.trackFailure(context, KEY);
-                await adapter.updateState(context, KEY);
+                await adapter.trackFailure(KEY, context);
+                await adapter.updateState(KEY, context);
 
                 await delayWithBuffer(waitTime);
-                await adapter.updateState(context, KEY);
+                await adapter.updateState(KEY, context);
 
-                await adapter.reset(context, KEY);
+                await adapter.reset(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.CLOSED);
             });
             test("Should reset when in IsolatedState", async () => {
-                await adapter.isolate(context, KEY);
+                await adapter.isolate(KEY, context);
 
-                await adapter.reset(context, KEY);
+                await adapter.reset(KEY, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBe(CIRCUIT_BREAKER_STATE.CLOSED);
             });


### PR DESCRIPTION
- **refactor(circuit-breaker): reorder parameters from (context, key) to (key, context) in contracts**
- **refactor(circuit-breaker): update adapter implementations to match key-first parameter order**
- **refactor(circuit-breaker): update CircuitBreakerStorage to key-first parameter order**
- **refactor(circuit-breaker): update test suites to use key-first parameter order**
- **refactor(circuit-breaker): update CircuitBreaker class to use key-first parameter order**
- **refactor(circuit-breaker): update withCircuitBreakerPrefix plugin to key-first parameter order**
- **refactor(circuit-breaker): update test files to use key-first parameter order**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Circuit-breaker adapter and storage operations now accept the key before the context.
  * Transaction methods now accept the callback before the context.
  * Update integrations and custom implementations to use the new argument order.

* **Refactor**
  * Applied the updated calling convention consistently across memory, database, MongoDB, Redis, no-op, and prefixed adapters.
  * Existing circuit-breaker behavior and state management remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->