### PR TITLE
chore/enhance code quality

### DIFF
--- a/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.test.ts
+++ b/src/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.test.ts
@@ -1,16 +1,16 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { type ICacheAdapter } from "@/cache/contracts/cache-adapter.contract.js";
+import { type ICacheAdapter } from "@/cache/contracts/_module.js";
 import { NoOpCacheAdapter } from "@/cache/implementations/adapters/_module.js";
 import { withCacheJitter } from "@/cache/implementations/plugins/with-cache-jitter/with-cache-jitter.js";
-import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
+import { NoOpContext } from "@/execution-context/implementations/derivables/execution-context/no-op-context.js";
 import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enhance-factory.js";
 import { useFactory } from "@/middleware/implementations/use-factory/_module.js";
 import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
 import { TimeSpan } from "@/time-span/implementations/_module.js";
 
 describe("function: withCacheJitter", () => {
-    const context = new Context(new Map());
+    const noOpContext = new NoOpContext();
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
 
     afterEach(() => {
@@ -34,14 +34,14 @@ describe("function: withCacheJitter", () => {
             const ttl = TimeSpan.fromMinutes(1);
             const expectedMs = (1 - 0.2 * 0.5) * ttl.toMilliseconds();
 
-            await enhanced.add("myKey", "value", ttl, context);
+            await enhanced.add("myKey", "value", ttl, noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<Parameters<ICacheAdapter["add"]>>(
                 "myKey",
                 "value",
                 TimeSpan.fromMilliseconds(expectedMs),
-                context,
+                noOpContext,
             );
         });
         test("Should not apply jitter when TTL is null", async () => {
@@ -54,10 +54,10 @@ describe("function: withCacheJitter", () => {
                 withCacheJitter({ _mathRandom: mathRandom }),
             );
 
-            await enhanced.add("myKey", "value", null, context);
+            await enhanced.add("myKey", "value", null, noOpContext);
 
             expect(spy).toHaveBeenCalledWith<Parameters<ICacheAdapter["add"]>>(
-                ...["myKey", "value", null, context],
+                ...["myKey", "value", null, noOpContext],
             );
         });
         test("Should use default jitter of 0.2 when not specified", async () => {
@@ -73,13 +73,13 @@ describe("function: withCacheJitter", () => {
             const ttl = TimeSpan.fromMinutes(1);
             const expectedMs = (1 - 0.2 * 0.5) * ttl.toMilliseconds();
 
-            await enhanced.add("myKey", "value", ttl, context);
+            await enhanced.add("myKey", "value", ttl, noOpContext);
 
             expect(spy).toHaveBeenCalledWith<Parameters<ICacheAdapter["add"]>>(
                 "myKey",
                 "value",
                 TimeSpan.fromMilliseconds(expectedMs),
-                context,
+                noOpContext,
             );
         });
     });
@@ -100,14 +100,14 @@ describe("function: withCacheJitter", () => {
             const ttl = TimeSpan.fromMinutes(1);
             const expectedMs = (1 - 0.5 * 0.3) * ttl.toMilliseconds();
 
-            await enhanced.put("myKey", "value", ttl, context);
+            await enhanced.put("myKey", "value", ttl, noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<Parameters<ICacheAdapter["put"]>>(
                 "myKey",
                 "value",
                 TimeSpan.fromMilliseconds(expectedMs),
-                context,
+                noOpContext,
             );
         });
         test("Should not apply jitter when TTL is null", async () => {
@@ -120,13 +120,13 @@ describe("function: withCacheJitter", () => {
                 withCacheJitter({ _mathRandom: mathRandom }),
             );
 
-            await enhanced.put("myKey", "value", null, context);
+            await enhanced.put("myKey", "value", null, noOpContext);
 
             expect(spy).toHaveBeenCalledWith<Parameters<ICacheAdapter["put"]>>(
                 "myKey",
                 "value",
                 null,
-                context,
+                noOpContext,
             );
         });
     });

--- a/src/cache/implementations/plugins/with-cache-prefix/with-cache-prefix.test.ts
+++ b/src/cache/implementations/plugins/with-cache-prefix/with-cache-prefix.test.ts
@@ -1,16 +1,16 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { type ICacheAdapter } from "@/cache/contracts/cache-adapter.contract.js";
+import { type ICacheAdapter } from "@/cache/contracts/_module.js";
 import { NoOpCacheAdapter } from "@/cache/implementations/adapters/_module.js";
 import { withCachePrefix } from "@/cache/implementations/plugins/with-cache-prefix/with-cache-prefix.js";
-import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
+import { NoOpContext } from "@/execution-context/implementations/derivables/execution-context/no-op-context.js";
 import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enhance-factory.js";
 import { useFactory } from "@/middleware/implementations/use-factory/_module.js";
 import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
 import { TimeSpan } from "@/time-span/implementations/_module.js";
 
 describe("function: withCachePrefix", () => {
-    const context = new Context(new Map());
+    const noOpContext = new NoOpContext();
     const prefix = "test-prefix:";
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
 
@@ -29,7 +29,7 @@ describe("function: withCachePrefix", () => {
                 "myKey",
                 "value",
                 TimeSpan.fromMinutes(5),
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -37,7 +37,7 @@ describe("function: withCachePrefix", () => {
                 `${prefix}myKey`,
                 "value",
                 TimeSpan.fromMinutes(5),
-                context,
+                noOpContext,
             );
         });
     });
@@ -48,12 +48,12 @@ describe("function: withCachePrefix", () => {
 
             const enhanced = withPlugin(adapter, withCachePrefix(prefix));
 
-            await enhanced.get("myKey", context);
+            await enhanced.get("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<Parameters<ICacheAdapter["get"]>>(
                 `${prefix}myKey`,
-                context,
+                noOpContext,
             );
         });
     });
@@ -64,12 +64,12 @@ describe("function: withCachePrefix", () => {
 
             const enhanced = withPlugin(adapter, withCachePrefix(prefix));
 
-            await enhanced.getAndRemove("myKey", context);
+            await enhanced.getAndRemove("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ICacheAdapter["getAndRemove"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
     describe("method: increment", () => {
@@ -79,12 +79,12 @@ describe("function: withCachePrefix", () => {
 
             const enhanced = withPlugin(adapter, withCachePrefix(prefix));
 
-            await enhanced.increment("myKey", 5, context);
+            await enhanced.increment("myKey", 5, noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ICacheAdapter["increment"]>
-            >(`${prefix}myKey`, 5, context);
+            >(`${prefix}myKey`, 5, noOpContext);
         });
     });
     describe("method: put", () => {
@@ -98,7 +98,7 @@ describe("function: withCachePrefix", () => {
                 "myKey",
                 "value",
                 TimeSpan.fromMinutes(5),
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -106,7 +106,7 @@ describe("function: withCachePrefix", () => {
                 `${prefix}myKey`,
                 "value",
                 TimeSpan.fromMinutes(5),
-                context,
+                noOpContext,
             );
         });
     });
@@ -117,12 +117,12 @@ describe("function: withCachePrefix", () => {
 
             const enhanced = withPlugin(adapter, withCachePrefix(prefix));
 
-            await enhanced.removeByKeyPrefix("myKey", context);
+            await enhanced.removeByKeyPrefix("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ICacheAdapter["removeByKeyPrefix"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
     describe("method: removeMany", () => {
@@ -132,12 +132,12 @@ describe("function: withCachePrefix", () => {
 
             const enhanced = withPlugin(adapter, withCachePrefix(prefix));
 
-            await enhanced.removeMany(["key1", "key2"], context);
+            await enhanced.removeMany(["key1", "key2"], noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ICacheAdapter["removeMany"]>
-            >([`${prefix}key1`, `${prefix}key2`], context);
+            >([`${prefix}key1`, `${prefix}key2`], noOpContext);
         });
     });
     describe("method: update", () => {
@@ -147,12 +147,12 @@ describe("function: withCachePrefix", () => {
 
             const enhanced = withPlugin(adapter, withCachePrefix(prefix));
 
-            await enhanced.update("myKey", "newValue", context);
+            await enhanced.update("myKey", "newValue", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ICacheAdapter["update"]>
-            >(`${prefix}myKey`, "newValue", context);
+            >(`${prefix}myKey`, "newValue", noOpContext);
         });
     });
 });

--- a/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.test.ts
+++ b/src/cache/implementations/plugins/with-cache-schema/with-cache-schema.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 
-import { type ICacheAdapter } from "@/cache/contracts/cache-adapter.contract.js";
+import { type ICacheAdapter } from "@/cache/contracts/_module.js";
 import { NoOpCacheAdapter } from "@/cache/implementations/adapters/_module.js";
 import { withCacheSchema } from "@/cache/implementations/plugins/with-cache-schema/with-cache-schema.js";
-import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
+import { NoOpContext } from "@/execution-context/implementations/derivables/execution-context/no-op-context.js";
 import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enhance-factory.js";
 import { useFactory } from "@/middleware/implementations/use-factory/_module.js";
 import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
 import { TimeSpan } from "@/time-span/implementations/_module.js";
 
 describe("function: withCacheSchema", () => {
-    const context = new Context(new Map());
+    const noOpContext = new NoOpContext();
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
     const passingSchema = z.string();
     const failingSchema = z.string().min(100);
@@ -29,7 +29,7 @@ describe("function: withCacheSchema", () => {
                 "myKey",
                 "validValue",
                 TimeSpan.fromMinutes(5),
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -37,7 +37,7 @@ describe("function: withCacheSchema", () => {
                 "myKey",
                 "validValue",
                 TimeSpan.fromMinutes(5),
-                context,
+                noOpContext,
             );
         });
         test("Should throw when input validation fails", async () => {
@@ -52,7 +52,7 @@ describe("function: withCacheSchema", () => {
                     "myKey",
                     "invalidValue",
                     TimeSpan.fromMinutes(5),
-                    context,
+                    noOpContext,
                 ),
             ).rejects.toThrow();
         });
@@ -71,7 +71,7 @@ describe("function: withCacheSchema", () => {
                 "myKey",
                 "validValue",
                 TimeSpan.fromMinutes(5),
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -90,7 +90,7 @@ describe("function: withCacheSchema", () => {
                 "myKey",
                 "validValue",
                 TimeSpan.fromMinutes(5),
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -98,7 +98,7 @@ describe("function: withCacheSchema", () => {
                 "myKey",
                 "validValue",
                 TimeSpan.fromMinutes(5),
-                context,
+                noOpContext,
             );
         });
         test("Should throw when input validation fails", async () => {
@@ -113,7 +113,7 @@ describe("function: withCacheSchema", () => {
                     "myKey",
                     "invalidValue",
                     TimeSpan.fromMinutes(5),
-                    context,
+                    noOpContext,
                 ),
             ).rejects.toThrow();
         });
@@ -132,7 +132,7 @@ describe("function: withCacheSchema", () => {
                 "myKey",
                 "validValue",
                 TimeSpan.fromMinutes(5),
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -147,12 +147,12 @@ describe("function: withCacheSchema", () => {
                 withCacheSchema({ schema: passingSchema }),
             );
 
-            await enhanced.update("myKey", "validValue", context);
+            await enhanced.update("myKey", "validValue", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ICacheAdapter["update"]>
-            >("myKey", "validValue", context);
+            >("myKey", "validValue", noOpContext);
         });
         test("Should throw when input validation fails", async () => {
             const adapter = new NoOpCacheAdapter<string>();
@@ -162,7 +162,7 @@ describe("function: withCacheSchema", () => {
             );
 
             await expect(
-                enhanced.update("myKey", "invalidValue", context),
+                enhanced.update("myKey", "invalidValue", noOpContext),
             ).rejects.toThrow();
         });
         test("Should still validate input when shouldValidateOutput is false", async () => {
@@ -176,7 +176,7 @@ describe("function: withCacheSchema", () => {
                 }),
             );
 
-            await enhanced.update("myKey", "validValue", context);
+            await enhanced.update("myKey", "validValue", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
         });
@@ -190,7 +190,7 @@ describe("function: withCacheSchema", () => {
                 withCacheSchema({ schema: passingSchema }),
             );
 
-            const result = await enhanced.get("myKey", context);
+            const result = await enhanced.get("myKey", noOpContext);
 
             expect(result).toBe("storedValue");
         });
@@ -202,7 +202,7 @@ describe("function: withCacheSchema", () => {
                 withCacheSchema({ schema: failingSchema }),
             );
 
-            await expect(enhanced.get("myKey", context)).rejects.toThrow();
+            await expect(enhanced.get("myKey", noOpContext)).rejects.toThrow();
         });
         test("Should pass null through without validation when key is not found", async () => {
             const adapter = new NoOpCacheAdapter<string>();
@@ -212,7 +212,7 @@ describe("function: withCacheSchema", () => {
                 withCacheSchema({ schema: passingSchema }),
             );
 
-            const result = await enhanced.get("myKey", context);
+            const result = await enhanced.get("myKey", noOpContext);
 
             expect(result).toBeNull();
         });
@@ -227,7 +227,7 @@ describe("function: withCacheSchema", () => {
                 }),
             );
 
-            const result = await enhanced.get("myKey", context);
+            const result = await enhanced.get("myKey", noOpContext);
 
             expect(result).toBe("someValue");
         });
@@ -242,7 +242,7 @@ describe("function: withCacheSchema", () => {
                 withCacheSchema({ schema: passingSchema }),
             );
 
-            const result = await enhanced.getAndRemove("myKey", context);
+            const result = await enhanced.getAndRemove("myKey", noOpContext);
 
             expect(result).toBe("storedValue");
         });
@@ -255,7 +255,7 @@ describe("function: withCacheSchema", () => {
             );
 
             await expect(
-                enhanced.getAndRemove("myKey", context),
+                enhanced.getAndRemove("myKey", noOpContext),
             ).rejects.toThrow();
         });
         test("Should pass null through without validation when key is not found", async () => {
@@ -266,7 +266,7 @@ describe("function: withCacheSchema", () => {
                 withCacheSchema({ schema: passingSchema }),
             );
 
-            const result = await enhanced.getAndRemove("myKey", context);
+            const result = await enhanced.getAndRemove("myKey", noOpContext);
 
             expect(result).toBeNull();
         });
@@ -281,7 +281,7 @@ describe("function: withCacheSchema", () => {
                 }),
             );
 
-            const result = await enhanced.getAndRemove("myKey", context);
+            const result = await enhanced.getAndRemove("myKey", noOpContext);
 
             expect(result).toBe("someValue");
         });

--- a/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.test.ts
+++ b/src/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { NoOpCacheAdapter } from "@/cache/implementations/adapters/_module.js";
 import { withCacheWriteLock } from "@/cache/implementations/plugins/with-cache-write-lock/with-cache-write-lock.js";
-import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
+import { NoOpContext } from "@/execution-context/implementations/derivables/execution-context/no-op-context.js";
 import { NoOpLockAdapter } from "@/lock/implementations/adapters/no-op-lock-adapter/no-op-lock-adapter.js";
 import { LockFactory } from "@/lock/implementations/derivables/lock-factory/lock-factory.js";
 import { Lock } from "@/lock/implementations/derivables/lock-factory/lock.js";
@@ -12,7 +12,7 @@ import { withPluginFactory } from "@/middleware/implementations/with-plugin-fact
 import { TimeSpan } from "@/time-span/implementations/_module.js";
 
 describe("function: withCacheWriteLock", () => {
-    const context = new Context(new Map());
+    const noOpContext = new NoOpContext();
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
 
     afterEach(() => {
@@ -41,7 +41,7 @@ describe("function: withCacheWriteLock", () => {
                 "myKey",
                 "value",
                 TimeSpan.fromMinutes(5),
-                context,
+                noOpContext,
             );
             console.log("2.");
 
@@ -68,7 +68,7 @@ describe("function: withCacheWriteLock", () => {
                 "myKey",
                 "value",
                 TimeSpan.fromMinutes(5),
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -90,7 +90,7 @@ describe("function: withCacheWriteLock", () => {
                 withCacheWriteLock({ lockFactory }),
             );
 
-            await enhanced.update("myKey", "newValue", context);
+            await enhanced.update("myKey", "newValue", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -111,7 +111,7 @@ describe("function: withCacheWriteLock", () => {
                 withCacheWriteLock({ lockFactory }),
             );
 
-            await enhanced.increment("myKey", 5, context);
+            await enhanced.increment("myKey", 5, noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -132,7 +132,7 @@ describe("function: withCacheWriteLock", () => {
                 withCacheWriteLock({ lockFactory }),
             );
 
-            await enhanced.getAndRemove("myKey", context);
+            await enhanced.getAndRemove("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -149,7 +149,7 @@ describe("function: withCacheWriteLock", () => {
                 withCacheWriteLock({ lockFactory }),
             );
 
-            const result = await enhanced.getAndRemove("myKey", context);
+            const result = await enhanced.getAndRemove("myKey", noOpContext);
 
             expect(result).toBe("storedValue");
         });
@@ -168,7 +168,7 @@ describe("function: withCacheWriteLock", () => {
                 withCacheWriteLock({ lockFactory }),
             );
 
-            await enhanced.removeMany(["key1", "key2", "key3"], context);
+            await enhanced.removeMany(["key1", "key2", "key3"], noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledWith("key1");
@@ -191,7 +191,7 @@ describe("function: withCacheWriteLock", () => {
 
             await enhanced.removeMany(
                 ["key1", "key2", "key1", "key3"],
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -212,7 +212,10 @@ describe("function: withCacheWriteLock", () => {
                 withCacheWriteLock({ lockFactory }),
             );
 
-            const result = await enhanced.removeMany(["key1", "key2"], context);
+            const result = await enhanced.removeMany(
+                ["key1", "key2"],
+                noOpContext,
+            );
 
             expect(result).toBe(true);
         });
@@ -238,13 +241,13 @@ describe("function: withCacheWriteLock", () => {
                 "myKey",
                 "value",
                 TimeSpan.fromMinutes(5),
-                context,
+                noOpContext,
             );
             expect(createSpy).toHaveBeenCalledWith("myKey");
             expect(runSpy).toHaveBeenCalledTimes(1);
 
             vi.clearAllMocks();
-            await enhanced.get("myKey", context);
+            await enhanced.get("myKey", noOpContext);
             expect(createSpy).not.toHaveBeenCalled();
             expect(runSpy).not.toHaveBeenCalled();
             expect(getSpy).toHaveBeenCalledOnce();

--- a/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker.ts
+++ b/src/circuit-breaker/implementations/derivables/circuit-breaker-factory/circuit-breaker.ts
@@ -110,29 +110,29 @@ export class CircuitBreaker implements ICircuitBreaker {
     }
 
     async getState(): Promise<CircuitBreakerState> {
-        return this.adapter.getState(this._key.toString(), this.context);
+        return this.adapter.getState(this._key, this.context);
     }
 
     private async trackFailure(): Promise<void> {
         if (this.enableAsyncTracking) {
             callInvokable(
                 this.waitUntil,
-                this.adapter.trackFailure(this._key.toString(), this.context),
+                this.adapter.trackFailure(this._key, this.context),
             );
             return;
         }
-        await this.adapter.trackFailure(this._key.toString(), this.context);
+        await this.adapter.trackFailure(this._key, this.context);
     }
 
     private async trackSuccess(): Promise<void> {
         if (this.enableAsyncTracking) {
             callInvokable(
                 this.waitUntil,
-                this.adapter.trackSuccess(this._key.toString(), this.context),
+                this.adapter.trackSuccess(this._key, this.context),
             );
             return;
         }
-        await this.adapter.trackSuccess(this._key.toString(), this.context);
+        await this.adapter.trackSuccess(this._key, this.context);
     }
 
     private async trackErrorWrapper<TValue = void>(
@@ -191,7 +191,7 @@ export class CircuitBreaker implements ICircuitBreaker {
 
     private async guard(): Promise<void> {
         const transition = await this.adapter.updateState(
-            this._key.toString(),
+            this._key,
             this.context,
         );
 
@@ -219,10 +219,10 @@ export class CircuitBreaker implements ICircuitBreaker {
     }
 
     async reset(): Promise<void> {
-        await this.adapter.reset(this._key.toString(), this.context);
+        await this.adapter.reset(this._key, this.context);
     }
 
     async isolate(): Promise<void> {
-        await this.adapter.isolate(this._key.toString(), this.context);
+        await this.adapter.isolate(this._key, this.context);
     }
 }

--- a/src/circuit-breaker/implementations/plugins/with-circuit-breaker-prefix/with-circuit-breaker-prefix.test.ts
+++ b/src/circuit-breaker/implementations/plugins/with-circuit-breaker-prefix/with-circuit-breaker-prefix.test.ts
@@ -3,13 +3,13 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { type ICircuitBreakerAdapter } from "@/circuit-breaker/contracts/_module.js";
 import { NoOpCircuitBreakerAdapter } from "@/circuit-breaker/implementations/adapters/_module.js";
 import { withCircuitBreakerPrefix } from "@/circuit-breaker/implementations/plugins/with-circuit-breaker-prefix/with-circuit-breaker-prefix.js";
-import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
+import { NoOpContext } from "@/execution-context/implementations/derivables/execution-context/no-op-context.js";
 import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enhance-factory.js";
 import { useFactory } from "@/middleware/implementations/use-factory/_module.js";
 import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
 
 describe("function: withCircuitBreakerPrefix", () => {
-    const context = new Context(new Map());
+    const noOpContext = new NoOpContext();
     const prefix = "test-prefix:";
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
 
@@ -27,12 +27,12 @@ describe("function: withCircuitBreakerPrefix", () => {
                 withCircuitBreakerPrefix(prefix),
             );
 
-            await enhanced.getState("myKey", context);
+            await enhanced.getState("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ICircuitBreakerAdapter["getState"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
     describe("method: isolate", () => {
@@ -45,12 +45,12 @@ describe("function: withCircuitBreakerPrefix", () => {
                 withCircuitBreakerPrefix(prefix),
             );
 
-            await enhanced.isolate("myKey", context);
+            await enhanced.isolate("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ICircuitBreakerAdapter["isolate"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
     describe("method: reset", () => {
@@ -63,12 +63,12 @@ describe("function: withCircuitBreakerPrefix", () => {
                 withCircuitBreakerPrefix(prefix),
             );
 
-            await enhanced.reset("myKey", context);
+            await enhanced.reset("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ICircuitBreakerAdapter["reset"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
     describe("method: trackFailure", () => {
@@ -81,12 +81,12 @@ describe("function: withCircuitBreakerPrefix", () => {
                 withCircuitBreakerPrefix(prefix),
             );
 
-            await enhanced.trackFailure("myKey", context);
+            await enhanced.trackFailure("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ICircuitBreakerAdapter["trackFailure"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
     describe("method: trackSuccess", () => {
@@ -99,12 +99,12 @@ describe("function: withCircuitBreakerPrefix", () => {
                 withCircuitBreakerPrefix(prefix),
             );
 
-            await enhanced.trackSuccess("myKey", context);
+            await enhanced.trackSuccess("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ICircuitBreakerAdapter["trackSuccess"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
     describe("method: updateState", () => {
@@ -117,12 +117,12 @@ describe("function: withCircuitBreakerPrefix", () => {
                 withCircuitBreakerPrefix(prefix),
             );
 
-            await enhanced.updateState("myKey", context);
+            await enhanced.updateState("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ICircuitBreakerAdapter["updateState"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
 });

--- a/src/event-bus/implementations/plugins/with-event-bus-prefix/with-event-bus-prefix.test.ts
+++ b/src/event-bus/implementations/plugins/with-event-bus-prefix/with-event-bus-prefix.test.ts
@@ -3,13 +3,13 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { type IEventBusAdapter } from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
 import { withEventBusPrefix } from "@/event-bus/implementations/plugins/with-event-bus-prefix/with-event-bus-prefix.js";
-import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
+import { NoOpContext } from "@/execution-context/implementations/derivables/execution-context/no-op-context.js";
 import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enhance-factory.js";
 import { useFactory } from "@/middleware/implementations/use-factory/_module.js";
 import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
 
 describe("function: withEventBusPrefix", () => {
-    const context = new Context(new Map());
+    const noOpContext = new NoOpContext();
     const prefix = "test-prefix:";
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
 
@@ -24,7 +24,11 @@ describe("function: withEventBusPrefix", () => {
 
             const enhanced = withPlugin(adapter, withEventBusPrefix(prefix));
 
-            await enhanced.dispatch("user.created", { userId: "123" }, context);
+            await enhanced.dispatch(
+                "user.created",
+                { userId: "123" },
+                noOpContext,
+            );
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
@@ -34,7 +38,7 @@ describe("function: withEventBusPrefix", () => {
                 {
                     userId: "123",
                 },
-                context,
+                noOpContext,
             );
         });
     });
@@ -46,12 +50,12 @@ describe("function: withEventBusPrefix", () => {
 
             const enhanced = withPlugin(adapter, withEventBusPrefix(prefix));
 
-            await enhanced.addListener("user.created", listener, context);
+            await enhanced.addListener("user.created", listener, noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<IEventBusAdapter["addListener"]>
-            >(`${prefix}user.created`, listener, context);
+            >(`${prefix}user.created`, listener, noOpContext);
         });
     });
     describe("method: removeListener", () => {
@@ -62,12 +66,16 @@ describe("function: withEventBusPrefix", () => {
 
             const enhanced = withPlugin(adapter, withEventBusPrefix(prefix));
 
-            await enhanced.removeListener("user.created", listener, context);
+            await enhanced.removeListener(
+                "user.created",
+                listener,
+                noOpContext,
+            );
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<IEventBusAdapter["removeListener"]>
-            >(`${prefix}user.created`, listener, context);
+            >(`${prefix}user.created`, listener, noOpContext);
         });
     });
 });

--- a/src/event-bus/implementations/plugins/with-event-bus-schema/with-event-bus-schema.test.ts
+++ b/src/event-bus/implementations/plugins/with-event-bus-schema/with-event-bus-schema.test.ts
@@ -4,13 +4,13 @@ import { z } from "zod";
 import { type IEventBusAdapter } from "@/event-bus/contracts/_module.js";
 import { NoOpEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
 import { withEventBusSchema } from "@/event-bus/implementations/plugins/with-event-bus-schema/with-event-bus-schema.js";
-import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
+import { NoOpContext } from "@/execution-context/implementations/derivables/execution-context/no-op-context.js";
 import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enhance-factory.js";
 import { useFactory } from "@/middleware/implementations/use-factory/_module.js";
 import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
 
 describe("function: withEventBusSchema", () => {
-    const context = new Context(new Map());
+    const noOpContext = new NoOpContext();
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
     const adapter = new NoOpEventBusAdapter();
 
@@ -33,7 +33,7 @@ describe("function: withEventBusSchema", () => {
                 {
                     userId: "123",
                 },
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -44,7 +44,7 @@ describe("function: withEventBusSchema", () => {
                 {
                     userId: "123",
                 },
-                context,
+                noOpContext,
             );
         });
         test("Should throw when dispatch event data validation fails", async () => {
@@ -65,7 +65,7 @@ describe("function: withEventBusSchema", () => {
                     {
                         userId: 123,
                     },
-                    context,
+                    noOpContext,
                 ),
             ).rejects.toThrow();
         });
@@ -87,7 +87,7 @@ describe("function: withEventBusSchema", () => {
                 {
                     anyData: "anything",
                 },
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -98,7 +98,7 @@ describe("function: withEventBusSchema", () => {
                 {
                     anyData: "anything",
                 },
-                context,
+                noOpContext,
             );
         });
         test("Should still validate dispatch when shouldValidateListeners is false", async () => {
@@ -120,7 +120,7 @@ describe("function: withEventBusSchema", () => {
                 {
                     userId: "123",
                 },
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -141,7 +141,7 @@ describe("function: withEventBusSchema", () => {
                 }),
             );
 
-            await enhanced.addListener("user.created", listener, context);
+            await enhanced.addListener("user.created", listener, noOpContext);
 
             expect(addListenerSpy).toHaveBeenCalledOnce();
             const wrappedListener = addListenerSpy.mock.calls[0]?.[1];
@@ -167,7 +167,7 @@ describe("function: withEventBusSchema", () => {
                 }),
             );
 
-            await enhanced.addListener("user.created", listener, context);
+            await enhanced.addListener("user.created", listener, noOpContext);
 
             expect(addListenerSpy).toHaveBeenCalledOnce();
             const wrappedListener = addListenerSpy.mock.calls[0]?.[1];
@@ -190,12 +190,12 @@ describe("function: withEventBusSchema", () => {
                 }),
             );
 
-            await enhanced.addListener("unknown.event", listener, context);
+            await enhanced.addListener("unknown.event", listener, noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<IEventBusAdapter["addListener"]>
-            >("unknown.event", listener, context);
+            >("unknown.event", listener, noOpContext);
         });
         test("Should skip listener wrapping when shouldValidateListeners is false", async () => {
             const spy = vi.spyOn(adapter, "addListener");
@@ -212,12 +212,12 @@ describe("function: withEventBusSchema", () => {
                 }),
             );
 
-            await enhanced.addListener("user.created", listener, context);
+            await enhanced.addListener("user.created", listener, noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<IEventBusAdapter["addListener"]>
-            >("user.created", listener, context);
+            >("user.created", listener, noOpContext);
         });
     });
 });

--- a/src/event-bus/implementations/plugins/with-listener-tracking/with-listener-tracking.test.ts
+++ b/src/event-bus/implementations/plugins/with-listener-tracking/with-listener-tracking.test.ts
@@ -3,14 +3,14 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { type IEventBusAdapter } from "@/event-bus/contracts/_module.js";
 import { MemoryEventBusAdapter } from "@/event-bus/implementations/adapters/_module.js";
 import { withListenerTracking } from "@/event-bus/implementations/plugins/with-listener-tracking/with-listener-tracking.js";
-import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
+import { NoOpContext } from "@/execution-context/implementations/derivables/execution-context/no-op-context.js";
 import { type PluginFn } from "@/middleware/contracts/_module.js";
 import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enhance-factory.js";
 import { useFactory } from "@/middleware/implementations/use-factory/_module.js";
 import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
 
 describe("function: withListenerTracking", () => {
-    const context = new Context(new Map());
+    const noOpContext = new NoOpContext();
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
 
     afterEach(() => {
@@ -35,13 +35,17 @@ describe("function: withListenerTracking", () => {
         const listener = vi.fn();
         const payload = { value: 42 };
 
-        await enhancedAdapter.addListener("test.event", listener, context);
-        await enhancedAdapter.dispatch("test.event", payload, context);
+        await enhancedAdapter.addListener("test.event", listener, noOpContext);
+        await enhancedAdapter.dispatch("test.event", payload, noOpContext);
         expect(listener).toHaveBeenCalledOnce();
         expect(listener).toHaveBeenCalledWith(payload);
 
-        await enhancedAdapter.removeListener("test.event", listener, context);
-        await enhancedAdapter.dispatch("test.event", payload, context);
+        await enhancedAdapter.removeListener(
+            "test.event",
+            listener,
+            noOpContext,
+        );
+        await enhancedAdapter.dispatch("test.event", payload, noOpContext);
         expect(listener).toHaveBeenCalledTimes(1);
     });
     test("Should pass through removeListener unchanged for a listener that was never added", async () => {
@@ -59,9 +63,13 @@ describe("function: withListenerTracking", () => {
 
         const listener = vi.fn();
 
-        await enhancedAdapter.removeListener("ghost.event", listener, context);
+        await enhancedAdapter.removeListener(
+            "ghost.event",
+            listener,
+            noOpContext,
+        );
 
-        await enhancedAdapter.dispatch("ghost.event", {}, context);
+        await enhancedAdapter.dispatch("ghost.event", {}, noOpContext);
         expect(listener).not.toHaveBeenCalled();
     });
     test("Should independently track multiple distinct listeners for the same event", async () => {
@@ -78,20 +86,28 @@ describe("function: withListenerTracking", () => {
         const listenerB = vi.fn();
         const payload = { data: true };
 
-        await enhancedAdapter.addListener("shared.event", listenerA, context);
-        await enhancedAdapter.addListener("shared.event", listenerB, context);
+        await enhancedAdapter.addListener(
+            "shared.event",
+            listenerA,
+            noOpContext,
+        );
+        await enhancedAdapter.addListener(
+            "shared.event",
+            listenerB,
+            noOpContext,
+        );
 
-        await enhancedAdapter.dispatch("shared.event", payload, context);
+        await enhancedAdapter.dispatch("shared.event", payload, noOpContext);
         expect(listenerA).toHaveBeenCalledOnce();
         expect(listenerB).toHaveBeenCalledOnce();
 
         await enhancedAdapter.removeListener(
             "shared.event",
             listenerA,
-            context,
+            noOpContext,
         );
 
-        await enhancedAdapter.dispatch("shared.event", payload, context);
+        await enhancedAdapter.dispatch("shared.event", payload, noOpContext);
         expect(listenerA).toHaveBeenCalledTimes(1);
         expect(listenerB).toHaveBeenCalledTimes(2);
     });
@@ -107,29 +123,37 @@ describe("function: withListenerTracking", () => {
 
         const listener = vi.fn();
 
-        await enhancedAdapter.addListener("event.alpha", listener, context);
-        await enhancedAdapter.addListener("event.beta", listener, context);
+        await enhancedAdapter.addListener("event.alpha", listener, noOpContext);
+        await enhancedAdapter.addListener("event.beta", listener, noOpContext);
 
         await enhancedAdapter.dispatch(
             "event.alpha",
             {
                 key: "alpha",
             },
-            context,
+            noOpContext,
         );
         expect(listener).toHaveBeenCalledTimes(1);
 
-        await enhancedAdapter.removeListener("event.alpha", listener, context);
+        await enhancedAdapter.removeListener(
+            "event.alpha",
+            listener,
+            noOpContext,
+        );
         await enhancedAdapter.dispatch(
             "event.alpha",
             {
                 key: "alpha",
             },
-            context,
+            noOpContext,
         );
         expect(listener).toHaveBeenCalledTimes(1);
 
-        await enhancedAdapter.dispatch("event.beta", { key: "beta" }, context);
+        await enhancedAdapter.dispatch(
+            "event.beta",
+            { key: "beta" },
+            noOpContext,
+        );
         expect(listener).toHaveBeenCalledTimes(2);
     });
     test("Should chain multiple withListenerTracking calls correctly", async () => {
@@ -143,12 +167,16 @@ describe("function: withListenerTracking", () => {
         const listener = vi.fn();
         const payload = { value: true };
 
-        await enhancedAdapter.addListener("chain.event", listener, context);
-        await enhancedAdapter.dispatch("chain.event", payload, context);
+        await enhancedAdapter.addListener("chain.event", listener, noOpContext);
+        await enhancedAdapter.dispatch("chain.event", payload, noOpContext);
         expect(listener).toHaveBeenCalledOnce();
 
-        await enhancedAdapter.removeListener("chain.event", listener, context);
-        await enhancedAdapter.dispatch("chain.event", payload, context);
+        await enhancedAdapter.removeListener(
+            "chain.event",
+            listener,
+            noOpContext,
+        );
+        await enhancedAdapter.dispatch("chain.event", payload, noOpContext);
         expect(listener).toHaveBeenCalledTimes(1);
     });
     test("Should chain multiple withListenerTracking calls with multiple distinct listeners", async () => {
@@ -162,20 +190,28 @@ describe("function: withListenerTracking", () => {
         const listenerA = vi.fn();
         const listenerB = vi.fn();
 
-        await enhancedAdapter.addListener("multi.listener", listenerA, context);
-        await enhancedAdapter.addListener("multi.listener", listenerB, context);
+        await enhancedAdapter.addListener(
+            "multi.listener",
+            listenerA,
+            noOpContext,
+        );
+        await enhancedAdapter.addListener(
+            "multi.listener",
+            listenerB,
+            noOpContext,
+        );
 
-        await enhancedAdapter.dispatch("multi.listener", { n: 1 }, context);
+        await enhancedAdapter.dispatch("multi.listener", { n: 1 }, noOpContext);
         expect(listenerA).toHaveBeenCalledOnce();
         expect(listenerB).toHaveBeenCalledOnce();
 
         await enhancedAdapter.removeListener(
             "multi.listener",
             listenerA,
-            context,
+            noOpContext,
         );
 
-        await enhancedAdapter.dispatch("multi.listener", { n: 2 }, context);
+        await enhancedAdapter.dispatch("multi.listener", { n: 2 }, noOpContext);
         expect(listenerA).toHaveBeenCalledTimes(1);
         expect(listenerB).toHaveBeenCalledTimes(2);
     });
@@ -192,14 +228,22 @@ describe("function: withListenerTracking", () => {
         const listener = vi.fn();
         const payload = { id: 1 };
 
-        await enhancedAdapter.addListener("test.event", listener, context);
-        await enhancedAdapter.dispatch("test.event", payload, context);
+        await enhancedAdapter.addListener("test.event", listener, noOpContext);
+        await enhancedAdapter.dispatch("test.event", payload, noOpContext);
         expect(listener).toHaveBeenCalledOnce();
 
-        await enhancedAdapter.removeListener("test.event", listener, context);
-        await enhancedAdapter.removeListener("test.event", listener, context);
+        await enhancedAdapter.removeListener(
+            "test.event",
+            listener,
+            noOpContext,
+        );
+        await enhancedAdapter.removeListener(
+            "test.event",
+            listener,
+            noOpContext,
+        );
 
-        await enhancedAdapter.dispatch("test.event", payload, context);
+        await enhancedAdapter.dispatch("test.event", payload, noOpContext);
         expect(listener).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/file-storage/implementations/plugins/with-file-storage-lock/with-file-storage-lock.test.ts
+++ b/src/file-storage/implementations/plugins/with-file-storage-lock/with-file-storage-lock.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
+import { NoOpContext } from "@/execution-context/implementations/derivables/execution-context/no-op-context.js";
 import { NoOpFileStorageAdapter } from "@/file-storage/implementations/adapters/no-op-file-storage-adapter/_module.js";
 import { withFileStorageLock } from "@/file-storage/implementations/plugins/with-file-storage-lock/with-file-storage-lock.js";
 import { NoOpLockAdapter } from "@/lock/implementations/adapters/no-op-lock-adapter/no-op-lock-adapter.js";
@@ -11,7 +11,7 @@ import { useFactory } from "@/middleware/implementations/use-factory/_module.js"
 import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
 
 describe("function: withFileStorageLock", () => {
-    const context = new Context(new Map());
+    const noOpContext = new NoOpContext();
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
 
     afterEach(() => {
@@ -36,7 +36,7 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.getPublicUrl("myKey", context);
+                await enhanced.getPublicUrl("myKey", noOpContext);
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -55,7 +55,10 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                const result = await enhanced.getPublicUrl("myKey", context);
+                const result = await enhanced.getPublicUrl(
+                    "myKey",
+                    noOpContext,
+                );
 
                 expect(result).toBe("https://example.com/file");
             });
@@ -74,7 +77,7 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.exists("myKey", context);
+                await enhanced.exists("myKey", noOpContext);
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -95,7 +98,7 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.getStream("myKey", context);
+                await enhanced.getStream("myKey", noOpContext);
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -116,7 +119,7 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.getBytes("myKey", context);
+                await enhanced.getBytes("myKey", noOpContext);
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -137,7 +140,7 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.getMetaData("myKey", context);
+                await enhanced.getMetaData("myKey", noOpContext);
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("myKey");
@@ -165,7 +168,7 @@ describe("function: withFileStorageLock", () => {
                         contentType: null,
                         contentDisposition: null,
                     },
-                    context,
+                    noOpContext,
                 );
 
                 expect(spy).toHaveBeenCalledOnce();
@@ -193,7 +196,7 @@ describe("function: withFileStorageLock", () => {
                         expirationInSeconds: 3600,
                         contentType: null,
                     },
-                    context,
+                    noOpContext,
                 );
 
                 expect(spy).toHaveBeenCalledOnce();
@@ -228,7 +231,7 @@ describe("function: withFileStorageLock", () => {
                         contentDisposition: null,
                         cacheControl: null,
                     },
-                    context,
+                    noOpContext,
                 );
 
                 expect(spy).toHaveBeenCalledOnce();
@@ -261,7 +264,7 @@ describe("function: withFileStorageLock", () => {
                         contentDisposition: null,
                         cacheControl: null,
                     },
-                    context,
+                    noOpContext,
                 );
 
                 expect(spy).toHaveBeenCalledOnce();
@@ -294,7 +297,7 @@ describe("function: withFileStorageLock", () => {
                         contentDisposition: null,
                         cacheControl: null,
                     },
-                    context,
+                    noOpContext,
                 );
 
                 expect(spy).toHaveBeenCalledOnce();
@@ -327,7 +330,7 @@ describe("function: withFileStorageLock", () => {
                         contentDisposition: null,
                         cacheControl: null,
                     },
-                    context,
+                    noOpContext,
                 );
 
                 expect(spy).toHaveBeenCalledOnce();
@@ -360,7 +363,7 @@ describe("function: withFileStorageLock", () => {
                         contentDisposition: null,
                         cacheControl: null,
                     },
-                    context,
+                    noOpContext,
                 );
 
                 expect(spy).toHaveBeenCalledOnce();
@@ -393,7 +396,7 @@ describe("function: withFileStorageLock", () => {
                         contentDisposition: null,
                         cacheControl: null,
                     },
-                    context,
+                    noOpContext,
                 );
 
                 expect(spy).toHaveBeenCalledOnce();
@@ -417,7 +420,7 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.copy("sourceKey", "destKey", context);
+                await enhanced.copy("sourceKey", "destKey", noOpContext);
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("sourceKey");
@@ -438,7 +441,11 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.copyAndReplace("sourceKey", "destKey", context);
+                await enhanced.copyAndReplace(
+                    "sourceKey",
+                    "destKey",
+                    noOpContext,
+                );
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("sourceKey");
@@ -459,7 +466,7 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.move("sourceKey", "destKey", context);
+                await enhanced.move("sourceKey", "destKey", noOpContext);
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("sourceKey");
@@ -480,7 +487,11 @@ describe("function: withFileStorageLock", () => {
                     withFileStorageLock({ lockFactory }),
                 );
 
-                await enhanced.moveAndReplace("sourceKey", "destKey", context);
+                await enhanced.moveAndReplace(
+                    "sourceKey",
+                    "destKey",
+                    noOpContext,
+                );
 
                 expect(spy).toHaveBeenCalledOnce();
                 expect(createSpy).toHaveBeenCalledWith("sourceKey");
@@ -502,7 +513,7 @@ describe("function: withFileStorageLock", () => {
                 withFileStorageLock({ lockFactory }),
             );
 
-            await enhanced.removeMany(["key1", "key2", "key3"], context);
+            await enhanced.removeMany(["key1", "key2", "key3"], noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledWith("key1");
@@ -525,7 +536,7 @@ describe("function: withFileStorageLock", () => {
 
             await enhanced.removeMany(
                 ["key1", "key2", "key1", "key3"],
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -546,7 +557,10 @@ describe("function: withFileStorageLock", () => {
                 withFileStorageLock({ lockFactory }),
             );
 
-            const result = await enhanced.removeMany(["key1", "key2"], context);
+            const result = await enhanced.removeMany(
+                ["key1", "key2"],
+                noOpContext,
+            );
 
             expect(result).toBe(true);
         });
@@ -568,12 +582,12 @@ describe("function: withFileStorageLock", () => {
                 }),
             );
 
-            await enhanced.exists("myKey", context);
+            await enhanced.exists("myKey", noOpContext);
             expect(createSpy).toHaveBeenCalledWith("myKey");
             expect(runSpy).toHaveBeenCalledTimes(1);
 
             vi.clearAllMocks();
-            await enhanced.getBytes("myKey", context);
+            await enhanced.getBytes("myKey", noOpContext);
             expect(createSpy).not.toHaveBeenCalled();
             expect(runSpy).not.toHaveBeenCalled();
             expect(existsSpy).not.toHaveBeenCalled();

--- a/src/file-storage/implementations/plugins/with-file-storage-prefix/with-file-storage-prefix.test.ts
+++ b/src/file-storage/implementations/plugins/with-file-storage-prefix/with-file-storage-prefix.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
+import { NoOpContext } from "@/execution-context/implementations/derivables/execution-context/no-op-context.js";
 import {
     type ISignedFileStorageAdapter,
     type WritableFileAdapterContent,
@@ -12,7 +12,7 @@ import { useFactory } from "@/middleware/implementations/use-factory/_module.js"
 import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
 
 describe("function: withFileStoragePrefix", () => {
-    const context = new Context(new Map());
+    const noOpContext = new NoOpContext();
     const prefix = "test-prefix:";
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
 
@@ -26,12 +26,12 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.getPublicUrl("myKey", context);
+            await enhanced.getPublicUrl("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISignedFileStorageAdapter["getPublicUrl"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
     describe("method: getSignedDownloadUrl", () => {
@@ -48,7 +48,7 @@ describe("function: withFileStoragePrefix", () => {
                     contentType: null,
                     contentDisposition: null,
                 },
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -61,7 +61,7 @@ describe("function: withFileStoragePrefix", () => {
                     contentType: null,
                     contentDisposition: null,
                 },
-                context,
+                noOpContext,
             );
         });
     });
@@ -78,7 +78,7 @@ describe("function: withFileStoragePrefix", () => {
                     expirationInSeconds: 3600,
                     contentType: null,
                 },
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -90,7 +90,7 @@ describe("function: withFileStoragePrefix", () => {
                     expirationInSeconds: 3600,
                     contentType: null,
                 },
-                context,
+                noOpContext,
             );
         });
     });
@@ -101,12 +101,12 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.exists("myKey", context);
+            await enhanced.exists("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISignedFileStorageAdapter["exists"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
     describe("method: getStream", () => {
@@ -116,12 +116,12 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.getStream("myKey", context);
+            await enhanced.getStream("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISignedFileStorageAdapter["getStream"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
     describe("method: getBytes", () => {
@@ -131,12 +131,12 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.getBytes("myKey", context);
+            await enhanced.getBytes("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISignedFileStorageAdapter["getBytes"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
     describe("method: getMetaData", () => {
@@ -146,12 +146,12 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.getMetaData("myKey", context);
+            await enhanced.getMetaData("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISignedFileStorageAdapter["getMetaData"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
     describe("method: add", () => {
@@ -170,12 +170,12 @@ describe("function: withFileStoragePrefix", () => {
             };
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.add("myKey", content, context);
+            await enhanced.add("myKey", content, noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISignedFileStorageAdapter["add"]>
-            >(`${prefix}myKey`, content, context);
+            >(`${prefix}myKey`, content, noOpContext);
         });
     });
     describe("method: addStream", () => {
@@ -205,7 +205,7 @@ describe("function: withFileStoragePrefix", () => {
                     contentDisposition: null,
                     cacheControl: null,
                 },
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -222,7 +222,7 @@ describe("function: withFileStoragePrefix", () => {
                     contentDisposition: null,
                     cacheControl: null,
                 },
-                context,
+                noOpContext,
             );
         });
     });
@@ -242,12 +242,12 @@ describe("function: withFileStoragePrefix", () => {
             };
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.update("myKey", content, context);
+            await enhanced.update("myKey", content, noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISignedFileStorageAdapter["update"]>
-            >(`${prefix}myKey`, content, context);
+            >(`${prefix}myKey`, content, noOpContext);
         });
     });
     describe("method: updateStream", () => {
@@ -277,7 +277,7 @@ describe("function: withFileStoragePrefix", () => {
                     contentDisposition: null,
                     cacheControl: null,
                 },
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -294,7 +294,7 @@ describe("function: withFileStoragePrefix", () => {
                     contentDisposition: null,
                     cacheControl: null,
                 },
-                context,
+                noOpContext,
             );
         });
     });
@@ -314,12 +314,12 @@ describe("function: withFileStoragePrefix", () => {
             };
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.put("myKey", content, context);
+            await enhanced.put("myKey", content, noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISignedFileStorageAdapter["put"]>
-            >(`${prefix}myKey`, content, context);
+            >(`${prefix}myKey`, content, noOpContext);
         });
     });
     describe("method: putStream", () => {
@@ -349,7 +349,7 @@ describe("function: withFileStoragePrefix", () => {
                     contentDisposition: null,
                     cacheControl: null,
                 },
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
@@ -366,7 +366,7 @@ describe("function: withFileStoragePrefix", () => {
                     contentDisposition: null,
                     cacheControl: null,
                 },
-                context,
+                noOpContext,
             );
         });
     });
@@ -377,12 +377,12 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.copy("sourceKey", "destKey", context);
+            await enhanced.copy("sourceKey", "destKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISignedFileStorageAdapter["copy"]>
-            >(`${prefix}sourceKey`, `${prefix}destKey`, context);
+            >(`${prefix}sourceKey`, `${prefix}destKey`, noOpContext);
         });
     });
     describe("method: copyAndReplace", () => {
@@ -392,12 +392,12 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.copyAndReplace("sourceKey", "destKey", context);
+            await enhanced.copyAndReplace("sourceKey", "destKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISignedFileStorageAdapter["copyAndReplace"]>
-            >(`${prefix}sourceKey`, `${prefix}destKey`, context);
+            >(`${prefix}sourceKey`, `${prefix}destKey`, noOpContext);
         });
     });
     describe("method: move", () => {
@@ -407,12 +407,12 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.move("sourceKey", "destKey", context);
+            await enhanced.move("sourceKey", "destKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISignedFileStorageAdapter["move"]>
-            >(`${prefix}sourceKey`, `${prefix}destKey`, context);
+            >(`${prefix}sourceKey`, `${prefix}destKey`, noOpContext);
         });
     });
     describe("method: moveAndReplace", () => {
@@ -422,12 +422,12 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.moveAndReplace("sourceKey", "destKey", context);
+            await enhanced.moveAndReplace("sourceKey", "destKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISignedFileStorageAdapter["moveAndReplace"]>
-            >(`${prefix}sourceKey`, `${prefix}destKey`, context);
+            >(`${prefix}sourceKey`, `${prefix}destKey`, noOpContext);
         });
     });
     describe("method: removeMany", () => {
@@ -437,12 +437,12 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.removeMany(["key1", "key2"], context);
+            await enhanced.removeMany(["key1", "key2"], noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISignedFileStorageAdapter["removeMany"]>
-            >([`${prefix}key1`, `${prefix}key2`], context);
+            >([`${prefix}key1`, `${prefix}key2`], noOpContext);
         });
     });
     describe("method: removeByPrefix", () => {
@@ -452,12 +452,12 @@ describe("function: withFileStoragePrefix", () => {
 
             const enhanced = withPlugin(adapter, withFileStoragePrefix(prefix));
 
-            await enhanced.removeByPrefix("myKey", context);
+            await enhanced.removeByPrefix("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISignedFileStorageAdapter["removeByPrefix"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
 });

--- a/src/lock/implementations/plugins/with-lock-prefix/with-lock-prefix.test.ts
+++ b/src/lock/implementations/plugins/with-lock-prefix/with-lock-prefix.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
-import { type ILockAdapter } from "@/lock/contracts/lock-adapter.contract.js";
+import { NoOpContext } from "@/execution-context/implementations/derivables/execution-context/no-op-context.js";
+import { type ILockAdapter } from "@/lock/contracts/_module.js";
 import { NoOpLockAdapter } from "@/lock/implementations/adapters/_module.js";
 import { withLockPrefix } from "@/lock/implementations/plugins/with-lock-prefix/with-lock-prefix.js";
 import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enhance-factory.js";
@@ -10,7 +10,7 @@ import { withPluginFactory } from "@/middleware/implementations/with-plugin-fact
 import { TimeSpan } from "@/time-span/implementations/_module.js";
 
 describe("function: withLockPrefix", () => {
-    const context = new Context(new Map());
+    const noOpContext = new NoOpContext();
     const prefix = "test-prefix:";
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
 
@@ -29,13 +29,18 @@ describe("function: withLockPrefix", () => {
                 "myKey",
                 "lockId",
                 TimeSpan.fromSeconds(30),
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ILockAdapter["acquire"]>
-            >(`${prefix}myKey`, "lockId", TimeSpan.fromSeconds(30), context);
+            >(
+                `${prefix}myKey`,
+                "lockId",
+                TimeSpan.fromSeconds(30),
+                noOpContext,
+            );
         });
     });
 
@@ -46,12 +51,12 @@ describe("function: withLockPrefix", () => {
 
             const enhanced = withPlugin(adapter, withLockPrefix(prefix));
 
-            await enhanced.forceRelease("myKey", context);
+            await enhanced.forceRelease("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ILockAdapter["forceRelease"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
 
@@ -62,12 +67,12 @@ describe("function: withLockPrefix", () => {
 
             const enhanced = withPlugin(adapter, withLockPrefix(prefix));
 
-            await enhanced.getState("myKey", context);
+            await enhanced.getState("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ILockAdapter["getState"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
 
@@ -82,13 +87,18 @@ describe("function: withLockPrefix", () => {
                 "myKey",
                 "lockId",
                 TimeSpan.fromSeconds(30),
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ILockAdapter["refresh"]>
-            >(`${prefix}myKey`, "lockId", TimeSpan.fromSeconds(30), context);
+            >(
+                `${prefix}myKey`,
+                "lockId",
+                TimeSpan.fromSeconds(30),
+                noOpContext,
+            );
         });
     });
 
@@ -99,12 +109,12 @@ describe("function: withLockPrefix", () => {
 
             const enhanced = withPlugin(adapter, withLockPrefix(prefix));
 
-            await enhanced.release("myKey", "lockId", context);
+            await enhanced.release("myKey", "lockId", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ILockAdapter["release"]>
-            >(`${prefix}myKey`, "lockId", context);
+            >(`${prefix}myKey`, "lockId", noOpContext);
         });
     });
 });

--- a/src/rate-limiter/implementations/plugins/with-rate-limiter-prefix/with-rate-limiter-prefix.test.ts
+++ b/src/rate-limiter/implementations/plugins/with-rate-limiter-prefix/with-rate-limiter-prefix.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
+import { NoOpContext } from "@/execution-context/implementations/derivables/execution-context/no-op-context.js";
 import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enhance-factory.js";
 import { useFactory } from "@/middleware/implementations/use-factory/_module.js";
 import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
@@ -9,7 +9,7 @@ import { NoOpRateLimiterAdapter } from "@/rate-limiter/implementations/adapters/
 import { withRateLimiterPrefix } from "@/rate-limiter/implementations/plugins/with-rate-limiter-prefix/with-rate-limiter-prefix.js";
 
 describe("function: withRateLimiterPrefix", () => {
-    const context = new Context(new Map());
+    const noOpContext = new NoOpContext();
     const prefix = "test-prefix:";
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
 
@@ -24,12 +24,12 @@ describe("function: withRateLimiterPrefix", () => {
 
             const enhanced = withPlugin(adapter, withRateLimiterPrefix(prefix));
 
-            await enhanced.getState("myKey", context);
+            await enhanced.getState("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<IRateLimiterAdapter["getState"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
     describe("method: reset", () => {
@@ -39,12 +39,12 @@ describe("function: withRateLimiterPrefix", () => {
 
             const enhanced = withPlugin(adapter, withRateLimiterPrefix(prefix));
 
-            await enhanced.reset("myKey", context);
+            await enhanced.reset("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<IRateLimiterAdapter["reset"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
     describe("method: updateState", () => {
@@ -54,12 +54,12 @@ describe("function: withRateLimiterPrefix", () => {
 
             const enhanced = withPlugin(adapter, withRateLimiterPrefix(prefix));
 
-            await enhanced.updateState("myKey", 10, context);
+            await enhanced.updateState("myKey", 10, noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<IRateLimiterAdapter["updateState"]>
-            >(`${prefix}myKey`, 10, context);
+            >(`${prefix}myKey`, 10, noOpContext);
         });
     });
 });

--- a/src/semaphore/implementations/plugins/with-semaphore-prefix/with-semaphore-prefix.test.ts
+++ b/src/semaphore/implementations/plugins/with-semaphore-prefix/with-semaphore-prefix.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
+import { NoOpContext } from "@/execution-context/implementations/derivables/execution-context/no-op-context.js";
 import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enhance-factory.js";
 import { useFactory } from "@/middleware/implementations/use-factory/_module.js";
 import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
@@ -10,7 +10,7 @@ import { withSemaphorePrefix } from "@/semaphore/implementations/plugins/with-se
 import { TimeSpan } from "@/time-span/implementations/_module.js";
 
 describe("function: withSemaphorePrefix", () => {
-    const context = new Context(new Map());
+    const noOpContext = new NoOpContext();
     const prefix = "test-prefix:";
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
 
@@ -26,7 +26,7 @@ describe("function: withSemaphorePrefix", () => {
             const enhanced = withPlugin(adapter, withSemaphorePrefix(prefix));
 
             await enhanced.acquire({
-                context,
+                context: noOpContext,
                 key: "myKey",
                 slotId: "slot1",
                 limit: 5,
@@ -37,7 +37,7 @@ describe("function: withSemaphorePrefix", () => {
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISemaphoreAdapter["acquire"]>
             >({
-                context,
+                context: noOpContext,
                 key: `${prefix}myKey`,
                 slotId: "slot1",
                 limit: 5,
@@ -53,12 +53,12 @@ describe("function: withSemaphorePrefix", () => {
 
             const enhanced = withPlugin(adapter, withSemaphorePrefix(prefix));
 
-            await enhanced.forceReleaseAll("myKey", context);
+            await enhanced.forceReleaseAll("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISemaphoreAdapter["forceReleaseAll"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
 
@@ -69,12 +69,12 @@ describe("function: withSemaphorePrefix", () => {
 
             const enhanced = withPlugin(adapter, withSemaphorePrefix(prefix));
 
-            await enhanced.getState("myKey", context);
+            await enhanced.getState("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISemaphoreAdapter["getState"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
 
@@ -89,13 +89,13 @@ describe("function: withSemaphorePrefix", () => {
                 "myKey",
                 "slot1",
                 TimeSpan.fromSeconds(30),
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISemaphoreAdapter["refresh"]>
-            >(`${prefix}myKey`, "slot1", TimeSpan.fromSeconds(30), context);
+            >(`${prefix}myKey`, "slot1", TimeSpan.fromSeconds(30), noOpContext);
         });
     });
 
@@ -106,12 +106,12 @@ describe("function: withSemaphorePrefix", () => {
 
             const enhanced = withPlugin(adapter, withSemaphorePrefix(prefix));
 
-            await enhanced.release("myKey", "slot1", context);
+            await enhanced.release("myKey", "slot1", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISemaphoreAdapter["release"]>
-            >(`${prefix}myKey`, "slot1", context);
+            >(`${prefix}myKey`, "slot1", noOpContext);
         });
     });
 });

--- a/src/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.test.ts
+++ b/src/shared-lock/implementations/plugins/with-shared-lock-prefix/with-shared-lock-prefix.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { Context } from "@/execution-context/implementations/derivables/execution-context/context.js";
+import { NoOpContext } from "@/execution-context/implementations/derivables/execution-context/no-op-context.js";
 import { enhanceFactory } from "@/middleware/implementations/enhance-factory/enhance-factory.js";
 import { useFactory } from "@/middleware/implementations/use-factory/_module.js";
 import { withPluginFactory } from "@/middleware/implementations/with-plugin-factory/_module.js";
@@ -10,7 +10,7 @@ import { withSharedLockPrefix } from "@/shared-lock/implementations/plugins/with
 import { TimeSpan } from "@/time-span/implementations/_module.js";
 
 describe("function: withSharedLockPrefix", () => {
-    const context = new Context(new Map());
+    const noOpContext = new NoOpContext();
     const prefix = "test-prefix:";
     const withPlugin = withPluginFactory(enhanceFactory(useFactory()));
 
@@ -25,12 +25,12 @@ describe("function: withSharedLockPrefix", () => {
 
             const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
-            await enhanced.forceRelease("myKey", context);
+            await enhanced.forceRelease("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISharedLockAdapter["forceRelease"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
 
@@ -41,12 +41,12 @@ describe("function: withSharedLockPrefix", () => {
 
             const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
-            await enhanced.getState("myKey", context);
+            await enhanced.getState("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISharedLockAdapter["getState"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
 
@@ -61,13 +61,18 @@ describe("function: withSharedLockPrefix", () => {
                 "myKey",
                 "lockId",
                 TimeSpan.fromSeconds(30),
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISharedLockAdapter["acquireWriter"]>
-            >(`${prefix}myKey`, "lockId", TimeSpan.fromSeconds(30), context);
+            >(
+                `${prefix}myKey`,
+                "lockId",
+                TimeSpan.fromSeconds(30),
+                noOpContext,
+            );
         });
     });
 
@@ -78,12 +83,12 @@ describe("function: withSharedLockPrefix", () => {
 
             const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
-            await enhanced.forceReleaseWriter("myKey", context);
+            await enhanced.forceReleaseWriter("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISharedLockAdapter["forceReleaseWriter"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
 
@@ -98,13 +103,18 @@ describe("function: withSharedLockPrefix", () => {
                 "myKey",
                 "lockId",
                 TimeSpan.fromSeconds(30),
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISharedLockAdapter["refreshWriter"]>
-            >(`${prefix}myKey`, "lockId", TimeSpan.fromSeconds(30), context);
+            >(
+                `${prefix}myKey`,
+                "lockId",
+                TimeSpan.fromSeconds(30),
+                noOpContext,
+            );
         });
     });
 
@@ -115,12 +125,12 @@ describe("function: withSharedLockPrefix", () => {
 
             const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
-            await enhanced.releaseWriter("myKey", "lockId", context);
+            await enhanced.releaseWriter("myKey", "lockId", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISharedLockAdapter["releaseWriter"]>
-            >(`${prefix}myKey`, "lockId", context);
+            >(`${prefix}myKey`, "lockId", noOpContext);
         });
     });
 
@@ -132,7 +142,7 @@ describe("function: withSharedLockPrefix", () => {
             const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
             await enhanced.acquireReader({
-                context,
+                context: noOpContext,
                 key: "myKey",
                 lockId: "lock1",
                 limit: 5,
@@ -143,7 +153,7 @@ describe("function: withSharedLockPrefix", () => {
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISharedLockAdapter["acquireReader"]>
             >({
-                context,
+                context: noOpContext,
                 key: `${prefix}myKey`,
                 lockId: "lock1",
                 limit: 5,
@@ -159,12 +169,12 @@ describe("function: withSharedLockPrefix", () => {
 
             const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
-            await enhanced.forceReleaseAllReaders("myKey", context);
+            await enhanced.forceReleaseAllReaders("myKey", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISharedLockAdapter["forceReleaseAllReaders"]>
-            >(`${prefix}myKey`, context);
+            >(`${prefix}myKey`, noOpContext);
         });
     });
 
@@ -179,13 +189,18 @@ describe("function: withSharedLockPrefix", () => {
                 "myKey",
                 "lockId",
                 TimeSpan.fromSeconds(30),
-                context,
+                noOpContext,
             );
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISharedLockAdapter["refreshReader"]>
-            >(`${prefix}myKey`, "lockId", TimeSpan.fromSeconds(30), context);
+            >(
+                `${prefix}myKey`,
+                "lockId",
+                TimeSpan.fromSeconds(30),
+                noOpContext,
+            );
         });
     });
 
@@ -196,12 +211,12 @@ describe("function: withSharedLockPrefix", () => {
 
             const enhanced = withPlugin(adapter, withSharedLockPrefix(prefix));
 
-            await enhanced.releaseReader("myKey", "lockId", context);
+            await enhanced.releaseReader("myKey", "lockId", noOpContext);
 
             expect(spy).toHaveBeenCalledOnce();
             expect(spy).toHaveBeenCalledWith<
                 Parameters<ISharedLockAdapter["releaseReader"]>
-            >(`${prefix}myKey`, "lockId", context);
+            >(`${prefix}myKey`, "lockId", noOpContext);
         });
     });
 });


### PR DESCRIPTION
- **refactor(circuit-breaker): remove unnecessary .toString() calls on key**
- **test(cache): replace Context with NoOpContext in plugin tests**
- **test(circuit-breaker): replace Context with NoOpContext in prefix plugin test**
- **test(event-bus): replace Context with NoOpContext in plugin tests**
- **test(file-storage): replace Context with NoOpContext in plugin tests**
- **test(lock): replace Context with NoOpContext in prefix plugin test**
- **test(rate-limiter): replace Context with NoOpContext in prefix plugin test**
- **test(semaphore): replace Context with NoOpContext in prefix plugin test**
- **test(shared-lock): replace Context with NoOpContext in prefix plugin test**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved circuit-breaker keys without converting them to strings, ensuring adapters receive the original key values.

* **Tests**
  * Updated plugin test coverage across caching, event bus, file storage, locks, rate limiting, semaphores, and shared locks.
  * Standardized test execution contexts while retaining validation of key/event prefixes, locking behavior, TTL handling, and listener tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->