### PR TITLE
enhancement/database adapter settings

### DIFF
--- a/.changeset/updated-database-adapters-settings.md
+++ b/.changeset/updated-database-adapters-settings.md
@@ -1,0 +1,37 @@
+---
+"@daiso-tech/core": minor
+---
+
+## Simplified Database Adapter Settings
+
+Removed the `enableTransactions`, `shouldRemoveExpiredKeys`, and `expiredKeysRemovalInterval` settings from all database-backed adapters. Database operations are now always wrapped in a transaction, and the built-in background cleanup of expired records has been removed.
+
+### What changed
+
+**Removed `enableTransactions` from:**
+
+- `KyselyCacheAdapter`
+- `KyselyCircuitBreakerStorageAdapter`
+- `KyselyLockAdapter`
+- `KyselyRateLimiterStorageAdapter`
+- `KyselySemaphoreAdapter`
+- `KyselySharedLockAdapter`
+- `MongodbCircuitBreakerStorageAdapter`
+- `MongodbRateLimiterStorageAdapter`
+
+Every operation is now always executed inside a database transaction (with `serializable` isolation for the Kysely lock, semaphore, and shared-lock adapters), which matches the previous default behavior.
+
+**Removed `shouldRemoveExpiredKeys` and `expiredKeysRemovalInterval` from:**
+
+- `KyselyCacheAdapter`
+- `KyselyLockAdapter`
+- `KyselyRateLimiterStorageAdapter`
+- `KyselySemaphoreAdapter`
+- `KyselySharedLockAdapter`
+
+The background task that periodically removed expired records is no longer started automatically.
+
+### Migration
+
+- Remove any `enableTransactions`, `shouldRemoveExpiredKeys`, or `expiredKeysRemovalInterval` options from adapter settings — they are no longer accepted.
+- If you relied on automatic expired-key cleanup, schedule `removeAllExpired()` yourself (e.g. with a cron job or `setInterval`), as the adapters no longer run it in the background.

--- a/src/cache/implementations/adapters/kysely-cache-adapter/kysely-cache-adapter.ts
+++ b/src/cache/implementations/adapters/kysely-cache-adapter/kysely-cache-adapter.ts
@@ -2,13 +2,12 @@
  * @module Cache
  */
 
-import { MysqlAdapter, Transaction, type Kysely } from "kysely";
+import { MysqlAdapter, type Kysely } from "kysely";
 
 import { type ICacheAdapter } from "@/cache/contracts/_module.js";
 import { type IReadableContext } from "@/execution-context/contracts/_module.js";
 import { type ISerde } from "@/serde/contracts/_module.js";
-import { type ITimeSpan } from "@/time-span/contracts/_module.js";
-import { TimeSpan } from "@/time-span/implementations/_module.js";
+import { type TimeSpan } from "@/time-span/implementations/_module.js";
 import {
     type IDeinitizable,
     type IInitizable,
@@ -52,34 +51,6 @@ export type KyselyCacheAdapterSettings = {
      * Serde instance for serializing and deserializing cache values to and from strings.
      */
     serde: ISerde<string>;
-
-    /**
-     * How often expired cache entries are automatically removed in the background.
-     * @default
-     * ```ts
-     * import { TimeSpan } from "@daiso-tech/core/time-span";
-     *
-     * TimeSpan.fromMinutes(1)
-     * ```
-     */
-    expiredKeysRemovalInterval?: ITimeSpan;
-
-    /**
-     * When `true`, a background task periodically removes expired keys.
-     * Set to `false` to disable automatic cleanup.
-     * @default true
-     */
-    shouldRemoveExpiredKeys?: boolean;
-
-    /**
-     * @default
-     * ```ts
-     * import { Transaction } from "kysely"
-     *
-     * !(settings.kysely instanceof Transaction)
-     * ```
-     */
-    enableTransactions?: boolean;
 };
 
 /**
@@ -95,10 +66,6 @@ export class KyselyCacheAdapter<TType = unknown>
     private readonly isMysql: boolean;
     private readonly serde: ISerde<string>;
     private readonly kysely: Kysely<KyselyCacheTables>;
-    private readonly shouldRemoveExpiredKeys: boolean;
-    private readonly expiredKeysRemovalInterval: TimeSpan;
-    private timeoutId: NodeJS.Timeout | string | number | null = null;
-    private readonly enableTransactions: boolean;
 
     /**
      * @example
@@ -123,20 +90,9 @@ export class KyselyCacheAdapter<TType = unknown>
      * ```
      */
     constructor(settings: KyselyCacheAdapterSettings) {
-        const {
-            kysely,
-            serde,
-            expiredKeysRemovalInterval = TimeSpan.fromMinutes(1),
-            shouldRemoveExpiredKeys = true,
-            enableTransactions = !(settings.kysely instanceof Transaction),
-        } = settings;
-        this.enableTransactions = enableTransactions;
+        const { kysely, serde } = settings;
         this.kysely = kysely;
         this.serde = serde;
-        this.expiredKeysRemovalInterval = TimeSpan.fromTimeSpan(
-            expiredKeysRemovalInterval,
-        );
-        this.shouldRemoveExpiredKeys = shouldRemoveExpiredKeys;
         this.isMysql =
             this.kysely.getExecutor().adapter instanceof MysqlAdapter;
     }
@@ -171,12 +127,6 @@ export class KyselyCacheAdapter<TType = unknown>
         } catch {
             /* EMPTY */
         }
-
-        if (this.shouldRemoveExpiredKeys && this.timeoutId === null) {
-            this.timeoutId = setInterval(() => {
-                void this.removeAllExpired();
-            }, this.expiredKeysRemovalInterval.toMilliseconds());
-        }
     }
 
     /**
@@ -184,10 +134,6 @@ export class KyselyCacheAdapter<TType = unknown>
      * Note all cache data will be removed.
      */
     async deInit(): Promise<void> {
-        if (this.shouldRemoveExpiredKeys && this.timeoutId !== null) {
-            clearInterval(this.timeoutId);
-        }
-
         // Should throw if the index does not exists thats why the try catch is used.
         try {
             await this.kysely.schema
@@ -210,12 +156,9 @@ export class KyselyCacheAdapter<TType = unknown>
         _context: IReadableContext,
         trxFn: InvokableFn<[trx: Kysely<KyselyCacheTables>], Promise<TValue>>,
     ): Promise<TValue> {
-        if (this.enableTransactions) {
-            return this.kysely.transaction().execute(async (trx) => {
-                return await trxFn(trx);
-            });
-        }
-        return trxFn(this.kysely);
+        return this.kysely.transaction().execute(async (trx) => {
+            return await trxFn(trx);
+        });
     }
 
     async get(key: string, _context: IReadableContext): Promise<TType | null> {

--- a/src/cache/implementations/adapters/kysely-cache-adapter/mysql-kysely-cache-adapter.test.ts
+++ b/src/cache/implementations/adapters/kysely-cache-adapter/mysql-kysely-cache-adapter.test.ts
@@ -47,7 +47,6 @@ describe("mysql class: KyselyCacheAdapter", () => {
                         pool: database,
                     }),
                 }),
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();

--- a/src/cache/implementations/adapters/kysely-cache-adapter/postgres-kysely-cache-adapter.test.ts
+++ b/src/cache/implementations/adapters/kysely-cache-adapter/postgres-kysely-cache-adapter.test.ts
@@ -39,7 +39,6 @@ describe("postgres class: KyselyCacheAdapter", () => {
                         pool: database,
                     }),
                 }),
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();

--- a/src/cache/implementations/adapters/kysely-cache-adapter/sqlite-kysely-cache-adapter.test.ts
+++ b/src/cache/implementations/adapters/kysely-cache-adapter/sqlite-kysely-cache-adapter.test.ts
@@ -23,7 +23,6 @@ describe("sqlite class: KyselyCacheAdapter", () => {
                         database,
                     }),
                 }),
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();

--- a/src/circuit-breaker/implementations/adapters/kysely-circuit-breaker-storage-adapter/kysely-circuit-breaker-storage-adapter.ts
+++ b/src/circuit-breaker/implementations/adapters/kysely-circuit-breaker-storage-adapter/kysely-circuit-breaker-storage-adapter.ts
@@ -2,7 +2,7 @@
  * @module CircuitBreaker
  */
 
