### PR TITLE
enhacement/rate limiter

### DIFF
--- a/src/rate-limiter/contracts/rate-limiter-adapter.contract.ts
+++ b/src/rate-limiter/contracts/rate-limiter-adapter.contract.ts
@@ -52,13 +52,14 @@ export type IRateLimiterAdapter = {
      * Retrieves the current rate limiter state without modifying it.
      * Returns the tracking metrics if the rate limiter exists, otherwise null.
      *
-     * @param context Readable execution context for the operation
      * @param key Unique identifier for the rate limiter
+     * @param context Readable execution context for the operation
+     *
      * @returns Current adapter state if found, or null if not yet initialized
      */
     getState(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<IRateLimiterAdapterState | null>;
 
     /**
@@ -66,15 +67,16 @@ export type IRateLimiterAdapter = {
      * Increments attempt counter and determines if the request should be allowed or blocked.
      * The decision logic is handled by the policy interface configured for this adapter.
      *
-     * @param context Readable execution context for the operation
      * @param key Unique identifier for the rate limiter
      * @param limit Maximum allowed attempts in the current window
+     * @param context Readable execution context for the operation
+     *
      * @returns Updated state with incremented attempt and success flag
      */
     updateState(
-        context: IReadableContext,
         key: string,
         limit: number,
+        context: IReadableContext,
     ): Promise<IRateLimiterAdapterState>;
 
     /**
@@ -82,8 +84,8 @@ export type IRateLimiterAdapter = {
      * Clears all attempt tracking and lifts any blocking status.
      * Can be called even if the rate limiter has expired or was never initialized.
      *
-     * @param context Readable execution context for the operation
      * @param key Unique identifier for the rate limiter to reset
+     * @param context Readable execution context for the operation
      */
-    reset(context: IReadableContext, key: string): Promise<void>;
+    reset(key: string, context: IReadableContext): Promise<void>;
 };

--- a/src/rate-limiter/contracts/rate-limiter-storage-adapter.contract.ts
+++ b/src/rate-limiter/contracts/rate-limiter-storage-adapter.contract.ts
@@ -44,16 +44,16 @@ export type IRateLimiterStorageAdapterTransaction<TType = unknown> = {
      * Used when recording a new attempt or updating metrics after evaluation.
      * Implementations should use database UPSERT semantics if available.
      *
-     * @param context Readable execution context for the operation
      * @param key Unique identifier for the rate limiter
      * @param state The new metrics/state object from the policy
      * @param expiration The calculated expiration date for this state
+     * @param context Readable execution context for the operation
      */
     upsert(
-        context: IReadableContext,
         key: string,
         state: TType,
         expiration: Date,
+        context: IReadableContext,
     ): Promise<void>;
 
     /**
@@ -61,13 +61,14 @@ export type IRateLimiterStorageAdapterTransaction<TType = unknown> = {
      * Used to load existing state when evaluating subsequent attempts.
      * Returns null if the rate limiter hasn't been initialized yet.
      *
-     * @param context Readable execution context for the operation
      * @param key Unique identifier for the rate limiter
+     * @param context Readable execution context for the operation
+     *
      * @returns The stored rate limiter data if found, otherwise null
      */
     find(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<IRateLimiterData<TType> | null>;
 };
 
@@ -92,16 +93,17 @@ export type IRateLimiterStorageAdapter<TType = unknown> = {
      * All database operations within the transaction function should succeed or fail atomically.
      * If the transaction function throws, the transaction should be rolled back.
      *
-     * @param context Readable execution context for the operation
      * @param fn Callback function receiving transaction object, should return a Promise
+     * @param context Readable execution context for the operation
+     *
      * @returns The value returned by the fn callback
      */
     transaction<TValue>(
-        context: IReadableContext,
         fn: InvokableFn<
             [transaction: IRateLimiterStorageAdapterTransaction<TType>],
             Promise<TValue>
         >,
+        context: IReadableContext,
     ): Promise<TValue>;
 
     /**
@@ -109,13 +111,14 @@ export type IRateLimiterStorageAdapter<TType = unknown> = {
      * Useful for read-only operations or standalone state checks.
      * Returns null if the rate limiter hasn't been initialized.
      *
-     * @param context Readable execution context for the operation
      * @param key Unique identifier for the rate limiter
+     * @param context Readable execution context for the operation
+     *
      * @returns The stored rate limiter data if found, otherwise null
      */
     find(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<IRateLimiterData<TType> | null>;
 
     /**
@@ -123,8 +126,8 @@ export type IRateLimiterStorageAdapter<TType = unknown> = {
      * Called when explicitly resetting a rate limiter or cleaning up expired entries.
      * Safe to call even if the rate limiter doesn't exist.
      *
-     * @param context Readable execution context for the operation
      * @param key Unique identifier for the rate limiter to remove
+     * @param context Readable execution context for the operation
      */
-    remove(context: IReadableContext, key: string): Promise<void>;
+    remove(key: string, context: IReadableContext): Promise<void>;
 };

--- a/src/rate-limiter/implementations/adapters/database-rate-limiter-adapter/database-rate-limiter-adapter.ts
+++ b/src/rate-limiter/implementations/adapters/database-rate-limiter-adapter/database-rate-limiter-adapter.ts
@@ -101,8 +101,8 @@ export class DatabaseRateLimiterAdapter<
     }
 
     async getState(
-        context: IReadableContext,
         key: string,
+        context: IReadableContext,
     ): Promise<IRateLimiterAdapterState | null> {
         const state = await this.rateLimiterStorage.find(context, key);
         if (state === null) {
@@ -118,9 +118,9 @@ export class DatabaseRateLimiterAdapter<
     }
 
     async updateState(
-        context: IReadableContext,
         key: string,
         limit: number,
+        context: IReadableContext,
     ): Promise<IRateLimiterAdapterState> {
         const currentDate = new Date();
         const track = this.rateLimiterStateManager.track(currentDate);
@@ -146,7 +146,7 @@ export class DatabaseRateLimiterAdapter<
         };
     }
 
-    async reset(context: IReadableContext, key: string): Promise<void> {
+    async reset(key: string, context: IReadableContext): Promise<void> {
         await this.rateLimiterStorage.remove(context, key);
     }
 }

--- a/src/rate-limiter/implementations/adapters/database-rate-limiter-adapter/rate-limiter-storage.ts
+++ b/src/rate-limiter/implementations/adapters/database-rate-limiter-adapter/rate-limiter-storage.ts
@@ -93,32 +93,28 @@ export class RateLimiterStorage<TMetrics = unknown> {
         args: AtomicUpdateArgs<TMetrics>,
     ): Promise<IRateLimiterStorageState> {
         const currentDate = new Date();
-        const state = await this.adapter.transaction(
-            args.context,
-            async (trx) => {
-                let currentState = RateLimiterStorage.resolveStorageData(
-                    await trx.find(args.context, args.key),
-                );
-                if (currentState === null) {
-                    currentState =
-                        this.rateLimiterPolicy.initialState(currentDate);
-                }
+        const state = await this.adapter.transaction(async (trx) => {
+            let currentState = RateLimiterStorage.resolveStorageData(
+                await trx.find(args.key, args.context),
+            );
+            if (currentState === null) {
+                currentState = this.rateLimiterPolicy.initialState(currentDate);
+            }
 
-                const newState = args.update(currentState);
+            const newState = args.update(currentState);
 
-                await trx.upsert(
-                    args.context,
-                    args.key,
-                    newState,
-                    this.rateLimiterPolicy.getExpiration(newState, {
-                        backoffPolicy: this.backoffPolicy,
-                        currentDate,
-                    }),
-                );
+            await trx.upsert(
+                args.key,
+                newState,
+                this.rateLimiterPolicy.getExpiration(newState, {
+                    backoffPolicy: this.backoffPolicy,
+                    currentDate,
+                }),
+                args.context,
+            );
 
-                return newState;
-            },
-        );
+            return newState;
+        }, args.context);
         return this.toAdapterState(state);
     }
 
@@ -127,7 +123,7 @@ export class RateLimiterStorage<TMetrics = unknown> {
         key: string,
     ): Promise<IRateLimiterStorageState | null> {
         const state = RateLimiterStorage.resolveStorageData(
-            await this.adapter.find(context, key),
+            await this.adapter.find(key, context),
         );
         if (state === null) {
             return null;
@@ -136,6 +132,6 @@ export class RateLimiterStorage<TMetrics = unknown> {
     }
 
     async remove(context: IReadableContext, key: string): Promise<void> {
-        await this.adapter.remove(context, key);
+        await this.adapter.remove(key, context);
     }
 }

--- a/src/rate-limiter/implementations/adapters/kysely-rate-limiter-storage-adapter/kysely-rate-limiter-storage-adapter.ts
+++ b/src/rate-limiter/implementations/adapters/kysely-rate-limiter-storage-adapter/kysely-rate-limiter-storage-adapter.ts
@@ -80,10 +80,10 @@ class KyselyRateLimiterStorageAdapterTransaction<
     }
 
     async upsert(
-        _context: IReadableContext,
         key: string,
         state: TType,
         expiration: Date,
+        _context: IReadableContext,
     ): Promise<void> {
         const expirationAsMs = expiration.getTime();
         const serializedState = this.serde.serialize(state);
@@ -114,8 +114,8 @@ class KyselyRateLimiterStorageAdapterTransaction<
     }
 
     async find(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<IRateLimiterData<TType> | null> {
         return await find(this.kysely, this.serde, key);
     }
@@ -310,11 +310,11 @@ export class KyselyRateLimiterStorageAdapter<TType>
     }
 
     async transaction<TValue>(
-        _context: IReadableContext,
         fn: InvokableFn<
             [transaction: IRateLimiterStorageAdapterTransaction<TType>],
             Promise<TValue>
         >,
+        _context: IReadableContext,
     ): Promise<TValue> {
         return await this._transaction(async (trx) => {
             return await fn(
@@ -324,13 +324,13 @@ export class KyselyRateLimiterStorageAdapter<TType>
     }
 
     async find(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<IRateLimiterData<TType> | null> {
         return await find(this.kysely, this.serde, key);
     }
 
-    async remove(_context: IReadableContext, key: string): Promise<void> {
+    async remove(key: string, _context: IReadableContext): Promise<void> {
         await this.kysely
             .deleteFrom("rateLimiter")
             .where("rateLimiter.key", "=", key)

--- a/src/rate-limiter/implementations/adapters/kysely-rate-limiter-storage-adapter/mysql-kysely-rate-limiter-storage-adapter.test.ts
+++ b/src/rate-limiter/implementations/adapters/kysely-rate-limiter-storage-adapter/mysql-kysely-rate-limiter-storage-adapter.test.ts
@@ -81,32 +81,32 @@ describe("mysql class: KyselyRateLimiterStorageAdapter", () => {
             });
             await adapter.init();
 
-            await adapter.transaction(noOpContext, async (trx) => {
+            await adapter.transaction(async (trx) => {
                 await trx.upsert(
-                    noOpContext,
                     "a",
                     "owner",
                     TimeSpan.fromMilliseconds(50).toStartDate(),
+                    noOpContext,
                 );
                 await trx.upsert(
-                    noOpContext,
                     "b",
                     "owner",
                     TimeSpan.fromMilliseconds(50).toStartDate(),
+                    noOpContext,
                 );
                 await trx.upsert(
-                    noOpContext,
                     "c",
                     "owner",
                     TimeSpan.fromMilliseconds(50).toEndDate(),
+                    noOpContext,
                 );
-            });
+            }, noOpContext);
 
             await adapter.removeAllExpired();
 
-            expect(await adapter.find(noOpContext, "a")).toBeNull();
-            expect(await adapter.find(noOpContext, "b")).toBeNull();
-            expect(await adapter.find(noOpContext, "c")).not.toBeNull();
+            expect(await adapter.find("a", noOpContext)).toBeNull();
+            expect(await adapter.find("b", noOpContext)).toBeNull();
+            expect(await adapter.find("c", noOpContext)).not.toBeNull();
         });
     });
     describe("method: init", () => {

--- a/src/rate-limiter/implementations/adapters/kysely-rate-limiter-storage-adapter/postgres-kysely-rate-limiter-storage-adapter.test.ts
+++ b/src/rate-limiter/implementations/adapters/kysely-rate-limiter-storage-adapter/postgres-kysely-rate-limiter-storage-adapter.test.ts
@@ -73,32 +73,32 @@ describe("postgres class: KyselyRateLimiterStorageAdapter", () => {
             });
             await adapter.init();
 
-            await adapter.transaction(noOpContext, async (trx) => {
+            await adapter.transaction(async (trx) => {
                 await trx.upsert(
-                    noOpContext,
                     "a",
                     "state",
                     TimeSpan.fromMilliseconds(50).toStartDate(),
+                    noOpContext,
                 );
                 await trx.upsert(
-                    noOpContext,
                     "b",
                     "state",
                     TimeSpan.fromMilliseconds(50).toStartDate(),
+                    noOpContext,
                 );
                 await trx.upsert(
-                    noOpContext,
                     "c",
                     "state",
                     TimeSpan.fromMilliseconds(50).toEndDate(),
+                    noOpContext,
                 );
-            });
+            }, noOpContext);
 
             await adapter.removeAllExpired();
 
-            expect(await adapter.find(noOpContext, "a")).toBeNull();
-            expect(await adapter.find(noOpContext, "b")).toBeNull();
-            expect(await adapter.find(noOpContext, "c")).not.toBeNull();
+            expect(await adapter.find("a", noOpContext)).toBeNull();
+            expect(await adapter.find("b", noOpContext)).toBeNull();
+            expect(await adapter.find("c", noOpContext)).not.toBeNull();
         });
     });
     describe("method: init", () => {

--- a/src/rate-limiter/implementations/adapters/kysely-rate-limiter-storage-adapter/sqlite-kysely-rate-limiter-storage.test.ts
+++ b/src/rate-limiter/implementations/adapters/kysely-rate-limiter-storage-adapter/sqlite-kysely-rate-limiter-storage.test.ts
@@ -58,32 +58,32 @@ describe("sqlite class: KyselyRateLimiterStorageAdapter", () => {
             });
             await adapter.init();
 
-            await adapter.transaction(noOpContext, async (trx) => {
+            await adapter.transaction(async (trx) => {
                 await trx.upsert(
-                    noOpContext,
                     "a",
                     "state",
                     TimeSpan.fromMilliseconds(50).toStartDate(),
+                    noOpContext,
                 );
                 await trx.upsert(
-                    noOpContext,
                     "b",
                     "state",
                     TimeSpan.fromMilliseconds(50).toStartDate(),
+                    noOpContext,
                 );
                 await trx.upsert(
-                    noOpContext,
                     "c",
                     "state",
                     TimeSpan.fromMilliseconds(50).toEndDate(),
+                    noOpContext,
                 );
-            });
+            }, noOpContext);
 
             await adapter.removeAllExpired();
 
-            expect(await adapter.find(noOpContext, "a")).toBeNull();
-            expect(await adapter.find(noOpContext, "b")).toBeNull();
-            expect(await adapter.find(noOpContext, "c")).not.toBeNull();
+            expect(await adapter.find("a", noOpContext)).toBeNull();
+            expect(await adapter.find("b", noOpContext)).toBeNull();
+            expect(await adapter.find("c", noOpContext)).not.toBeNull();
         });
     });
     describe("method: init", () => {

--- a/src/rate-limiter/implementations/adapters/memory-rate-limiter-storage-adapter/memory-rate-limiter-storage-adapter.ts
+++ b/src/rate-limiter/implementations/adapters/memory-rate-limiter-storage-adapter/memory-rate-limiter-storage-adapter.ts
@@ -53,18 +53,18 @@ export class MemoryRateLimiterStorageAdapter<TType>
     }
 
     async transaction<TValue>(
-        _context: IReadableContext,
         fn: InvokableFn<
             [transaction: IRateLimiterStorageAdapterTransaction<TType>],
             Promise<TValue>
         >,
+        _context: IReadableContext,
     ): Promise<TValue> {
         return await fn({
             upsert: (
-                _nestedContext: IReadableContext,
                 key: string,
                 state: TType,
                 expiration: Date,
+                _nestedContext: IReadableContext,
             ): Promise<void> => {
                 const ttl = expiration.getTime() - Date.now();
                 const timeoutId = setTimeout(() => {
@@ -78,17 +78,17 @@ export class MemoryRateLimiterStorageAdapter<TType>
                 return Promise.resolve();
             },
             find: (
-                context: IReadableContext,
                 key: string,
+                _nestedContext: IReadableContext,
             ): Promise<IRateLimiterData<TType> | null> => {
-                return this.find(context, key);
+                return this.find(key, _nestedContext);
             },
         });
     }
 
     find(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<IRateLimiterData<TType> | null> {
         const data = this.map.get(key);
         if (data === undefined) {
@@ -100,7 +100,7 @@ export class MemoryRateLimiterStorageAdapter<TType>
         });
     }
 
-    remove(_context: IReadableContext, key: string): Promise<void> {
+    remove(key: string, _context: IReadableContext): Promise<void> {
         const data = this.map.get(key);
         if (data === undefined) {
             return Promise.resolve();

--- a/src/rate-limiter/implementations/adapters/memory-rate-limiter-storage-adapter/memory-rate-limiter-storage.test.ts
+++ b/src/rate-limiter/implementations/adapters/memory-rate-limiter-storage-adapter/memory-rate-limiter-storage.test.ts
@@ -24,26 +24,26 @@ describe("class: MemoryRateLimiterStorageAdapter", () => {
         test("Should clear rate limiter data", async () => {
             const map = new Map<string, MemoryRateLimiterData>();
             const adapter = new MemoryRateLimiterStorageAdapter(map);
-            await adapter.transaction(noOpContext, async (trx) => {
+            await adapter.transaction(async (trx) => {
                 await trx.upsert(
-                    noOpContext,
                     "a",
                     1,
                     TimeSpan.fromSeconds(2).toEndDate(),
+                    noOpContext,
                 );
                 await trx.upsert(
-                    noOpContext,
                     "b",
                     2,
                     TimeSpan.fromSeconds(2).toEndDate(),
+                    noOpContext,
                 );
                 await trx.upsert(
-                    noOpContext,
                     "c",
                     3,
                     TimeSpan.fromSeconds(2).toEndDate(),
+                    noOpContext,
                 );
-            });
+            }, noOpContext);
             await adapter.deInit();
 
             expect(map.size).toBe(0);

--- a/src/rate-limiter/implementations/adapters/mongodb-rate-limiter-storage-adapter/mongodb-rate-limiter-storage-adapter.test.ts
+++ b/src/rate-limiter/implementations/adapters/mongodb-rate-limiter-storage-adapter/mongodb-rate-limiter-storage-adapter.test.ts
@@ -129,9 +129,9 @@ describe("class: MongodbRateLimiterStorageAdapter", () => {
             const state = "1";
             const ttl = TimeSpan.fromSeconds(1).toEndDate();
 
-            await adapter.transaction(noOpContext, async (trx) => {
-                await trx.upsert(noOpContext, key, state, ttl);
-            });
+            await adapter.transaction(async (trx) => {
+                await trx.upsert(key, state, ttl, noOpContext);
+            }, noOpContext);
 
             const doc = await collection.findOne({
                 key,
@@ -161,9 +161,9 @@ describe("class: MongodbRateLimiterStorageAdapter", () => {
             const ttl = TimeSpan.fromMinutes(5);
             const expiration = ttl.toEndDate();
 
-            await adapter.transaction(noOpContext, async (trx) => {
-                await trx.upsert(noOpContext, key, state, expiration);
-            });
+            await adapter.transaction(async (trx) => {
+                await trx.upsert(key, state, expiration, noOpContext);
+            }, noOpContext);
 
             const doc = await collection.findOne({
                 key,

--- a/src/rate-limiter/implementations/adapters/mongodb-rate-limiter-storage-adapter/mongodb-rate-limiter-storage-adapter.ts
+++ b/src/rate-limiter/implementations/adapters/mongodb-rate-limiter-storage-adapter/mongodb-rate-limiter-storage-adapter.ts
@@ -173,10 +173,10 @@ export class MongodbRateLimiterStorageAdapter<TType>
     }
 
     private async upsert(
-        _context: IReadableContext,
         key: string,
         state: TType,
         expiration: Date,
+        _context: IReadableContext,
         session?: ClientSession,
     ): Promise<void> {
         await this.collection.updateOne(
@@ -207,24 +207,24 @@ export class MongodbRateLimiterStorageAdapter<TType>
     }
 
     async transaction<TValue>(
-        _context: IReadableContext,
         fn: InvokableFn<
             [transaction: IRateLimiterStorageAdapterTransaction<TType>],
             Promise<TValue>
         >,
+        _context: IReadableContext,
     ): Promise<TValue> {
         return await this._transaction(async (session) => {
             return await fn({
-                upsert: (context, key, state, exiration) =>
-                    this.upsert(context, key, state, exiration, session),
-                find: (context, key) => this.find(context, key, session),
+                upsert: (key, state, expiration, context) =>
+                    this.upsert(key, state, expiration, context, session),
+                find: (key, context) => this.find(key, context, session),
             });
         });
     }
 
     async find(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
         session?: ClientSession,
     ): Promise<IRateLimiterData<TType> | null> {
         const doc = await this.collection.findOne(
@@ -245,8 +245,8 @@ export class MongodbRateLimiterStorageAdapter<TType>
     }
 
     async remove(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
         session?: ClientSession,
     ): Promise<void> {
         await this.collection.deleteOne(

--- a/src/rate-limiter/implementations/adapters/no-op-rate-limiter-adapter/no-op-rate-limiter-adapter.ts
+++ b/src/rate-limiter/implementations/adapters/no-op-rate-limiter-adapter/no-op-rate-limiter-adapter.ts
@@ -19,8 +19,8 @@ import { TimeSpan } from "@/time-span/implementations/time-span.js";
  */
 export class NoOpRateLimiterAdapter implements IRateLimiterAdapter {
     getState(
-        _context: IReadableContext,
         _key: string,
+        _context: IReadableContext,
     ): Promise<IRateLimiterAdapterState> {
         return Promise.resolve({
             success: true,
@@ -30,9 +30,9 @@ export class NoOpRateLimiterAdapter implements IRateLimiterAdapter {
     }
 
     updateState(
-        _context: IReadableContext,
         _key: string,
         limit: number,
+        _context: IReadableContext,
     ): Promise<IRateLimiterAdapterState> {
         return Promise.resolve({
             success: true,
@@ -42,7 +42,7 @@ export class NoOpRateLimiterAdapter implements IRateLimiterAdapter {
         });
     }
 
-    reset(_context: IReadableContext, _key: string): Promise<void> {
+    reset(_key: string, _context: IReadableContext): Promise<void> {
         return Promise.resolve();
     }
 }

--- a/src/rate-limiter/implementations/adapters/no-op-rate-limiter-storage-adapter/no-op-rate-limiter-storage-adapter.ts
+++ b/src/rate-limiter/implementations/adapters/no-op-rate-limiter-storage-adapter/no-op-rate-limiter-storage-adapter.ts
@@ -20,17 +20,17 @@ class NoOpRateLimiterStorageAdapterTransaction<
     TType,
 > implements IRateLimiterStorageAdapterTransaction<TType> {
     upsert(
-        _context: IReadableContext,
         _key: string,
         _state: TType,
         _expiration: Date,
+        _context: IReadableContext,
     ): Promise<void> {
         return Promise.resolve();
     }
 
     find(
-        _context: IReadableContext,
         _key: string,
+        _context: IReadableContext,
     ): Promise<IRateLimiterData<TType> | null> {
         return Promise.resolve(null);
     }
@@ -46,11 +46,11 @@ export class NoOpRateLimiterStorageAdapter<
     TType,
 > implements IRateLimiterStorageAdapter<TType> {
     transaction<TValue>(
-        _context: IReadableContext,
         fn: InvokableFn<
             [transaction: IRateLimiterStorageAdapterTransaction<TType>],
             Promise<TValue>
         >,
+        _context: IReadableContext,
     ): Promise<TValue> {
         return Promise.resolve(
             fn(new NoOpRateLimiterStorageAdapterTransaction()),
@@ -58,13 +58,13 @@ export class NoOpRateLimiterStorageAdapter<
     }
 
     find(
-        _context: IReadableContext,
         _key: string,
+        _context: IReadableContext,
     ): Promise<IRateLimiterData<TType> | null> {
         return Promise.resolve(null);
     }
 
-    remove(_context: IReadableContext, _key: string): Promise<void> {
+    remove(_key: string, _context: IReadableContext): Promise<void> {
         return Promise.resolve();
     }
 }

--- a/src/rate-limiter/implementations/adapters/redis-rate-limiter-adapter/redis-rate-limiter-adapter.ts
+++ b/src/rate-limiter/implementations/adapters/redis-rate-limiter-adapter/redis-rate-limiter-adapter.ts
@@ -182,8 +182,8 @@ export class RedisRateLimiterAdapter implements IRateLimiterAdapter {
     }
 
     async getState(
-        _context: IReadableContext,
         key: string,
+        _context: IReadableContext,
     ): Promise<IRateLimiterAdapterState | null> {
         const json = await this.database.daiso_rate_limiter_get_state(
             key,
@@ -205,9 +205,9 @@ export class RedisRateLimiterAdapter implements IRateLimiterAdapter {
     }
 
     async updateState(
-        _context: IReadableContext,
         key: string,
         limit: number,
+        _context: IReadableContext,
     ): Promise<IRateLimiterAdapterState> {
         const json = await this.database.daiso_rate_limiter_update_state(
             key,
@@ -226,7 +226,7 @@ export class RedisRateLimiterAdapter implements IRateLimiterAdapter {
         };
     }
 
-    async reset(_context: IReadableContext, key: string): Promise<void> {
+    async reset(key: string, _context: IReadableContext): Promise<void> {
         await this.database.del(key);
     }
 }

--- a/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter-factory.test.ts
+++ b/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter-factory.test.ts
@@ -25,19 +25,19 @@ import { TimeSpan } from "@/time-span/implementations/_module.js";
 describe("class: RateLimiterFactory", () => {
     const adapter: IRateLimiterAdapter = {
         getState(
-            _context: IReadableContext,
             _key: string,
+            _context: IReadableContext,
         ): Promise<IRateLimiterAdapterState | null> {
             throw new UnexpectedErrorA("Function not implemented.");
         },
         updateState(
-            _context: IReadableContext,
             _key: string,
             _limit: number,
+            _context: IReadableContext,
         ): Promise<IRateLimiterAdapterState> {
             throw new UnexpectedErrorA("Function not implemented.");
         },
-        reset(_context: IReadableContext, _key: string): Promise<void> {
+        reset(_key: string, _context: IReadableContext): Promise<void> {
             throw new UnexpectedErrorA("Function not implemented.");
         },
     };
@@ -422,22 +422,22 @@ describe("class: RateLimiterFactory", () => {
                 constructor(private readonly adapter_: IRateLimiterAdapter) {}
 
                 getState(
-                    context: IReadableContext,
                     key: string,
+                    context: IReadableContext,
                 ): Promise<IRateLimiterAdapterState | null> {
-                    return this.adapter_.getState(context, key);
+                    return this.adapter_.getState(key, context);
                 }
 
                 updateState(
-                    context: IReadableContext,
                     key: string,
                     limit: number,
+                    context: IReadableContext,
                 ): Promise<IRateLimiterAdapterState> {
-                    return this.adapter_.updateState(context, key, limit);
+                    return this.adapter_.updateState(key, limit, context);
                 }
 
-                reset(context: IReadableContext, key: string): Promise<void> {
-                    return this.adapter_.reset(context, key);
+                reset(key: string, context: IReadableContext): Promise<void> {
+                    return this.adapter_.reset(key, context);
                 }
             }
 

--- a/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter.ts
+++ b/src/rate-limiter/implementations/derivables/rate-limiter-factory/rate-limiter.ts
@@ -131,10 +131,7 @@ export class RateLimiter implements IRateLimiter {
     }
 
     async getState(): Promise<RateLimiterState> {
-        const state = await this.adapter.getState(
-            this.context,
-            this._key.toString(),
-        );
+        const state = await this.adapter.getState(this._key, this.context);
 
         return this.toRateLimiterState(state);
     }
@@ -151,7 +148,7 @@ export class RateLimiter implements IRateLimiter {
         asyncFn: AsyncLazy<TValue>,
     ): Promise<TValue> {
         const state = this.toRateLimiterState(
-            await this.adapter.getState(this.context, this._key.toString()),
+            await this.adapter.getState(this._key, this.context),
         );
 
         if (state.type === RATE_LIMITER_STATE.BLOCKED) {
@@ -170,9 +167,9 @@ export class RateLimiter implements IRateLimiter {
             if (isErrorMatching) {
                 const fn = async () => {
                     await this.adapter.updateState(
-                        this.context,
-                        this._key.toString(),
+                        this._key,
                         this.limit,
+                        this.context,
                     );
                 };
                 if (this.enableAsyncTracking) {
@@ -190,11 +187,7 @@ export class RateLimiter implements IRateLimiter {
         asyncFn: AsyncLazy<TValue>,
     ): Promise<TValue> {
         const state = this.toRateLimiterState(
-            await this.adapter.updateState(
-                this.context,
-                this._key.toString(),
-                this.limit,
-            ),
+            await this.adapter.updateState(this._key, this.limit, this.context),
         );
 
         if (state.type === RATE_LIMITER_STATE.BLOCKED) {
@@ -215,6 +208,6 @@ export class RateLimiter implements IRateLimiter {
     }
 
     async reset(): Promise<void> {
-        await this.adapter.reset(this.context, this._key.toString());
+        await this.adapter.reset(this._key, this.context);
     }
 }

--- a/src/rate-limiter/implementations/plugins/with-rate-limiter-prefix/with-rate-limiter-prefix.test.ts
+++ b/src/rate-limiter/implementations/plugins/with-rate-limiter-prefix/with-rate-limiter-prefix.test.ts
@@ -4,6 +4,7 @@ import { Context } from "@/execution-context/implementations/derivables/executio
 import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enhance-factory.js";
 import { useFactory } from "@/middleware/implementations/use-factory/_module.js";
 import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
+import { type IRateLimiterAdapter } from "@/rate-limiter/contracts/_module.js";
 import { NoOpRateLimiterAdapter } from "@/rate-limiter/implementations/adapters/_module.js";
 import { withRateLimiterPrefix } from "@/rate-limiter/implementations/plugins/with-rate-limiter-prefix/with-rate-limiter-prefix.js";
 
@@ -23,13 +24,14 @@ describe("function: withRateLimiterPrefix", () => {
 
             const enhanced = withPlugin(adapter, withRateLimiterPrefix(prefix));
 
-            await enhanced.getState(context, "myKey");
+            await enhanced.getState("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<IRateLimiterAdapter["getState"]>
+            >(`${prefix}myKey`, context);
         });
     });
-
     describe("method: reset", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpRateLimiterAdapter();
@@ -37,13 +39,14 @@ describe("function: withRateLimiterPrefix", () => {
 
             const enhanced = withPlugin(adapter, withRateLimiterPrefix(prefix));
 
-            await enhanced.reset(context, "myKey");
+            await enhanced.reset("myKey", context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<IRateLimiterAdapter["reset"]>
+            >(`${prefix}myKey`, context);
         });
     });
-
     describe("method: updateState", () => {
         test("Should prefix the key", async () => {
             const adapter = new NoOpRateLimiterAdapter();
@@ -51,10 +54,12 @@ describe("function: withRateLimiterPrefix", () => {
 
             const enhanced = withPlugin(adapter, withRateLimiterPrefix(prefix));
 
-            await enhanced.updateState(context, "myKey", 10);
+            await enhanced.updateState("myKey", 10, context);
 
             expect(spy).toHaveBeenCalledOnce();
-            expect(spy).toHaveBeenCalledWith(context, `${prefix}myKey`, 10);
+            expect(spy).toHaveBeenCalledWith<
+                Parameters<IRateLimiterAdapter["updateState"]>
+            >(`${prefix}myKey`, 10, context);
         });
     });
 });

--- a/src/rate-limiter/implementations/plugins/with-rate-limiter-prefix/with-rate-limiter-prefix.ts
+++ b/src/rate-limiter/implementations/plugins/with-rate-limiter-prefix/with-rate-limiter-prefix.ts
@@ -26,18 +26,14 @@ export function withRateLimiterPrefix(
         return prefix + key;
     }
     return (adapter, enhance) => {
-        enhance(adapter, "getState", ({ args: [context, key], next }) => {
-            return next([context, withPrefix(key)]);
+        enhance(adapter, "getState", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
         });
-        enhance(adapter, "reset", ({ args: [context, key], next }) => {
-            return next([context, withPrefix(key)]);
+        enhance(adapter, "reset", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
         });
-        enhance(
-            adapter,
-            "updateState",
-            ({ args: [context, key, ...rest], next }) => {
-                return next([context, withPrefix(key), ...rest]);
-            },
-        );
+        enhance(adapter, "updateState", ({ args: [key, ...rest], next }) => {
+            return next([withPrefix(key), ...rest]);
+        });
     };
 }

--- a/src/rate-limiter/implementations/test-utilities/fixed-window-limiter.test-suite.ts
+++ b/src/rate-limiter/implementations/test-utilities/fixed-window-limiter.test-suite.ts
@@ -142,16 +142,16 @@ export function fixedWindowLimiterTestSuite(
 
         describe("method: getState", () => {
             test("Should return null when updateState method have not been called", async () => {
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBeNull();
             });
             test("Should return AllowedState attempt when 3 attempts occurs during window time", async () => {
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toEqual({
                     success: true,
@@ -160,12 +160,12 @@ export function fixedWindowLimiterTestSuite(
                 } satisfies IRateLimiterAdapterState);
             });
             test("Should return AllowedState attempt when 4 attempts occurs during window time", async () => {
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toEqual({
                     success: true,
@@ -174,24 +174,24 @@ export function fixedWindowLimiterTestSuite(
                 } satisfies IRateLimiterAdapterState);
             });
             test("Should return null when 4 attempts occurs during window time and resetTime is awaited", async () => {
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
 
-                const state1 = await adapter.updateState(context, KEY, LIMIT);
+                const state1 = await adapter.updateState(KEY, LIMIT, context);
                 await delayWithBuffer(state1.resetTime);
 
-                const state2 = await adapter.getState(context, KEY);
+                const state2 = await adapter.getState(KEY, context);
                 expect(state2).toBeNull();
             });
             test("Should return BlockedState when 5 attempts occurs during window time", async () => {
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toEqual({
                     success: false,
@@ -200,14 +200,14 @@ export function fixedWindowLimiterTestSuite(
                 } satisfies IRateLimiterAdapterState);
             });
             test("Should return BlockedState attempt when 6 attempts occurs during window time", async () => {
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
 
-                const state = await adapter.getState(context, KEY);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toEqual({
                     success: false,
@@ -216,25 +216,25 @@ export function fixedWindowLimiterTestSuite(
                 } satisfies IRateLimiterAdapterState);
             });
             test("Should return null when 6 attempts occurs during window time and resetTime is awaited", async () => {
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
 
-                const state1 = await adapter.updateState(context, KEY, LIMIT);
+                const state1 = await adapter.updateState(KEY, LIMIT, context);
                 await delayWithBuffer(state1.resetTime);
 
-                const state2 = await adapter.getState(context, KEY);
+                const state2 = await adapter.getState(KEY, context);
                 expect(state2).toBeNull();
             });
         });
         describe("method: updateState", () => {
             test("Should return AllowedState with incremented attempt when 3 attempts occurs during window time", async () => {
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
 
-                const state = await adapter.updateState(context, KEY, LIMIT);
+                const state = await adapter.updateState(KEY, LIMIT, context);
 
                 expect(state).toEqual({
                     success: true,
@@ -243,11 +243,11 @@ export function fixedWindowLimiterTestSuite(
                 } satisfies IRateLimiterAdapterState);
             });
             test("Should return AllowedState with incremented attempt when 4 attempts occurs during window time", async () => {
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
 
-                const state = await adapter.updateState(context, KEY, LIMIT);
+                const state = await adapter.updateState(KEY, LIMIT, context);
 
                 expect(state).toEqual({
                     success: true,
@@ -256,14 +256,14 @@ export function fixedWindowLimiterTestSuite(
                 } satisfies IRateLimiterAdapterState);
             });
             test("Should return reseted AllowedState when 4 attempts occurs during window time and resetTime is awaited", async () => {
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
 
-                const state1 = await adapter.updateState(context, KEY, LIMIT);
+                const state1 = await adapter.updateState(KEY, LIMIT, context);
                 await delayWithBuffer(state1.resetTime);
 
-                const state2 = await adapter.updateState(context, KEY, LIMIT);
+                const state2 = await adapter.updateState(KEY, LIMIT, context);
                 expect(state2).toEqual({
                     success: true,
                     attempt: 1,
@@ -271,12 +271,12 @@ export function fixedWindowLimiterTestSuite(
                 } satisfies IRateLimiterAdapterState);
             });
             test("Should return BlockedState when 5 attempts occurs during window time", async () => {
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
 
-                const state = await adapter.updateState(context, KEY, LIMIT);
+                const state = await adapter.updateState(KEY, LIMIT, context);
 
                 expect(state).toEqual({
                     success: false,
@@ -285,13 +285,13 @@ export function fixedWindowLimiterTestSuite(
                 } satisfies IRateLimiterAdapterState);
             });
             test("Should return BlockedState with incremented attempt when 6 attempts occurs during window time", async () => {
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
 
-                const state = await adapter.updateState(context, KEY, LIMIT);
+                const state = await adapter.updateState(KEY, LIMIT, context);
 
                 expect(state).toEqual({
                     success: false,
@@ -300,16 +300,16 @@ export function fixedWindowLimiterTestSuite(
                 } satisfies IRateLimiterAdapterState);
             });
             test("Should return reseted AllowedState when 6 attempts occurs during window time and resetTime is awaited", async () => {
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
 
-                const state1 = await adapter.updateState(context, KEY, LIMIT);
+                const state1 = await adapter.updateState(KEY, LIMIT, context);
                 await delayWithBuffer(state1.resetTime);
 
-                const state2 = await adapter.updateState(context, KEY, LIMIT);
+                const state2 = await adapter.updateState(KEY, LIMIT, context);
                 expect(state2).toEqual({
                     success: true,
                     attempt: 1,
@@ -319,24 +319,24 @@ export function fixedWindowLimiterTestSuite(
         });
         describe("method: reset", () => {
             test("Should return null when reseted in AllowedState", async () => {
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
 
-                await adapter.reset(context, KEY);
-                const state = await adapter.getState(context, KEY);
+                await adapter.reset(KEY, context);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBeNull();
             });
             test("Should return null when reseted in BlockedState", async () => {
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
-                await adapter.updateState(context, KEY, LIMIT);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
+                await adapter.updateState(KEY, LIMIT, context);
 
-                await adapter.reset(context, KEY);
-                const state = await adapter.getState(context, KEY);
+                await adapter.reset(KEY, context);
+                const state = await adapter.getState(KEY, context);
 
                 expect(state).toBeNull();
             });

--- a/src/rate-limiter/implementations/test-utilities/rate-limiter-storage-adapter.test-suite.ts
+++ b/src/rate-limiter/implementations/test-utilities/rate-limiter-storage-adapter.test-suite.ts
@@ -95,10 +95,10 @@ export function rateLimiterStorageAdapterTestSuite(
                     new Date("2026-01-01"),
                 );
 
-                const data = await adapter.transaction(context, async (trx) => {
-                    await trx.upsert(context, key, value, expiration);
-                    return await trx.find(context, key);
-                });
+                const data = await adapter.transaction(async (trx) => {
+                    await trx.upsert(key, value, expiration, context);
+                    return await trx.find(key, context);
+                }, context);
 
                 expect(data).toEqual({
                     state: value,
@@ -112,18 +112,18 @@ export function rateLimiterStorageAdapterTestSuite(
                     new Date("2026-01-01"),
                 );
 
-                const data = await adapter.transaction(context, async (trx) => {
+                const data = await adapter.transaction(async (trx) => {
                     await trx.upsert(
-                        context,
                         "a",
                         "b",
                         TimeSpan.fromMinutes(5).toEndDate(
                             new Date("2026-01-01"),
                         ),
+                        context,
                     );
-                    await trx.upsert(context, key, value, expiration);
-                    return await trx.find(context, key);
-                });
+                    await trx.upsert(key, value, expiration, context);
+                    return await trx.find(key, context);
+                }, context);
 
                 expect(data).toEqual({
                     state: value,
@@ -135,9 +135,9 @@ export function rateLimiterStorageAdapterTestSuite(
             test("Should return null when key doesnt exists", async () => {
                 const noneExistingKey = "a";
 
-                const data = await adapter.transaction(context, async (trx) => {
-                    return await trx.find(context, noneExistingKey);
-                });
+                const data = await adapter.transaction(async (trx) => {
+                    return await trx.find(noneExistingKey, context);
+                }, context);
 
                 expect(data).toBeNull();
             });
@@ -146,7 +146,7 @@ export function rateLimiterStorageAdapterTestSuite(
             test("Should return null when key doesnt exists", async () => {
                 const noneExistingKey = "a";
 
-                const data = await adapter.find(context, noneExistingKey);
+                const data = await adapter.find(noneExistingKey, context);
 
                 expect(data).toBeNull();
             });
@@ -159,11 +159,11 @@ export function rateLimiterStorageAdapterTestSuite(
                     new Date("2026-01-01"),
                 );
 
-                await adapter.transaction(context, async (trx) => {
-                    await trx.upsert(context, key, value, expiration);
-                });
-                await adapter.remove(context, key);
-                const item = await adapter.find(context, key);
+                await adapter.transaction(async (trx) => {
+                    await trx.upsert(key, value, expiration, context);
+                }, context);
+                await adapter.remove(key, context);
+                const item = await adapter.find(key, context);
 
                 expect(item).toBeNull();
             });


### PR DESCRIPTION
- **refactor(rate-limiter): reorder parameters - move context to last position in contracts**
- **refactor(rate-limiter): reorder parameters - move context to last in RateLimiterStorage**
- **refactor(rate-limiter): reorder parameters - move context to last in DatabaseRateLimiterAdapter**
- **refactor(rate-limiter): reorder parameters - move context to last in KyselyRateLimiterStorageAdapter**
- **refactor(rate-limiter): reorder parameters - move context to last in MemoryRateLimiterStorageAdapter**
- **refactor(rate-limiter): reorder parameters - move context to last in MongodbRateLimiterStorageAdapter**
- **refactor(rate-limiter): reorder parameters - move context to last in NoOpRateLimiterAdapter**
- **refactor(rate-limiter): reorder parameters - move context to last in NoOpRateLimiterStorageAdapter**
- **refactor(rate-limiter): reorder parameters - move context to last in RedisRateLimiterAdapter**
- **refactor(rate-limiter): update parameter order in RateLimiter to match new contract**
- **refactor(rate-limiter): update parameter order in factory test**
- **refactor(rate-limiter): update parameter destructuring in withRateLimiterPrefix plugin**
- **refactor(rate-limiter): update parameter order in prefix plugin test**
- **refactor(rate-limiter): update parameter order in fixed window limiter test suite**
- **refactor(rate-limiter): update parameter order in storage adapter test suite**
- **refactor(rate-limiter): update parameter order in MySQL Kysely adapter test**
- **refactor(rate-limiter): update parameter order in Postgres Kysely adapter test**
- **refactor(rate-limiter): update parameter order in SQLite Kysely adapter test**
- **refactor(rate-limiter): update parameter order in memory storage adapter test**
- **refactor(rate-limiter): update parameter order in MongoDB storage adapter test**