-import { MysqlAdapter, Transaction, type Kysely } from "kysely";
+import { MysqlAdapter, type Kysely } from "kysely";
 
 import {
     type ICircuitBreakerStorageAdapter,
@@ -50,16 +50,6 @@ export type KyselyCircuitBreakerStorageAdapterSettings = {
      * Serde instance for serializing and deserializing circuit-breaker state to and from strings.
      */
     serde: ISerde<string>;
-
-    /**
-     * @default
-     * ```ts
-     * import { Transaction } from "kysely"
-     *
-     * !(settings.kysely instanceof Transaction)
-     * ```
-     */
-    enableTransactions?: boolean;
 };
 
 /**
@@ -148,7 +138,6 @@ export class KyselyCircuitBreakerStorageAdapter<TType>
 {
     private readonly kysely: Kysely<KyselyCircuitBreakerStorageTables>;
     private readonly serde: ISerde<string>;
-    private readonly enableTransactions: boolean;
 
     /**
      * @example
@@ -173,15 +162,10 @@ export class KyselyCircuitBreakerStorageAdapter<TType>
      * ```
      */
     constructor(settings: KyselyCircuitBreakerStorageAdapterSettings) {
-        const {
-            kysely,
-            serde,
-            enableTransactions = !(settings.kysely instanceof Transaction),
-        } = settings;
+        const { kysely, serde } = settings;
 
         this.kysely = kysely;
         this.serde = serde;
-        this.enableTransactions = enableTransactions;
     }
     private _transaction<TValue>(
         trxFn: InvokableFn<
@@ -189,12 +173,9 @@ export class KyselyCircuitBreakerStorageAdapter<TType>
             Promise<TValue>
         >,
     ): Promise<TValue> {
-        if (this.enableTransactions) {
-            return this.kysely.transaction().execute(async (trx) => {
-                return await trxFn(trx);
-            });
-        }
-        return trxFn(this.kysely);
+        return this.kysely.transaction().execute(async (trx) => {
+            return await trxFn(trx);
+        });
     }
 
     /**

--- a/src/circuit-breaker/implementations/adapters/mongodb-circuit-breaker-storage-adapter/mongodb-circuit-breaker-storage-adapter.ts
+++ b/src/circuit-breaker/implementations/adapters/mongodb-circuit-breaker-storage-adapter/mongodb-circuit-breaker-storage-adapter.ts
@@ -62,13 +62,6 @@ export type MongodbCircuitBreakerStorageAdapterSettings = {
      * Serde instance for serializing and deserializing circuit-breaker state to and from strings.
      */
     serde: ISerde<string>;
-
-    /**
-     * When `true`, operations are wrapped in MongoDB transactions for atomicity.
-     * Requires a Replica Set or sharded cluster that supports transactions.
-     * @default true
-     */
-    enableTransactions?: boolean;
 };
 
 /**
@@ -85,7 +78,6 @@ export class MongodbCircuitBreakerStorageAdapter<TType = unknown>
     private readonly collection: Collection<MongodbCircuitBreakerStorageDocument>;
     private readonly client: MongoClient;
     private readonly serde: ISerde<string>;
-    private readonly enableTransactions: boolean;
 
     /**
      * @example
@@ -114,7 +106,6 @@ export class MongodbCircuitBreakerStorageAdapter<TType = unknown>
             collectionSettings,
             database,
             serde,
-            enableTransactions = true,
         } = settings;
         this.client = client;
         this.collection = database.collection(
@@ -122,7 +113,6 @@ export class MongodbCircuitBreakerStorageAdapter<TType = unknown>
             collectionSettings,
         );
         this.serde = serde;
-        this.enableTransactions = enableTransactions;
     }
 
     /**
@@ -190,14 +180,11 @@ export class MongodbCircuitBreakerStorageAdapter<TType = unknown>
     private async _transaction<TValue>(
         trxFn: InvokableFn<[session?: ClientSession], Promise<TValue>>,
     ): Promise<TValue> {
-        if (this.enableTransactions) {
-            return await this.client.withSession(async (session) => {
-                return await session.withTransaction(async () => {
-                    return await trxFn(session);
-                });
+        return await this.client.withSession(async (session) => {
+            return await session.withTransaction(async () => {
+                return await trxFn(session);
             });
-        }
-        return trxFn();
+        });
     }
 
     async transaction<TValue>(

--- a/src/lock/implementations/adapters/kysely-lock-adapter/kysely-lock-adapter.ts
+++ b/src/lock/implementations/adapters/kysely-lock-adapter/kysely-lock-adapter.ts
@@ -2,15 +2,14 @@
  * @module Lock
  */
 
-import { MysqlAdapter, Transaction, type Kysely } from "kysely";
+import { MysqlAdapter, type Kysely } from "kysely";
 
 import { type IReadableContext } from "@/execution-context/contracts/_module.js";
 import {
     type ILockAdapter,
     type ILockAdapterState,
 } from "@/lock/contracts/_module.js";
-import { type ITimeSpan } from "@/time-span/contracts/_module.js";
-import { TimeSpan } from "@/time-span/implementations/_module.js";
+import { type TimeSpan } from "@/time-span/implementations/_module.js";
 import {
     type IDeinitizable,
     type IInitizable,
@@ -51,33 +50,6 @@ export type KyselyLockAdapterSettings = {
      * The Kysely database instance typed with the required lock table.
      */
     kysely: Kysely<KyselyLockTables>;
-
-    /**
-     * @default
-     * ```ts
-     * import { TimeSpan } from "@daiso-tech/core/time-span";
-     *
-     * TimeSpan.fromMinutes(1)
-     * ```
-     */
-    expiredKeysRemovalInterval?: ITimeSpan;
-
-    /**
-     * When `true`, a background task periodically removes expired lock records.
-     * Set to `false` to disable automatic cleanup.
-     * @default true
-     */
-    shouldRemoveExpiredKeys?: boolean;
-
-    /**
-     * @default
-     * ```ts
-     * import { Transaction } from "kysely"
-     *
-     * !(settings.kysely instanceof Transaction)
-     * ```
-     */
-    enableTransactions?: boolean;
 };
 
 /**
@@ -93,12 +65,7 @@ export class KyselyLockAdapter
     implements ILockAdapter, IDeinitizable, IInitizable, IPrunable
 {
     private readonly kysely: Kysely<KyselyLockTables>;
-    private readonly expiredKeysRemovalInterval: TimeSpan;
-    private readonly shouldRemoveExpiredKeys: boolean;
-    private intervalId: string | number | NodeJS.Timeout | undefined | null =
-        null;
     private readonly isMysql: boolean;
-    private readonly enableTransactions: boolean;
 
     /**
      * @example
@@ -119,34 +86,21 @@ export class KyselyLockAdapter
      * ```
      */
     constructor(settings: KyselyLockAdapterSettings) {
-        const {
-            kysely,
-            expiredKeysRemovalInterval = TimeSpan.fromMinutes(1),
-            shouldRemoveExpiredKeys = true,
-            enableTransactions = !(settings.kysely instanceof Transaction),
-        } = settings;
-        this.expiredKeysRemovalInterval = TimeSpan.fromTimeSpan(
-            expiredKeysRemovalInterval,
-        );
-        this.shouldRemoveExpiredKeys = shouldRemoveExpiredKeys;
+        const { kysely } = settings;
         this.kysely = kysely;
         this.isMysql =
             this.kysely.getExecutor().adapter instanceof MysqlAdapter;
-        this.enableTransactions = enableTransactions;
     }
 
     private _transaction<TValue>(
         trxFn: InvokableFn<[trx: Kysely<KyselyLockTables>], Promise<TValue>>,
     ): Promise<TValue> {
-        if (this.enableTransactions) {
-            return this.kysely
-                .transaction()
-                .setIsolationLevel("serializable")
-                .execute(async (trx) => {
-                    return await trxFn(trx);
-                });
-        }
-        return trxFn(this.kysely);
+        return this.kysely
+            .transaction()
+            .setIsolationLevel("serializable")
+            .execute(async (trx) => {
+                return await trxFn(trx);
+            });
     }
 
     /**
@@ -154,10 +108,6 @@ export class KyselyLockAdapter
      * Note all lock data will be removed.
      */
     async deInit(): Promise<void> {
-        if (this.shouldRemoveExpiredKeys && this.intervalId !== null) {
-            clearInterval(this.intervalId);
-        }
-
         // Should throw if the index does not exists thats why the try catch is used.
         try {
             await this.kysely.schema
@@ -204,12 +154,6 @@ export class KyselyLockAdapter
                 .execute();
         } catch {
             /* EMPTY */
-        }
-
-        if (this.shouldRemoveExpiredKeys) {
-            this.intervalId = setInterval(() => {
-                void this.removeAllExpired();
-            }, this.expiredKeysRemovalInterval.toMilliseconds());
         }
     }
 

--- a/src/lock/implementations/adapters/kysely-lock-adapter/mysql-kysely-lock-adapter.test.ts
+++ b/src/lock/implementations/adapters/kysely-lock-adapter/mysql-kysely-lock-adapter.test.ts
@@ -9,7 +9,7 @@ import {
     type TableMetadata,
 } from "kysely";
 import { createPool, type Pool } from "mysql2";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -59,7 +59,6 @@ describe("mysql class: KyselyLockAdapter", () => {
         createAdapter: async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             return adapter;
@@ -73,7 +72,6 @@ describe("mysql class: KyselyLockAdapter", () => {
         test("Should remove all expired keys", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -107,7 +105,6 @@ describe("mysql class: KyselyLockAdapter", () => {
         test("Should create lock table", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -143,7 +140,6 @@ describe("mysql class: KyselyLockAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -151,35 +147,11 @@ describe("mysql class: KyselyLockAdapter", () => {
 
             await expect(promise).resolves.toBeUndefined();
         });
-        test("Should call not setInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselyLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call setInterval when shouldRemoveExpiredKeys is true", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselyLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
-        });
     });
     describe("method: deInit", () => {
         test("Should remove lock table", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -195,7 +167,6 @@ describe("mysql class: KyselyLockAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -207,38 +178,11 @@ describe("mysql class: KyselyLockAdapter", () => {
         test("Should not throw error when called before init", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
 
             const promise = adapter.deInit();
 
             await expect(promise).resolves.toBeUndefined();
-        });
-        test("Should call not clearInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselyLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call clearInterval when shouldRemoveExpiredKeys is true", async () => {
-            vi.useFakeTimers();
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselyLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
         });
     });
 });

--- a/src/lock/implementations/adapters/kysely-lock-adapter/postgres-kysely-lock-adapter.test.ts
+++ b/src/lock/implementations/adapters/kysely-lock-adapter/postgres-kysely-lock-adapter.test.ts
@@ -9,7 +9,7 @@ import {
     type TableMetadata,
 } from "kysely";
 import { Pool } from "pg";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -51,7 +51,6 @@ describe("postgres class: KyselyLockAdapter", () => {
         createAdapter: async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             return adapter;
@@ -65,7 +64,6 @@ describe("postgres class: KyselyLockAdapter", () => {
         test("Should remove all expired keys", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -99,7 +97,6 @@ describe("postgres class: KyselyLockAdapter", () => {
         test("Should create lock table", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -135,7 +132,6 @@ describe("postgres class: KyselyLockAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -143,35 +139,11 @@ describe("postgres class: KyselyLockAdapter", () => {
 
             await expect(promise).resolves.toBeUndefined();
         });
-        test("Should call not setInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselyLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call setInterval when shouldRemoveExpiredKeys is true", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselyLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
-        });
     });
     describe("method: deInit", () => {
         test("Should remove lock table", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -187,7 +159,6 @@ describe("postgres class: KyselyLockAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -199,38 +170,11 @@ describe("postgres class: KyselyLockAdapter", () => {
         test("Should not throw error when called before init", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
 
             const promise = adapter.deInit();
 
             await expect(promise).resolves.toBeUndefined();
-        });
-        test("Should call not clearInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselyLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call clearInterval when shouldRemoveExpiredKeys is true", async () => {
-            vi.useFakeTimers();
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselyLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
         });
     });
 });

--- a/src/lock/implementations/adapters/kysely-lock-adapter/sqlite-kysely-lock-adapter.test.ts
+++ b/src/lock/implementations/adapters/kysely-lock-adapter/sqlite-kysely-lock-adapter.test.ts
@@ -5,7 +5,7 @@ import {
     type ColumnMetadata,
     type TableMetadata,
 } from "kysely";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -36,7 +36,6 @@ describe("sqlite class: KyselyLockAdapter", () => {
         createAdapter: async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             return adapter;
@@ -50,7 +49,6 @@ describe("sqlite class: KyselyLockAdapter", () => {
         test("Should remove all expired keys", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -84,7 +82,6 @@ describe("sqlite class: KyselyLockAdapter", () => {
         test("Should create lock table", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -120,7 +117,6 @@ describe("sqlite class: KyselyLockAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -128,35 +124,11 @@ describe("sqlite class: KyselyLockAdapter", () => {
 
             await expect(promise).resolves.toBeUndefined();
         });
-        test("Should call not setInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselyLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call setInterval when shouldRemoveExpiredKeys is true", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselyLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
-        });
     });
     describe("method: deInit", () => {
         test("Should remove lock table", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -172,7 +144,6 @@ describe("sqlite class: KyselyLockAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -184,38 +155,11 @@ describe("sqlite class: KyselyLockAdapter", () => {
         test("Should not throw error when called before init", async () => {
             const adapter = new KyselyLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
 
             const promise = adapter.deInit();
 
             await expect(promise).resolves.toBeUndefined();
-        });
-        test("Should call not clearInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselyLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call clearInterval when shouldRemoveExpiredKeys is true", async () => {
-            vi.useFakeTimers();
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselyLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
         });
     });
 });

--- a/src/lock/implementations/derivables/lock-factory/lock-factory.test.ts
+++ b/src/lock/implementations/derivables/lock-factory/lock-factory.test.ts
@@ -50,7 +50,6 @@ describe("class: LockFactory", () => {
                         database: new Sqlite(":memory:"),
                     }),
                 }),
-                shouldRemoveExpiredKeys: false,
             });
             await adapter2.init();
             const lockFactory2 = new LockFactory({

--- a/src/rate-limiter/implementations/adapters/kysely-rate-limiter-storage-adapter/kysely-rate-limiter-storage-adapter.ts
+++ b/src/rate-limiter/implementations/adapters/kysely-rate-limiter-storage-adapter/kysely-rate-limiter-storage-adapter.ts
@@ -2,7 +2,7 @@
  * @module RateLimiter
  */
 
-import { MysqlAdapter, Transaction, type Kysely } from "kysely";
+import { MysqlAdapter, type Kysely } from "kysely";
 
 import { type IReadableContext } from "@/execution-context/contracts/_module.js";
 import {
@@ -11,8 +11,6 @@ import {
     type IRateLimiterStorageAdapterTransaction,
 } from "@/rate-limiter/contracts/_module.js";
 import { type ISerde } from "@/serde/contracts/_module.js";
-import { type ITimeSpan } from "@/time-span/contracts/_module.js";
-import { TimeSpan } from "@/time-span/implementations/_module.js";
 import {
     type IDeinitizable,
     type IInitizable,
@@ -137,33 +135,6 @@ export type KyselyRateLimiterStorageAdapterSettings = {
      * Serde instance for serializing and deserializing rate-limiter state to and from strings.
      */
     serde: ISerde<string>;
-
-    /**
-     * @default
-     * ```ts
-     * import { TimeSpan } from "@daiso-tech/core/time-span";
-     *
-     * TimeSpan.fromMinutes(1)
-     * ```
-     */
-    expiredKeysRemovalInterval?: ITimeSpan;
-
-    /**
-     * When `true`, a background task periodically removes expired rate-limiter records.
-     * Set to `false` to disable automatic cleanup.
-     * @default true
-     */
-    shouldRemoveExpiredKeys?: boolean;
-
-    /**
-     * @default
-     * ```ts
-     * import { Transaction } from "kysely"
-     *
-     * !(settings.kysely instanceof Transaction)
-     * ```
-     */
-    enableTransactions?: boolean;
 };
 
 /**
@@ -179,11 +150,6 @@ export class KyselyRateLimiterStorageAdapter<TType>
 {
     private readonly kysely: Kysely<KyselyRateLimiterStorageTables>;
     private readonly serde: ISerde<string>;
-    private readonly expiredKeysRemovalInterval: TimeSpan;
-    private readonly shouldRemoveExpiredKeys: boolean;
-    private intervalId: string | number | NodeJS.Timeout | undefined | null =
-        null;
-    private readonly enableTransactions: boolean;
 
     /**
      * @example
@@ -208,21 +174,10 @@ export class KyselyRateLimiterStorageAdapter<TType>
      * ```
      */
     constructor(settings: KyselyRateLimiterStorageAdapterSettings) {
-        const {
-            kysely,
-            serde,
-            expiredKeysRemovalInterval = TimeSpan.fromMinutes(1),
-            shouldRemoveExpiredKeys = true,
-            enableTransactions = !(settings.kysely instanceof Transaction),
-        } = settings;
+        const { kysely, serde } = settings;
 
-        this.expiredKeysRemovalInterval = TimeSpan.fromTimeSpan(
-            expiredKeysRemovalInterval,
-        );
-        this.shouldRemoveExpiredKeys = shouldRemoveExpiredKeys;
         this.kysely = kysely;
         this.serde = serde;
-        this.enableTransactions = enableTransactions;
     }
     private _transaction<TValue>(
         trxFn: InvokableFn<
@@ -230,12 +185,9 @@ export class KyselyRateLimiterStorageAdapter<TType>
             Promise<TValue>
         >,
     ): Promise<TValue> {
-        if (this.enableTransactions) {
-            return this.kysely.transaction().execute(async (trx) => {
-                return await trxFn(trx);
-            });
-        }
-        return trxFn(this.kysely);
+        return this.kysely.transaction().execute(async (trx) => {
+            return await trxFn(trx);
+        });
     }
 
     /**
@@ -243,10 +195,6 @@ export class KyselyRateLimiterStorageAdapter<TType>
      * Note all rate limiter data will be removed.
      */
     async deInit(): Promise<void> {
-        if (this.shouldRemoveExpiredKeys && this.intervalId !== null) {
-            clearInterval(this.intervalId);
-        }
-
         // Should throw if the index does not exists thats why the try catch is used.
         try {
             await this.kysely.schema
@@ -293,12 +241,6 @@ export class KyselyRateLimiterStorageAdapter<TType>
                 .execute();
         } catch {
             /* EMPTY */
-        }
-
-        if (this.shouldRemoveExpiredKeys) {
-            this.intervalId = setInterval(() => {
-                void this.removeAllExpired();
-            }, this.expiredKeysRemovalInterval.toMilliseconds());
         }
     }
 

--- a/src/rate-limiter/implementations/adapters/kysely-rate-limiter-storage-adapter/mysql-kysely-rate-limiter-storage-adapter.test.ts
+++ b/src/rate-limiter/implementations/adapters/kysely-rate-limiter-storage-adapter/mysql-kysely-rate-limiter-storage-adapter.test.ts
@@ -9,7 +9,7 @@ import {
     type TableMetadata,
 } from "kysely";
 import { createPool, type Pool } from "mysql2";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -61,7 +61,6 @@ describe("mysql class: KyselyRateLimiterStorageAdapter", () => {
         createAdapter: async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -76,7 +75,6 @@ describe("mysql class: KyselyRateLimiterStorageAdapter", () => {
         test("Should remove all expired keys", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -113,7 +111,6 @@ describe("mysql class: KyselyRateLimiterStorageAdapter", () => {
         test("Should create rateLimiter table", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -150,7 +147,6 @@ describe("mysql class: KyselyRateLimiterStorageAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -159,37 +155,11 @@ describe("mysql class: KyselyRateLimiterStorageAdapter", () => {
 
             await expect(promise).resolves.toBeUndefined();
         });
-        test("Should call not setInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselyRateLimiterStorageAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-                serde: new Serde(new SuperJsonSerdeAdapter()),
-            });
-            await adapter.init();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call setInterval when shouldRemoveExpiredKeys is true", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselyRateLimiterStorageAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-                serde: new Serde(new SuperJsonSerdeAdapter()),
-            });
-            await adapter.init();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
-        });
     });
     describe("method: deInit", () => {
         test("Should remove rateLimiter table", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -206,7 +176,6 @@ describe("mysql class: KyselyRateLimiterStorageAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -219,41 +188,12 @@ describe("mysql class: KyselyRateLimiterStorageAdapter", () => {
         test("Should not throw error when called before init", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
 
             const promise = adapter.deInit();
 
             await expect(promise).resolves.toBeUndefined();
-        });
-        test("Should call not clearInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselyRateLimiterStorageAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-                serde: new Serde(new SuperJsonSerdeAdapter()),
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call clearInterval when shouldRemoveExpiredKeys is true", async () => {
-            vi.useFakeTimers();
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselyRateLimiterStorageAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-                serde: new Serde(new SuperJsonSerdeAdapter()),
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
         });
     });
 });

--- a/src/rate-limiter/implementations/adapters/kysely-rate-limiter-storage-adapter/postgres-kysely-rate-limiter-storage-adapter.test.ts
+++ b/src/rate-limiter/implementations/adapters/kysely-rate-limiter-storage-adapter/postgres-kysely-rate-limiter-storage-adapter.test.ts
@@ -9,7 +9,7 @@ import {
     type TableMetadata,
 } from "kysely";
 import { Pool } from "pg";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -53,7 +53,6 @@ describe("postgres class: KyselyRateLimiterStorageAdapter", () => {
         createAdapter: async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -68,7 +67,6 @@ describe("postgres class: KyselyRateLimiterStorageAdapter", () => {
         test("Should remove all expired keys", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -105,7 +103,6 @@ describe("postgres class: KyselyRateLimiterStorageAdapter", () => {
         test("Should create rateLimiter table", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -142,7 +139,6 @@ describe("postgres class: KyselyRateLimiterStorageAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -151,37 +147,11 @@ describe("postgres class: KyselyRateLimiterStorageAdapter", () => {
 
             await expect(promise).resolves.toBeUndefined();
         });
-        test("Should call not setInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselyRateLimiterStorageAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-                serde: new Serde(new SuperJsonSerdeAdapter()),
-            });
-            await adapter.init();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call setInterval when shouldRemoveExpiredKeys is true", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselyRateLimiterStorageAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-                serde: new Serde(new SuperJsonSerdeAdapter()),
-            });
-            await adapter.init();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
-        });
     });
     describe("method: deInit", () => {
         test("Should remove rateLimiter table", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -198,7 +168,6 @@ describe("postgres class: KyselyRateLimiterStorageAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -211,41 +180,12 @@ describe("postgres class: KyselyRateLimiterStorageAdapter", () => {
         test("Should not throw error when called before init", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
 
             const promise = adapter.deInit();
 
             await expect(promise).resolves.toBeUndefined();
-        });
-        test("Should call not clearInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselyRateLimiterStorageAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-                serde: new Serde(new SuperJsonSerdeAdapter()),
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call clearInterval when shouldRemoveExpiredKeys is true", async () => {
-            vi.useFakeTimers();
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselyRateLimiterStorageAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-                serde: new Serde(new SuperJsonSerdeAdapter()),
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
         });
     });
 });

--- a/src/rate-limiter/implementations/adapters/kysely-rate-limiter-storage-adapter/sqlite-kysely-rate-limiter-storage.test.ts
+++ b/src/rate-limiter/implementations/adapters/kysely-rate-limiter-storage-adapter/sqlite-kysely-rate-limiter-storage.test.ts
@@ -5,7 +5,7 @@ import {
     type ColumnMetadata,
     type TableMetadata,
 } from "kysely";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -38,7 +38,6 @@ describe("sqlite class: KyselyRateLimiterStorageAdapter", () => {
         createAdapter: async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -53,7 +52,6 @@ describe("sqlite class: KyselyRateLimiterStorageAdapter", () => {
         test("Should remove all expired keys", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -90,7 +88,6 @@ describe("sqlite class: KyselyRateLimiterStorageAdapter", () => {
         test("Should create rateLimiter table", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -127,7 +124,6 @@ describe("sqlite class: KyselyRateLimiterStorageAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -136,37 +132,11 @@ describe("sqlite class: KyselyRateLimiterStorageAdapter", () => {
 
             await expect(promise).resolves.toBeUndefined();
         });
-        test("Should call not setInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselyRateLimiterStorageAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-                serde: new Serde(new SuperJsonSerdeAdapter()),
-            });
-            await adapter.init();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call setInterval when shouldRemoveExpiredKeys is true", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselyRateLimiterStorageAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-                serde: new Serde(new SuperJsonSerdeAdapter()),
-            });
-            await adapter.init();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
-        });
     });
     describe("method: deInit", () => {
         test("Should remove rateLimiter table", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -183,7 +153,6 @@ describe("sqlite class: KyselyRateLimiterStorageAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
             await adapter.init();
@@ -196,41 +165,12 @@ describe("sqlite class: KyselyRateLimiterStorageAdapter", () => {
         test("Should not throw error when called before init", async () => {
             const adapter = new KyselyRateLimiterStorageAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
                 serde: new Serde(new SuperJsonSerdeAdapter()),
             });
 
             const promise = adapter.deInit();
 
             await expect(promise).resolves.toBeUndefined();
-        });
-        test("Should call not clearInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselyRateLimiterStorageAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-                serde: new Serde(new SuperJsonSerdeAdapter()),
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call clearInterval when shouldRemoveExpiredKeys is true", async () => {
-            vi.useFakeTimers();
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselyRateLimiterStorageAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-                serde: new Serde(new SuperJsonSerdeAdapter()),
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
         });
     });
 });

--- a/src/rate-limiter/implementations/adapters/mongodb-rate-limiter-storage-adapter/mongodb-rate-limiter-storage-adapter.ts
+++ b/src/rate-limiter/implementations/adapters/mongodb-rate-limiter-storage-adapter/mongodb-rate-limiter-storage-adapter.ts
@@ -53,13 +53,6 @@ export type MongodbRateLimiterStorageAdapterSettings = {
      * Serde instance for serializing and deserializing rate-limiter state to and from strings.
      */
     serde: ISerde<string>;
-
-    /**
-     * When `true`, operations are wrapped in MongoDB transactions for atomicity.
-     * Requires a Replica Set or sharded cluster that supports transactions.
-     * @default true
-     */
-    enableTransactions?: boolean;
 };
 
 /**
@@ -83,7 +76,6 @@ export class MongodbRateLimiterStorageAdapter<TType>
     private readonly client: MongoClient;
     private readonly collection: Collection<MongodbRateLimiterDocument>;
     private readonly serde: ISerde<string>;
-    private readonly enableTransactions: boolean;
 
     /**
      * @example
@@ -112,7 +104,6 @@ export class MongodbRateLimiterStorageAdapter<TType>
             collectionSettings,
             database,
             serde,
-            enableTransactions = true,
         } = settings;
         this.client = client;
         this.collection = database.collection(
@@ -120,7 +111,6 @@ export class MongodbRateLimiterStorageAdapter<TType>
             collectionSettings,
         );
         this.serde = serde;
-        this.enableTransactions = enableTransactions;
     }
 
     /**
@@ -196,14 +186,11 @@ export class MongodbRateLimiterStorageAdapter<TType>
     private async _transaction<TValue>(
         trxFn: InvokableFn<[session?: ClientSession], Promise<TValue>>,
     ): Promise<TValue> {
-        if (this.enableTransactions) {
-            return await this.client.withSession(async (session) => {
-                return await session.withTransaction(async () => {
-                    return await trxFn(session);
-                });
+        return await this.client.withSession(async (session) => {
+            return await session.withTransaction(async () => {
+                return await trxFn(session);
             });
-        }
-        return trxFn();
+        });
     }
 
     async transaction<TValue>(

--- a/src/semaphore/implementations/adapters/kysely-semaphore-adapter/kysely-semaphore-adapter.ts
+++ b/src/semaphore/implementations/adapters/kysely-semaphore-adapter/kysely-semaphore-adapter.ts
@@ -2,7 +2,7 @@
  * @module Semaphore
  */
 
-import { MysqlAdapter, Transaction, type Kysely } from "kysely";
+import { MysqlAdapter, type Kysely } from "kysely";
 
 import { type IReadableContext } from "@/execution-context/contracts/_module.js";
 import {
@@ -10,8 +10,7 @@ import {
     type ISemaphoreAdapterState,
     type SemaphoreAcquireSettings,
 } from "@/semaphore/contracts/_module.js";
-import { type ITimeSpan } from "@/time-span/contracts/_module.js";
-import { TimeSpan } from "@/time-span/implementations/_module.js";
+import { type TimeSpan } from "@/time-span/implementations/_module.js";
 import {
     type IDeinitizable,
     type IInitizable,
@@ -62,33 +61,6 @@ export type KyselySemaphoreAdapterSettings = {
      * The Kysely database instance typed with the required semaphore tables.
      */
     kysely: Kysely<KyselySemaphoreTables>;
-
-    /**
-     * @default
-     * ```ts
-     * import { TimeSpan } from "@daiso-tech/core/time-span";
-     *
-     * TimeSpan.fromMinutes(1)
-     * ```
-     */
-    expiredKeysRemovalInterval?: ITimeSpan;
-
-    /**
-     * When `true`, a background task periodically removes expired semaphore records and their related slots.
-     * Set to `false` to disable automatic cleanup.
-     * @default true
-     */
-    shouldRemoveExpiredKeys?: boolean;
-
-    /**
-     * @default
-     * ```ts
-     * import { Transaction } from "kysely"
-     *
-     * !(settings.kysely instanceof Transaction)
-     * ```
-     */
-    enableTransactions?: boolean;
 };
 
 /**
@@ -104,12 +76,7 @@ export class KyselySemaphoreAdapter
     implements ISemaphoreAdapter, IDeinitizable, IInitizable, IPrunable
 {
     private readonly kysely: Kysely<KyselySemaphoreTables>;
-    private readonly expiredKeysRemovalInterval: TimeSpan;
-    private readonly shouldRemoveExpiredKeys: boolean;
-    private intervalId: string | number | NodeJS.Timeout | undefined | null =
-        null;
     private readonly isMysql: boolean;
-    private readonly enableTransactions: boolean;
 
     /**
      * @example
@@ -130,20 +97,10 @@ export class KyselySemaphoreAdapter
      * ```
      */
     constructor(settings: KyselySemaphoreAdapterSettings) {
-        const {
-            kysely,
-            expiredKeysRemovalInterval = TimeSpan.fromMinutes(1),
-            shouldRemoveExpiredKeys = true,
-            enableTransactions = !(settings.kysely instanceof Transaction),
-        } = settings;
-        this.expiredKeysRemovalInterval = TimeSpan.fromTimeSpan(
-            expiredKeysRemovalInterval,
-        );
-        this.shouldRemoveExpiredKeys = shouldRemoveExpiredKeys;
+        const { kysely } = settings;
         this.kysely = kysely;
         this.isMysql =
             this.kysely.getExecutor().adapter instanceof MysqlAdapter;
-        this.enableTransactions = enableTransactions;
     }
 
     private _transaction<TValue>(
@@ -152,15 +109,12 @@ export class KyselySemaphoreAdapter
             Promise<TValue>
         >,
     ): Promise<TValue> {
-        if (this.enableTransactions) {
-            return this.kysely
-                .transaction()
-                .setIsolationLevel("serializable")
-                .execute(async (trx) => {
-                    return await trxFn(trx);
-                });
-        }
-        return trxFn(this.kysely);
+        return this.kysely
+            .transaction()
+            .setIsolationLevel("serializable")
+            .execute(async (trx) => {
+                return await trxFn(trx);
+            });
     }
 
     async init(): Promise<void> {
@@ -208,12 +162,6 @@ export class KyselySemaphoreAdapter
         } catch {
             /* EMPTY */
         }
-
-        if (this.shouldRemoveExpiredKeys) {
-            this.intervalId = setInterval(() => {
-                void this.removeAllExpired();
-            }, this.expiredKeysRemovalInterval.toMilliseconds());
-        }
     }
 
     /**
@@ -221,10 +169,6 @@ export class KyselySemaphoreAdapter
      * Note all semaphore data will be removed.
      */
     async deInit(): Promise<void> {
-        if (this.shouldRemoveExpiredKeys && this.intervalId !== null) {
-            clearInterval(this.intervalId);
-        }
-
         // Should throw if the index does not exists thats why the try catch is used.
         try {
             await this.kysely.schema

--- a/src/semaphore/implementations/adapters/kysely-semaphore-adapter/mysql-kysely-semaphore-adapter.test.ts
+++ b/src/semaphore/implementations/adapters/kysely-semaphore-adapter/mysql-kysely-semaphore-adapter.test.ts
@@ -11,7 +11,7 @@ import {
     type TableMetadata,
 } from "kysely";
 import { createPool, type Pool } from "mysql2";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -59,7 +59,6 @@ describe("mysql class: KyselySemaphoreAdapter", () => {
         createAdapter: async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             return adapter;
@@ -76,7 +75,6 @@ describe("mysql class: KyselySemaphoreAdapter", () => {
             );
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -139,7 +137,6 @@ describe("mysql class: KyselySemaphoreAdapter", () => {
         test("Should create semaphore table", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -168,7 +165,6 @@ describe("mysql class: KyselySemaphoreAdapter", () => {
         test("Should create semaphoreSlot table", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -203,7 +199,6 @@ describe("mysql class: KyselySemaphoreAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -211,35 +206,11 @@ describe("mysql class: KyselySemaphoreAdapter", () => {
 
             await expect(promise).resolves.toBeUndefined();
         });
-        test("Should call not setInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselySemaphoreAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call setInterval when shouldRemoveExpiredKeys is true", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselySemaphoreAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
-        });
     });
     describe("method: deInit", () => {
         test("Should remove semaphore table", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -255,7 +226,6 @@ describe("mysql class: KyselySemaphoreAdapter", () => {
         test("Should remove semaphoreSlot table", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -271,7 +241,6 @@ describe("mysql class: KyselySemaphoreAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -282,37 +251,11 @@ describe("mysql class: KyselySemaphoreAdapter", () => {
         test("Should not throw error when called before init", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             const promise = adapter.deInit();
             await adapter.init();
 
             await expect(promise).resolves.toBeUndefined();
-        });
-        test("Should call not clearInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselySemaphoreAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call clearInterval when shouldRemoveExpiredKeys is true", async () => {
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselySemaphoreAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
         });
     });
 });

--- a/src/semaphore/implementations/adapters/kysely-semaphore-adapter/postgres-kysely-semaphore-adapter.test.ts
+++ b/src/semaphore/implementations/adapters/kysely-semaphore-adapter/postgres-kysely-semaphore-adapter.test.ts
@@ -9,7 +9,7 @@ import {
     type TableMetadata,
 } from "kysely";
 import { Pool } from "pg";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -49,7 +49,6 @@ describe("postgres class: KyselySemaphoreAdapter", () => {
         createAdapter: async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             return adapter;
@@ -66,7 +65,6 @@ describe("postgres class: KyselySemaphoreAdapter", () => {
             );
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -129,7 +127,6 @@ describe("postgres class: KyselySemaphoreAdapter", () => {
         test("Should create semaphore table", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -159,7 +156,6 @@ describe("postgres class: KyselySemaphoreAdapter", () => {
         test("Should create semaphoreSlot table", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -195,7 +191,6 @@ describe("postgres class: KyselySemaphoreAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -203,35 +198,11 @@ describe("postgres class: KyselySemaphoreAdapter", () => {
 
             await expect(promise).resolves.toBeUndefined();
         });
-        test("Should call not setInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselySemaphoreAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call setInterval when shouldRemoveExpiredKeys is true", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselySemaphoreAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
-        });
     });
     describe("method: deInit", () => {
         test("Should remove semaphore table", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -247,7 +218,6 @@ describe("postgres class: KyselySemaphoreAdapter", () => {
         test("Should remove semaphoreSlot table", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -263,7 +233,6 @@ describe("postgres class: KyselySemaphoreAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -274,37 +243,11 @@ describe("postgres class: KyselySemaphoreAdapter", () => {
         test("Should not throw error when called before init", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             const promise = adapter.deInit();
             await adapter.init();
 
             await expect(promise).resolves.toBeUndefined();
-        });
-        test("Should call not clearInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselySemaphoreAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call clearInterval when shouldRemoveExpiredKeys is true", async () => {
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselySemaphoreAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
         });
     });
 });

--- a/src/semaphore/implementations/adapters/kysely-semaphore-adapter/sqlite-kysely-semaphore-adapter.test.ts
+++ b/src/semaphore/implementations/adapters/kysely-semaphore-adapter/sqlite-kysely-semaphore-adapter.test.ts
@@ -5,7 +5,7 @@ import {
     type ColumnMetadata,
     type TableMetadata,
 } from "kysely";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { NoOpExecutionContextAdapter } from "@/execution-context/implementations/adapters/no-op-execution-context-adapter/_module.js";
 import { ExecutionContext } from "@/execution-context/implementations/derivables/_module.js";
@@ -34,7 +34,6 @@ describe("sqlite class: KyselySemaphoreAdapter", () => {
         createAdapter: async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             return adapter;
@@ -51,7 +50,6 @@ describe("sqlite class: KyselySemaphoreAdapter", () => {
             );
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -114,7 +112,6 @@ describe("sqlite class: KyselySemaphoreAdapter", () => {
         test("Should create semaphore table", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -144,7 +141,6 @@ describe("sqlite class: KyselySemaphoreAdapter", () => {
         test("Should create semaphoreSlot table", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -180,7 +176,6 @@ describe("sqlite class: KyselySemaphoreAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -188,35 +183,11 @@ describe("sqlite class: KyselySemaphoreAdapter", () => {
 
             await expect(promise).resolves.toBeUndefined();
         });
-        test("Should call not setInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselySemaphoreAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call setInterval when shouldRemoveExpiredKeys is true", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselySemaphoreAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
-        });
     });
     describe("method: deInit", () => {
         test("Should remove semaphore table", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -232,7 +203,6 @@ describe("sqlite class: KyselySemaphoreAdapter", () => {
         test("Should remove semaphoreSlot table", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -248,7 +218,6 @@ describe("sqlite class: KyselySemaphoreAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -259,38 +228,11 @@ describe("sqlite class: KyselySemaphoreAdapter", () => {
         test("Should not throw error when called before init", async () => {
             const adapter = new KyselySemaphoreAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             const promise = adapter.deInit();
             await adapter.init();
 
             await expect(promise).resolves.toBeUndefined();
-        });
-        test("Should call not clearInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselySemaphoreAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call clearInterval when shouldRemoveExpiredKeys is true", async () => {
-            vi.useFakeTimers();
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselySemaphoreAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
         });
     });
 });

--- a/src/semaphore/implementations/derivables/semaphore-factory/semaphore-factory.test.ts
+++ b/src/semaphore/implementations/derivables/semaphore-factory/semaphore-factory.test.ts
@@ -49,7 +49,6 @@ describe("class: SemaphoreFactory", () => {
                         database: new Sqlite(":memory:"),
                     }),
                 }),
-                shouldRemoveExpiredKeys: false,
             });
             await adapter2.init();
             const lockProvider2 = new SemaphoreFactory({

--- a/src/shared-lock/implementations/adapters/kysely-shared-lock-adapter/kysely-shared-lock-adapter.ts
+++ b/src/shared-lock/implementations/adapters/kysely-shared-lock-adapter/kysely-shared-lock-adapter.ts
@@ -2,7 +2,7 @@
  * @module SharedLock
  */
 
-import { MysqlAdapter, Transaction, type Kysely } from "kysely";
+import { MysqlAdapter, type Kysely } from "kysely";
 
 import { type IReadableContext } from "@/execution-context/contracts/_module.js";
 import {
@@ -12,8 +12,7 @@ import {
     type IWriterLockAdapterState,
     type SharedLockAcquireSettings,
 } from "@/shared-lock/contracts/_module.js";
-import { type ITimeSpan } from "@/time-span/contracts/_module.js";
-import { TimeSpan } from "@/time-span/implementations/_module.js";
+import { type TimeSpan } from "@/time-span/implementations/_module.js";
 import {
     type IDeinitizable,
     type IInitizable,
@@ -79,39 +78,12 @@ export type KyselySharedLockAdapterSettings = {
     kysely: Kysely<KyselySharedLockTables>;
 
     /**
-     * @default
-     * ```ts
-     * import { TimeSpan } from "@daiso-tech/core/time-span";
-     *
-     * TimeSpan.fromMinutes(1)
-     * ```
-     */
-    expiredKeysRemovalInterval?: ITimeSpan;
-
-    /**
-     * When `true`, a background task periodically removes expired shared-lock records.
-     * Set to `false` to disable automatic cleanup.
-     * @default true
-     */
-    shouldRemoveExpiredKeys?: boolean;
-
-    /**
      *  @default
      * ```ts
      * () => new Date()
      * ```
      */
     currentDate?: () => Date;
-
-    /**
-     * @default
-     * ```ts
-     * import { Transaction } from "kysely"
-     *
-     * !(settings.kysely instanceof Transaction)
-     * ```
-     */
-    enableTransactions?: boolean;
 };
 
 /**
@@ -127,13 +99,8 @@ export class KyselySharedLockAdapter
     implements ISharedLockAdapter, IDeinitizable, IInitizable, IPrunable
 {
     private readonly kysely: Kysely<KyselySharedLockTables>;
-    private readonly expiredKeysRemovalInterval: TimeSpan;
-    private readonly shouldRemoveExpiredKeys: boolean;
-    private intervalId: string | number | NodeJS.Timeout | undefined | null =
-        null;
     private readonly isMysql: boolean;
     private readonly currentDate: () => Date;
-    private readonly enableTransactions: boolean;
 
     /**
      * @example
@@ -154,22 +121,11 @@ export class KyselySharedLockAdapter
      * ```
      */
     constructor(settings: KyselySharedLockAdapterSettings) {
-        const {
-            kysely,
-            expiredKeysRemovalInterval = TimeSpan.fromMinutes(1),
-            shouldRemoveExpiredKeys = true,
-            currentDate = () => new Date(),
-            enableTransactions = !(settings.kysely instanceof Transaction),
-        } = settings;
-        this.expiredKeysRemovalInterval = TimeSpan.fromTimeSpan(
-            expiredKeysRemovalInterval,
-        );
-        this.shouldRemoveExpiredKeys = shouldRemoveExpiredKeys;
+        const { kysely, currentDate = () => new Date() } = settings;
         this.kysely = kysely;
         this.isMysql =
             this.kysely.getExecutor().adapter instanceof MysqlAdapter;
         this.currentDate = currentDate;
-        this.enableTransactions = enableTransactions;
     }
 
     private _transaction<TValue>(
@@ -178,15 +134,12 @@ export class KyselySharedLockAdapter
             Promise<TValue>
         >,
     ): Promise<TValue> {
-        if (this.enableTransactions) {
-            return this.kysely
-                .transaction()
-                .setIsolationLevel("serializable")
-                .execute(async (trx) => {
-                    return await trxFn(trx);
-                });
-        }
-        return trxFn(this.kysely);
+        return this.kysely
+            .transaction()
+            .setIsolationLevel("serializable")
+            .execute(async (trx) => {
+                return await trxFn(trx);
+            });
     }
 
     async init(): Promise<void> {
@@ -259,12 +212,6 @@ export class KyselySharedLockAdapter
         } catch {
             /* EMPTY */
         }
-
-        if (this.shouldRemoveExpiredKeys) {
-            this.intervalId = setInterval(() => {
-                void this.removeAllExpired();
-            }, this.expiredKeysRemovalInterval.toMilliseconds());
-        }
     }
 
     /**
@@ -272,10 +219,6 @@ export class KyselySharedLockAdapter
      * Note all shared-lock data will be removed.
      */
     async deInit(): Promise<void> {
-        if (this.shouldRemoveExpiredKeys && this.intervalId !== null) {
-            clearInterval(this.intervalId);
-        }
-
         // Should throw if the index does not exists thats why the try catch is used.
         try {
             await this.kysely.schema

--- a/src/shared-lock/implementations/adapters/kysely-shared-lock-adapter/mysql-kysely-shared-lock-adapter.test.ts
+++ b/src/shared-lock/implementations/adapters/kysely-shared-lock-adapter/mysql-kysely-shared-lock-adapter.test.ts
@@ -9,7 +9,7 @@ import {
     type TableMetadata,
 } from "kysely";
 import { createPool, type Pool } from "mysql2";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import {
     KyselySharedLockAdapter,
@@ -56,7 +56,6 @@ describe("mysql class: KyselySharedLockAdapter", () => {
         createAdapter: async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             return adapter;
@@ -70,7 +69,6 @@ describe("mysql class: KyselySharedLockAdapter", () => {
         test("Should remove all expired writer locks", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -126,7 +124,6 @@ describe("mysql class: KyselySharedLockAdapter", () => {
         test("Should remove all expired reader semaphores", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -208,7 +205,6 @@ describe("mysql class: KyselySharedLockAdapter", () => {
         test("Should create writerLock table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -244,7 +240,6 @@ describe("mysql class: KyselySharedLockAdapter", () => {
         test("Should create readerSemaphore table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -274,7 +269,6 @@ describe("mysql class: KyselySharedLockAdapter", () => {
         test("Should create readerSemaphoreSlot table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -310,7 +304,6 @@ describe("mysql class: KyselySharedLockAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -318,35 +311,11 @@ describe("mysql class: KyselySharedLockAdapter", () => {
 
             await expect(promise).resolves.toBeUndefined();
         });
-        test("Should call not setInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselySharedLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call setInterval when shouldRemoveExpiredKeys is true", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselySharedLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
-        });
     });
     describe("method: deInit", () => {
         test("Should remove writer lock table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -362,7 +331,6 @@ describe("mysql class: KyselySharedLockAdapter", () => {
         test("Should remove readerSemaphore table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -378,7 +346,6 @@ describe("mysql class: KyselySharedLockAdapter", () => {
         test("Should remove readerSemaphoreSlot table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -394,7 +361,6 @@ describe("mysql class: KyselySharedLockAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -405,38 +371,11 @@ describe("mysql class: KyselySharedLockAdapter", () => {
         test("Should not throw error when called before init", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             const promise = adapter.deInit();
             await adapter.init();
 
             await expect(promise).resolves.toBeUndefined();
-        });
-        test("Should call not clearInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselySharedLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call clearInterval when shouldRemoveExpiredKeys is true", async () => {
-            vi.useFakeTimers();
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselySharedLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
         });
     });
 });

--- a/src/shared-lock/implementations/adapters/kysely-shared-lock-adapter/postgres-kysely-shared-lock-adapter.test.ts
+++ b/src/shared-lock/implementations/adapters/kysely-shared-lock-adapter/postgres-kysely-shared-lock-adapter.test.ts
@@ -9,7 +9,7 @@ import {
     type TableMetadata,
 } from "kysely";
 import { Pool } from "pg";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import {
     KyselySharedLockAdapter,
@@ -48,7 +48,6 @@ describe("postgres class: KyselySharedLockAdapter", () => {
         createAdapter: async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             return adapter;
@@ -62,7 +61,6 @@ describe("postgres class: KyselySharedLockAdapter", () => {
         test("Should remove all expired writer locks", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -118,7 +116,6 @@ describe("postgres class: KyselySharedLockAdapter", () => {
         test("Should remove all expired reader semaphores", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -200,7 +197,6 @@ describe("postgres class: KyselySharedLockAdapter", () => {
         test("Should create writerLock table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -236,7 +232,6 @@ describe("postgres class: KyselySharedLockAdapter", () => {
         test("Should create readerSemaphore table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -266,7 +261,6 @@ describe("postgres class: KyselySharedLockAdapter", () => {
         test("Should create readerSemaphoreSlot table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -302,7 +296,6 @@ describe("postgres class: KyselySharedLockAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -310,35 +303,11 @@ describe("postgres class: KyselySharedLockAdapter", () => {
 
             await expect(promise).resolves.toBeUndefined();
         });
-        test("Should call not setInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselySharedLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call setInterval when shouldRemoveExpiredKeys is true", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselySharedLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
-        });
     });
     describe("method: deInit", () => {
         test("Should remove writer lock table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -354,7 +323,6 @@ describe("postgres class: KyselySharedLockAdapter", () => {
         test("Should remove readerSemaphore table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -370,7 +338,6 @@ describe("postgres class: KyselySharedLockAdapter", () => {
         test("Should remove readerSemaphoreSlot table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -386,7 +353,6 @@ describe("postgres class: KyselySharedLockAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -397,38 +363,11 @@ describe("postgres class: KyselySharedLockAdapter", () => {
         test("Should not throw error when called before init", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             const promise = adapter.deInit();
             await adapter.init();
 
             await expect(promise).resolves.toBeUndefined();
-        });
-        test("Should call not clearInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselySharedLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call clearInterval when shouldRemoveExpiredKeys is true", async () => {
-            vi.useFakeTimers();
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselySharedLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
         });
     });
 });

--- a/src/shared-lock/implementations/adapters/kysely-shared-lock-adapter/sqlite-shared-kysely-lock-adapter.test.ts
+++ b/src/shared-lock/implementations/adapters/kysely-shared-lock-adapter/sqlite-shared-kysely-lock-adapter.test.ts
@@ -5,7 +5,7 @@ import {
     type ColumnMetadata,
     type TableMetadata,
 } from "kysely";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import {
     KyselySharedLockAdapter,
@@ -32,7 +32,6 @@ describe("sqlite class: KyselySharedLockAdapter", () => {
         createAdapter: async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             return adapter;
@@ -46,7 +45,6 @@ describe("sqlite class: KyselySharedLockAdapter", () => {
         test("Should remove all expired writer locks", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -102,7 +100,6 @@ describe("sqlite class: KyselySharedLockAdapter", () => {
         test("Should remove all expired reader semaphores", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -184,7 +181,6 @@ describe("sqlite class: KyselySharedLockAdapter", () => {
         test("Should create writerLock table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -220,7 +216,6 @@ describe("sqlite class: KyselySharedLockAdapter", () => {
         test("Should create readerSemaphore table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -250,7 +245,6 @@ describe("sqlite class: KyselySharedLockAdapter", () => {
         test("Should create readerSemaphoreSlot table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -286,7 +280,6 @@ describe("sqlite class: KyselySharedLockAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
 
@@ -294,35 +287,11 @@ describe("sqlite class: KyselySharedLockAdapter", () => {
 
             await expect(promise).resolves.toBeUndefined();
         });
-        test("Should call not setInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselySharedLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call setInterval when shouldRemoveExpiredKeys is true", async () => {
-            const intervalFn = vi.spyOn(globalThis, "setInterval");
-
-            const adapter = new KyselySharedLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
-        });
     });
     describe("method: deInit", () => {
         test("Should remove writer lock table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -338,7 +307,6 @@ describe("sqlite class: KyselySharedLockAdapter", () => {
         test("Should remove readerSemaphore table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -354,7 +322,6 @@ describe("sqlite class: KyselySharedLockAdapter", () => {
         test("Should remove readerSemaphoreSlot table", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -370,7 +337,6 @@ describe("sqlite class: KyselySharedLockAdapter", () => {
         test("Should not throw error when called multiple times", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             await adapter.init();
             await adapter.deInit();
@@ -381,38 +347,11 @@ describe("sqlite class: KyselySharedLockAdapter", () => {
         test("Should not throw error when called before init", async () => {
             const adapter = new KyselySharedLockAdapter({
                 kysely,
-                shouldRemoveExpiredKeys: false,
             });
             const promise = adapter.deInit();
             await adapter.init();
 
             await expect(promise).resolves.toBeUndefined();
-        });
-        test("Should call not clearInterval when shouldRemoveExpiredKeys is false", async () => {
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselySharedLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: false,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).not.toHaveBeenCalledTimes(1);
-        });
-        test("Should call clearInterval when shouldRemoveExpiredKeys is true", async () => {
-            vi.useFakeTimers();
-            const intervalFn = vi.spyOn(globalThis, "clearInterval");
-
-            const adapter = new KyselySharedLockAdapter({
-                kysely,
-                shouldRemoveExpiredKeys: true,
-            });
-            await adapter.init();
-            await adapter.deInit();
-
-            expect(intervalFn).toHaveBeenCalledTimes(1);
-            await adapter.deInit();
         });
     });
 });

--- a/src/shared-lock/implementations/derivables/shared-lock-factory/shared-lock-factory.test.ts
+++ b/src/shared-lock/implementations/derivables/shared-lock-factory/shared-lock-factory.test.ts
@@ -49,7 +49,6 @@ describe("class: SharedLockFactory", () => {
                         database: new Sqlite(":memory:"),
                     }),
                 }),
-                shouldRemoveExpiredKeys: false,
             });
             await adapter2.init();
             const sharedLockFactory2 = new SharedLockFactory({

--- a/website/docs/components/cache/configuring_cache_adapters.md
+++ b/website/docs/components/cache/configuring_cache_adapters.md
@@ -293,35 +293,17 @@ you won't be able to use following methods `put` and `increment`, as they requir
 
 ### Settings
 
-Expired keys are cleared at regular intervals and you can change the interval time:
+To clean up expired cache keys, call `removeAllExpired` at a regular interval (for example, using a cron job):
 
 ```ts
-import { TimeSpan } from "@daiso-tech/core/time-span";
-
 const kyselyCacheAdapter = new KyselyCacheAdapter({
     database,
     serde,
-    // By default, the interval is 1 minute
-    expiredKeysRemovalInterval: TimeSpan.fromSeconds(10),
-});
-
-await kyselyCacheAdapter.init();
-```
-
-Disabling scheduled interval cleanup of expired keys:
-
-```ts
-import { TimeSpan } from "@daiso-tech/core/time-span";
-
-const kyselyCacheAdapter = new KyselyCacheAdapter({
-    database,
-    serde,
-    shouldRemoveExpiredKeys: false,
 });
 
 await kyselyCacheAdapter.init();
 
-// You can remove all expired keys manually.
+// Remove all expired cache keys manually.
 await kyselyCacheAdapter.removeAllExpired();
 ```
 

--- a/website/docs/components/lock/configuring_lock_adapters.md
+++ b/website/docs/components/lock/configuring_lock_adapters.md
@@ -276,33 +276,16 @@ Note in order to use `KyselyLockAdapter` with `libsql` correctly, ensure you use
 
 ### Settings
 
-Expired keys are cleared at regular intervals and you can change the interval time:
+To clean up expired lock keys, call `removeAllExpired` at a regular interval (for example, using a cron job):
 
 ```ts
-import { TimeSpan } from "@daiso-tech/core/time-span";
-
 const kyselyLockAdapter = new KyselyLockAdapter({
     database,
-    // By default, the interval is 1 minute
-    expiredKeysRemovalInterval: TimeSpan.fromSeconds(10),
-});
-
-await kyselyLockAdapter.init();
-```
-
-Disabling scheduled interval cleanup of expired keys:
-
-```ts
-import { TimeSpan } from "@daiso-tech/core/time-span";
-
-const kyselyLockAdapter = new KyselyLockAdapter({
-    database,
-    shouldRemoveExpiredKeys: false,
 });
 
 await kyselyLockAdapter.init();
 
-// You can remove all expired keys manually.
+// Remove all expired lock keys manually.
 await kyselyLockAdapter.removeAllExpired();
 ```
 

--- a/website/docs/components/rate-limiter/configuring_rate_limiter_adapters.md
+++ b/website/docs/components/rate-limiter/configuring_rate_limiter_adapters.md
@@ -290,6 +290,22 @@ const kyselyRateLimiterStorageAdapter = new KyselyRateLimiterStorageAdapter({
 await kyselyRateLimiterStorageAdapter.init();
 ```
 
+### Settings
+
+To clean up expired rate-limiter records, call `removeAllExpired` at a regular interval (for example, using a cron job):
+
+```ts
+const kyselyRateLimiterStorageAdapter = new KyselyRateLimiterStorageAdapter({
+    kysely,
+    serde,
+});
+
+await kyselyRateLimiterStorageAdapter.init();
+
+// Remove all expired rate-limiter records manually.
+await kyselyRateLimiterStorageAdapter.removeAllExpired();
+```
+
 ## MemoryRateLimiterStorageAdapter
 
 To use the `MemoryRateLimiterStorageAdapter` you only need to create instance of it:

--- a/website/docs/components/semaphore/configuring_semaphore_adapters.md
+++ b/website/docs/components/semaphore/configuring_semaphore_adapters.md
@@ -276,33 +276,16 @@ Note in order to use `KyselySemaphoreAdapter` with `libsql` correctly, ensure yo
 
 ### Settings
 
-Expired keys are cleared at regular intervals and you can change the interval time:
+To clean up expired semaphore keys, call `removeAllExpired` at a regular interval (for example, using a cron job):
 
 ```ts
-import { TimeSpan } from "@daiso-tech/core/time-span";
-
 const kyselySemaphoreAdapter = new KyselySemaphoreAdapter({
     database,
-    // By default, the interval is 1 minute
-    expiredKeysRemovalInterval: TimeSpan.fromSeconds(10),
-});
-
-await kyselySemaphoreAdapter.init();
-```
-
-Disabling scheduled interval cleanup of expired keys:
-
-```ts
-import { TimeSpan } from "@daiso-tech/core/time-span";
-
-const kyselySemaphoreAdapter = new KyselySemaphoreAdapter({
-    database,
-    shouldRemoveExpiredKeys: false,
 });
 
 await kyselySemaphoreAdapter.init();
 
-// You can remove all expired keys manually.
+// Remove all expired semaphore keys manually.
 await kyselySemaphoreAdapter.removeAllExpired();
 ```
 

--- a/website/docs/components/shared_lock/configuring_shared_lock_adapters.md
+++ b/website/docs/components/shared_lock/configuring_shared_lock_adapters.md
@@ -276,33 +276,16 @@ Note in order to use `KyselySharedLockAdapter` with `libsql` correctly, ensure y
 
 ### Settings
 
-Expired keys are cleared at regular intervals and you can change the interval time:
+To clean up expired shared-lock keys, call `removeAllExpired` at a regular interval (for example, using a cron job):
 
 ```ts
-import { TimeSpan } from "@daiso-tech/core/time-span";
-
 const kyselySharedLockAdapter = new KyselySharedLockAdapter({
     database,
-    // By default, the interval is 1 minute
-    expiredKeysRemovalInterval: TimeSpan.fromSeconds(10),
-});
-
-await kyselySharedLockAdapter.init();
-```
-
-Disabling scheduled interval cleanup of expired keys:
-
-```ts
-import { TimeSpan } from "@daiso-tech/core/time-span";
-
-const kyselySharedLockAdapter = new KyselySharedLockAdapter({
-    database,
-    shouldRemoveExpiredKeys: false,
 });
 
 await kyselySharedLockAdapter.init();
 
-// You can remove all expired keys manually.
+// Remove all expired shared-lock keys manually.
 await kyselySharedLockAdapter.removeAllExpired();
 ```
 


### PR DESCRIPTION
- **refactor(cache): remove transaction and expired-keys cleanup settings**
- **refactor(circuit-breaker): remove transaction setting**
- **refactor(lock): remove transaction and expired-keys cleanup settings**
- **refactor(rate-limiter): remove transaction and expired-keys cleanup settings**
- **refactor(semaphore): remove transaction and expired-keys cleanup settings**
- **refactor(shared-lock): remove transaction and expired-keys cleanup settings**
- **chore: add changeset for database adapter settings removal**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed transaction and automatic expired-entry cleanup settings from database-backed adapters.
  * Database operations now always run within transactions, with serializable isolation where supported.

* **Behavior Changes**
  * Expired cache, lock, semaphore, shared-lock, and rate-limit records are no longer cleaned up automatically.
  * Applications should schedule or manually call `removeAllExpired()` as needed.

* **Documentation**
  * Updated adapter configuration guides with the new cleanup process and removed deprecated configuration examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->